### PR TITLE
Add a new test to circular buffer exercise

### DIFF
--- a/exercises/circular-buffer/circular-buffer.spec.js
+++ b/exercises/circular-buffer/circular-buffer.spec.js
@@ -109,4 +109,12 @@ describe('CircularBuffer', function() {
     expect(buffer.read).toThrow(bufferEmptyException());
   });
 
+  xit('multiple buffers don\'t interfere with each other', function() {
+    var buffer1 = circularBuffer(1);
+    var buffer2 = circularBuffer(1);
+    buffer1.write('1');
+    expect(buffer2.read).toThrow(bufferEmptyException());
+    expect(buffer1.read()).toBe('1');
+  });
+
 });


### PR DESCRIPTION
I've seen people came up with solution like
`Buffer.buffer = [];
Buffer.read = function() { /* do something with Buffer.buffer */ };
module.exports = Buffer;
`.
While it's not required in the description that multiple circular buffers can be instantiated, I felt that this kind of pattern should be discouraged, and there should be a test to check this.