### PR TITLE
Replace topics for simple-linked-list

### DIFF
--- a/config.json
+++ b/config.json
@@ -547,7 +547,9 @@
       "slug": "simple-linked-list",
       "difficulty": 8,
       "topics": [
-        "data-structures"
+        "Arrays",
+        "Data structures",
+        "Lists"
       ]
     }
   ],


### PR DESCRIPTION
`Arrays` and `Lists` instead of `data-structures`. I removed the `data-structures` because it's not listed in [`TOPICS.txt`](https://github.com/exercism/problem-specifications/blob/master/TOPICS.txt).