### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,10 @@
   "test_pattern": ".*[.]spec[.]js$",
   "exercises": [
     {
+      "uuid": "4756cfc9-7509-4783-8be7-60e3376b8256",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -16,7 +19,10 @@
       ]
     },
     {
+      "uuid": "0c231a1c-55f7-47b6-8a54-ccae4ab0c65b",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Booleans",
@@ -25,7 +31,10 @@
       ]
     },
     {
+      "uuid": "3e1358c8-2bea-41f9-bc9e-8277f354a4e0",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (loops)",
@@ -35,7 +44,10 @@
       ]
     },
     {
+      "uuid": "d7f57ab9-2edb-44cb-a04e-c575c0f4be4c",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Strings",
@@ -43,7 +55,10 @@
       ]
     },
     {
+      "uuid": "c57bf909-130f-46e6-97ca-aeed58df1a15",
       "slug": "pangram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control flow (conditionals)",
@@ -56,7 +71,10 @@
       ]
     },
     {
+      "uuid": "246be5d9-b361-4893-9707-f218ede2bed6",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control flow (conditionals)",
@@ -68,14 +86,20 @@
       ]
     },
     {
+      "uuid": "49e4874b-d7e2-4305-a9bc-627fab4ada44",
       "slug": "gigasecond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Time"
       ]
     },
     {
+      "uuid": "35821375-5c94-4d4b-aa56-e3b079a45ca0",
       "slug": "isogram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Strings",
@@ -83,7 +107,10 @@
       ]
     },
     {
+      "uuid": "6f315fc3-095a-4387-aefb-cc5fee97110a",
       "slug": "beer-song",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Looping",
@@ -92,7 +119,10 @@
       ]
     },
     {
+      "uuid": "347f9f54-a0d9-469d-babf-b3edb34d9d70",
       "slug": "phone-number",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Parsing",
@@ -100,7 +130,10 @@
       ]
     },
     {
+      "uuid": "432ec2ce-c919-4142-aea2-389b67503252",
       "slug": "anagram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Strings",
@@ -108,7 +141,10 @@
       ]
     },
     {
+      "uuid": "a717745f-da00-4a5f-8bf3-6876e20cdf17",
       "slug": "food-chain",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Text formatting",
@@ -116,63 +152,90 @@
       ]
     },
     {
+      "uuid": "029bc3ed-772d-439b-bd0a-1ba1196a79ec",
       "slug": "grade-school",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "3005340b-a8d6-46ac-9075-125f9adccc2a",
       "slug": "robot-name",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a2a19f61-62ba-447a-8f57-537c8baa2e7a",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "b668e11a-a8ce-4e94-ba68-3a1f0fa3f6c8",
       "slug": "space-age",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "c5be6908-f45c-4278-ba99-3701024f4eda",
       "slug": "grains",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "fde792fa-84e9-4b86-8ecb-8466ad92a99d",
       "slug": "triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "1ff85150-6c51-4758-af02-4484cf35658e",
       "slug": "clock",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "51aa5429-b2db-43ad-83cf-84e2ead22cb6",
       "slug": "perfect-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "9a4ea3da-ad43-4850-bdf3-2c578c5de838",
       "slug": "word-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control flow (loops)",
@@ -183,161 +246,230 @@
       ]
     },
     {
+      "uuid": "0c1c4788-0372-42e7-81c1-b090bb7ebc8b",
       "slug": "acronym",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a6bd8126-3879-4593-8380-39ebfa87801b",
       "slug": "scrabble-score",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "4226e3c6-99d4-406d-998a-bcf11845b211",
       "slug": "roman-numerals",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "f1943e87-182a-44f5-a885-3d68a0c0a0dc",
       "slug": "circular-buffer",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "c3035180-ff4c-4afe-8019-f8364158b74e",
       "slug": "binary",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "73ecd6c2-e59b-4354-b305-64e28a60433f",
       "slug": "prime-factors",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "86b1acf1-9e2d-4b04-b8b0-e9ae6beb5f3d",
       "slug": "raindrops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "23210e9e-81f6-4279-a776-00459c7ccd02",
       "slug": "allergies",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "e61f3d54-55d2-4d32-9d2a-e7d6af3a3247",
       "slug": "strain",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "99974454-0736-4cc0-b88f-ed5701397a97",
       "slug": "atbash-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "dc9b2598-9757-4b20-82f9-8049ad081ac9",
       "slug": "accumulate",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a98e3593-d5b4-4c2b-8569-ae3ae7e07dad",
       "slug": "crypto-square",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "f317721d-e1f5-4e68-9fdc-f9bc7b6b004d",
       "slug": "trinary",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "4cad8ee8-40be-4d4d-8c14-45d8c6e29a32",
       "slug": "sieve",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "fff57c49-cde9-4a0c-b70b-2903cef212af",
       "slug": "simple-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "9892d47d-97a0-4a2f-8284-6f84c86559e8",
       "slug": "octal",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "bb46e832-8c37-45ee-9ee7-5037015b965c",
       "slug": "luhn",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "9a515ad0-34c7-4191-8784-5c4cd6385b38",
       "slug": "pig-latin",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "26a973dd-d72e-40fb-abeb-0ba306356ed6",
       "slug": "pythagorean-triplet",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "06afdb06-8d2a-4cb0-baf1-48ae997cf1f5",
       "slug": "series",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "07110dd5-b879-40b9-9485-685cb0963d8f",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "0a3a452c-f734-47eb-8e65-34c8ae710ef0",
       "slug": "secret-handshake",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "8786d591-077b-49bc-be8d-d014dc9dc308",
       "slug": "proverb",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Arrays",
@@ -345,189 +477,270 @@
       ]
     },
     {
+      "uuid": "ecc41237-f629-458f-873e-2cc51ba1a385",
       "slug": "linked-list",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "bb54bf08-24ba-45e1-bdf7-08db161e5843",
       "slug": "wordy",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "32a0a5fa-c7de-470c-beff-118b448b3916",
       "slug": "flatten-array",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "33b8f4c0-3210-478a-9225-5c30ad6df870",
       "slug": "hexadecimal",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "44bd02a7-0e3a-4441-ab76-524e36d4661c",
       "slug": "largest-series-product",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "2702ac90-0be2-43a2-91b6-7256a25fec87",
       "slug": "kindergarten-garden",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "5991c379-f033-4b46-9702-6b7fd03640e8",
       "slug": "binary-search",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "865806e0-950f-49a5-a6e5-26472b90ab85",
       "slug": "binary-search-tree",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "fbfe6032-c209-40bd-b485-8b2881638166",
       "slug": "matrix",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "00002977-ea1e-45e2-b66e-09d793b5c1ad",
       "slug": "robot-simulator",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "8fa51380-ec2c-4806-8833-cf543579de17",
       "slug": "nth-prime",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "fde83f66-d927-48f8-a599-efb98927f0b1",
       "slug": "palindrome-products",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a96ab45d-10a0-42cf-a754-c2466037ceaf",
       "slug": "pascals-triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "01d286f6-5f29-4d4b-a4de-e217a4833bfa",
       "slug": "say",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "d4ec15c4-2742-493b-97fe-9d5121f0b659",
       "slug": "custom-set",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "f30463c4-9d8c-4238-a691-e594291b4425",
       "slug": "sum-of-multiples",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "fefcfeba-59ec-4c63-a562-374201ee39a7",
       "slug": "queen-attack",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "98cbae4f-78b6-4745-b922-39e8db9a12bb",
       "slug": "saddle-points",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "759618b1-7ccc-46cd-889d-aea58ec88756",
       "slug": "ocr-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "86b1b6ba-c1fe-492d-a7ec-c22c525b4da8",
       "slug": "meetup",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "25099f87-5c3b-4a8a-b648-4639d1e9fa84",
       "slug": "bracket-push",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "4c857b17-33b0-47fa-b981-6b2fe4e394a1",
       "slug": "two-bucket",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "c168fe1f-f84e-46e6-91fc-7553d048a4e9",
       "slug": "bowling",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "04a4ef78-5b61-454f-8c37-798875fb4956",
       "slug": "diamond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "cdfcec62-f2f3-4408-ad2c-8b5e1e56e791",
       "slug": "all-your-base",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "d66c2b56-b465-4922-af35-ae78944c0aac",
       "slug": "run-length-encoding",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "22fa5ab4-935b-44cc-b055-9803214ae5f3",
       "slug": "minesweeper",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "games",
@@ -536,7 +749,10 @@
       ]
     },
     {
+      "uuid": "42a7fd83-4508-403c-8b5e-f0a3126fac8a",
       "slug": "alphametics",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "games",
@@ -544,7 +760,10 @@
       ]
     },
     {
+      "uuid": "c21ab6e8-b845-49d0-a2f6-1c89c7a07626",
       "slug": "simple-linked-list",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
         "Arrays",
@@ -553,18 +772,27 @@
       ]
     },
     {
+      "uuid": "e70defe4-5944-4392-956c-63cb92e7fd9c",
       "slug": "list-ops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
         "Data structures",
         "Lists",
         "Recursion"
       ]
+    },
+    {
+      "uuid": "1b53340d-ea40-44ee-bf2e-42e516704e7c",
+      "slug": "nucleotide-count",
+      "deprecated": true
+    },
+    {
+      "uuid": "e9a6b2ea-a67d-4b75-800d-7b46240094ec",
+      "slug": "point-mutations",
+      "deprecated": true
     }
-  ],
-  "deprecated": [
-    "nucleotide-count",
-    "point-mutations"
   ],
   "foregone": [
 


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16