### PR TITLE
Refactor two-bucket

### DIFF
--- a/exercises/two-bucket/example.js
+++ b/exercises/two-bucket/example.js
@@ -25,11 +25,7 @@ function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
     var currentBucketTwo = initialBucketTwo;
     var moveCount = 0;
     var pourOrReceive = true;
-    while (true) {
-      if (this.reachedGoal(currentBucketOne, currentBucketTwo)) {
-        this.recordGoal(currentBucketOne, currentBucketTwo);
-        break;
-      }
+    while (!this.reachedGoal(currentBucketOne, currentBucketTwo)) {
       if (currentBucketTwo > bucketOne && currentBucketOne === 0 && moveCount === 0) {
         currentBucketOne = bucketOne;
         currentBucketTwo = bucketTwo - currentBucketOne;
@@ -47,6 +43,7 @@ function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
       moveCount++;
       pourOrReceive ? pourOrReceive = false : pourOrReceive = true;
     }
+    this.recordGoal(currentBucketOne, currentBucketTwo);
     return moveCount;
   };
 
@@ -55,11 +52,7 @@ function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
     var currentBucketTwo = initialBucketTwo;
     var moveCount = 0;
     var pourOrReceive = true;
-    while (true) {
-      if (this.reachedGoal(currentBucketOne, currentBucketTwo)) {
-        this.recordGoal(currentBucketOne, currentBucketTwo);
-        break;
-      }
+    while (!this.reachedGoal(currentBucketOne, currentBucketTwo)) {
       if (currentBucketOne === bucketOne && moveCount === 0) {
         currentBucketOne = 0;
         currentBucketTwo = bucketOne;
@@ -78,6 +71,7 @@ function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
       moveCount++;
       pourOrReceive ? pourOrReceive = false : pourOrReceive = true;
     }
+    this.recordGoal(currentBucketOne, currentBucketTwo);
     return moveCount;
   };
 

--- a/exercises/two-bucket/example.js
+++ b/exercises/two-bucket/example.js
@@ -1,14 +1,15 @@
 'use strict';
 
-function TwoBucket(x, y, z, starter) {
-  this.starter = starter;
-  this.x = x;
-  this.y = y;
+function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
+  this.startBucket = startBucket;
+  this.bucketOne = bucketOne;
+  this.bucketTwo = bucketTwo;
+  this.goal = goal;
 
   this.reachedGoal = function (measurements) {
     var reached = false;
-    if (measurements[0] == z || measurements[1] == z) {
-      if (measurements[0] == z) {
+    if (measurements[0] === goal || measurements[1] === goal) {
+      if (measurements[0] === goal) {
         this.goalBucket = 'one';
         this.otherBucket = measurements[1];
       } else {
@@ -21,22 +22,23 @@ function TwoBucket(x, y, z, starter) {
   };
 
   this.bigFirst = function (measurements, moveCount, prBool) {
-    var j = measurements[0], k = measurements[1];
+    var j = measurements[0];
+    var k = measurements[1];
     while (true) {
       if (this.reachedGoal(measurements)) break;
-      if (k > x && j == 0 && moveCount == 0) {
-        j = x;
-        k = y - j;
-      } else if (j == x) {
+      if (k > bucketOne && j === 0 && moveCount === 0) {
+        j = bucketOne;
+        k = bucketTwo - j;
+      } else if (j === bucketOne) {
         j = 0;
-      } else if ((k > x && j !== 0) || (k > x && prBool)) {
-        k = k - (x - j);
-        j = x;
-      } else if (k > x || j == 0) {
+      } else if ((k > bucketOne && j !== 0) || (k > bucketOne && prBool)) {
+        k = k - (bucketOne - j);
+        j = bucketOne;
+      } else if (k > bucketOne || j === 0) {
         j = k;
         k = k - j;
-      } else if (k == 0) {
-        k = y;
+      } else if (k === 0) {
+        k = bucketTwo;
       }
       measurements = [j, k];
       moveCount++;
@@ -46,21 +48,22 @@ function TwoBucket(x, y, z, starter) {
   };
 
   this.smallFirst = function (measurements, moveCount, prBool) {
-    var j = measurements[0], k = measurements[1];
+    var j = measurements[0];
+    var k = measurements[1];
     while (true) {
       if (this.reachedGoal(measurements)) break;
-      if (j == x && moveCount == 0) {
+      if (j === bucketOne && moveCount === 0) {
         j = 0;
-        k = x;
-      } else if (j == 0) {
-        j = x;
-      } else if (j == x && k < y) {
+        k = bucketOne;
+      } else if (j === 0) {
+        j = bucketOne;
+      } else if (j === bucketOne && k < bucketTwo) {
         var tempK = k;
-        k + j > y ? k = y : k = tempK + j;
-        tempK + j > y ? j = j - (y - tempK) : j = 0;
-      } else if (k == y) {
+        k + j > bucketTwo ? k = bucketTwo : k = tempK + j;
+        tempK + j > bucketTwo ? j = j - (bucketTwo - tempK) : j = 0;
+      } else if (k === bucketTwo) {
         k = 0;
-      } else if (k == 0 && j < x) {
+      } else if (k === 0 && j < bucketOne) {
         k = j;
         j = 0;
       }
@@ -73,17 +76,18 @@ function TwoBucket(x, y, z, starter) {
 }
 
 TwoBucket.prototype.moves = function () {
-  var j = 0, k = 0; // j will be running val of bucket one, k = running val of bucket two
-  this.starter == 'one' ? j = this.x : k = this.y;
+  var j = 0; // j will be running val of bucket one,
+  var k = 0; // k will be running val of bucket two
+  this.startBucket === 'one' ? j = this.bucketOne : k = this.bucketTwo;
   var measurements = [j, k];
   var moveCount = 0;
-  var prBool = true; // pour / receive boolean - need to pour or receive every other turn
-  if (this.starter == 'one') {
+  var prBool = true; // pour / receive boolean - need to pour or receive everbucketTwo other turn
+  if (this.startBucket === 'one') {
     moveCount = this.smallFirst(measurements, moveCount, prBool);
   } else {
     moveCount = this.bigFirst(measurements, moveCount, prBool);
   }
-  return moveCount + 1; // accounts for first move made before loop (and moveCount starts at zero before loop)
+  return moveCount + 1; // accounts for first move made before loop (and moveCount starts at goalero before loop)
 };
 
 module.exports = TwoBucket;

--- a/exercises/two-bucket/example.js
+++ b/exercises/two-bucket/example.js
@@ -6,28 +6,28 @@ function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
   this.goal = goal;
   this.startBucket = startBucket;
 
-  this.reachedGoal = function (measurements) {
-    return (measurements[0] === goal || measurements[1] === goal);
+  this.reachedGoal = function (currentBucketOne, currentBucketTwo) {
+    return (currentBucketOne === goal || currentBucketTwo === goal);
   };
 
-  this.recordGoal = function (measurements) {
-    if (measurements[0] === goal) {
+  this.recordGoal = function (currentBucketOne, currentBucketTwo) {
+    if (currentBucketOne === goal) {
       this.goalBucket = 'one';
-      this.otherBucket = measurements[1];
+      this.otherBucket = currentBucketTwo;
     } else {
       this.goalBucket = 'two';
-      this.otherBucket = measurements[0];
+      this.otherBucket = currentBucketOne;
     }
   };
 
-  this.bigFirst = function (measurements) {
-    var currentBucketOne = measurements[0];
-    var currentBucketTwo = measurements[1];
+  this.bigFirst = function (initialBucketOne, initialBucketTwo) {
+    var currentBucketOne = initialBucketOne;
+    var currentBucketTwo = initialBucketTwo;
     var moveCount = 0;
     var pourOrReceive = true;
     while (true) {
-      if (this.reachedGoal([currentBucketOne, currentBucketTwo])) {
-        this.recordGoal([currentBucketOne, currentBucketTwo]);
+      if (this.reachedGoal(currentBucketOne, currentBucketTwo)) {
+        this.recordGoal(currentBucketOne, currentBucketTwo);
         break;
       }
       if (currentBucketTwo > bucketOne && currentBucketOne === 0 && moveCount === 0) {
@@ -50,14 +50,14 @@ function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
     return moveCount;
   };
 
-  this.smallFirst = function (measurements) {
-    var currentBucketOne = measurements[0];
-    var currentBucketTwo = measurements[1];
+  this.smallFirst = function (initialBucketOne, initialBucketTwo) {
+    var currentBucketOne = initialBucketOne;
+    var currentBucketTwo = initialBucketTwo;
     var moveCount = 0;
     var pourOrReceive = true;
     while (true) {
-      if (this.reachedGoal([currentBucketOne, currentBucketTwo])) {
-        this.recordGoal([currentBucketOne, currentBucketTwo]);
+      if (this.reachedGoal(currentBucketOne, currentBucketTwo)) {
+        this.recordGoal(currentBucketOne, currentBucketTwo);
         break;
       }
       if (currentBucketOne === bucketOne && moveCount === 0) {
@@ -83,9 +83,9 @@ function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
 
   this.moves = function () {
     if (this.startBucket === 'one') {
-      return this.smallFirst([this.bucketOne, 0]) + 1;
+      return this.smallFirst(this.bucketOne, 0) + 1;
     }
-    return this.bigFirst([0, this.bucketTwo]) + 1;
+    return this.bigFirst(0, this.bucketTwo) + 1;
   };
 }
 

--- a/exercises/two-bucket/example.js
+++ b/exercises/two-bucket/example.js
@@ -21,30 +21,29 @@ function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
   };
 
   this.bigFirst = function (measurements) {
-    var j = measurements[0];
-    var k = measurements[1];
+    var currentBucketOne = measurements[0];
+    var currentBucketTwo = measurements[1];
     var moveCount = 0;
     var pourOrReceive = true;
     while (true) {
-      if (this.reachedGoal(measurements)) {
-        this.recordGoal(measurements);
+      if (this.reachedGoal([currentBucketOne, currentBucketTwo])) {
+        this.recordGoal([currentBucketOne, currentBucketTwo]);
         break;
       }
-      if (k > bucketOne && j === 0 && moveCount === 0) {
-        j = bucketOne;
-        k = bucketTwo - j;
-      } else if (j === bucketOne) {
-        j = 0;
-      } else if ((k > bucketOne && j !== 0) || (k > bucketOne && pourOrReceive)) {
-        k = k - (bucketOne - j);
-        j = bucketOne;
-      } else if (k > bucketOne || j === 0) {
-        j = k;
-        k = k - j;
-      } else if (k === 0) {
-        k = bucketTwo;
+      if (currentBucketTwo > bucketOne && currentBucketOne === 0 && moveCount === 0) {
+        currentBucketOne = bucketOne;
+        currentBucketTwo = bucketTwo - currentBucketOne;
+      } else if (currentBucketOne === bucketOne) {
+        currentBucketOne = 0;
+      } else if ((currentBucketTwo > bucketOne && currentBucketOne !== 0) || (currentBucketTwo > bucketOne && pourOrReceive)) {
+        currentBucketTwo = currentBucketTwo - (bucketOne - currentBucketOne);
+        currentBucketOne = bucketOne;
+      } else if (currentBucketTwo > bucketOne || currentBucketOne === 0) {
+        currentBucketOne = currentBucketTwo;
+        currentBucketTwo = currentBucketTwo - currentBucketOne;
+      } else if (currentBucketTwo === 0) {
+        currentBucketTwo = bucketTwo;
       }
-      measurements = [j, k];
       moveCount++;
       pourOrReceive ? pourOrReceive = false : pourOrReceive = true;
     }
@@ -52,31 +51,30 @@ function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
   };
 
   this.smallFirst = function (measurements) {
-    var j = measurements[0];
-    var k = measurements[1];
+    var currentBucketOne = measurements[0];
+    var currentBucketTwo = measurements[1];
     var moveCount = 0;
     var pourOrReceive = true;
     while (true) {
-      if (this.reachedGoal(measurements)) {
-        this.recordGoal(measurements);
+      if (this.reachedGoal([currentBucketOne, currentBucketTwo])) {
+        this.recordGoal([currentBucketOne, currentBucketTwo]);
         break;
       }
-      if (j === bucketOne && moveCount === 0) {
-        j = 0;
-        k = bucketOne;
-      } else if (j === 0) {
-        j = bucketOne;
-      } else if (j === bucketOne && k < bucketTwo) {
-        var tempK = k;
-        k + j > bucketTwo ? k = bucketTwo : k = tempK + j;
-        tempK + j > bucketTwo ? j = j - (bucketTwo - tempK) : j = 0;
-      } else if (k === bucketTwo) {
-        k = 0;
-      } else if (k === 0 && j < bucketOne) {
-        k = j;
-        j = 0;
+      if (currentBucketOne === bucketOne && moveCount === 0) {
+        currentBucketOne = 0;
+        currentBucketTwo = bucketOne;
+      } else if (currentBucketOne === 0) {
+        currentBucketOne = bucketOne;
+      } else if (currentBucketOne === bucketOne && currentBucketTwo < bucketTwo) {
+        var temp = currentBucketTwo;
+        currentBucketTwo + currentBucketOne > bucketTwo ? currentBucketTwo = bucketTwo : currentBucketTwo = temp + currentBucketOne;
+        temp + currentBucketOne > bucketTwo ? currentBucketOne = currentBucketOne - (bucketTwo - temp) : currentBucketOne = 0;
+      } else if (currentBucketTwo === bucketTwo) {
+        currentBucketTwo = 0;
+      } else if (currentBucketTwo === 0 && currentBucketOne < bucketOne) {
+        currentBucketTwo = currentBucketOne;
+        currentBucketOne = 0;
       }
-      measurements = [j, k];
       moveCount++;
       pourOrReceive ? pourOrReceive = false : pourOrReceive = true;
     }

--- a/exercises/two-bucket/example.js
+++ b/exercises/two-bucket/example.js
@@ -1,13 +1,12 @@
 'use strict';
 
 function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
-  this.startBucket = startBucket;
   this.bucketOne = bucketOne;
   this.bucketTwo = bucketTwo;
   this.goal = goal;
+  this.startBucket = startBucket;
 
   this.reachedGoal = function (measurements) {
-    var reached = false;
     if (measurements[0] === goal || measurements[1] === goal) {
       if (measurements[0] === goal) {
         this.goalBucket = 'one';
@@ -16,14 +15,15 @@ function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
         this.goalBucket = 'two';
         this.otherBucket = measurements[0];
       }
-      reached = true;
+      return true;
     }
-    return reached;
+    return false;
   };
 
-  this.bigFirst = function (measurements, moveCount, prBool) {
+  this.bigFirst = function (measurements, prBool) {
     var j = measurements[0];
     var k = measurements[1];
+    var moveCount = 0;
     while (true) {
       if (this.reachedGoal(measurements)) break;
       if (k > bucketOne && j === 0 && moveCount === 0) {
@@ -47,9 +47,10 @@ function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
     return moveCount;
   };
 
-  this.smallFirst = function (measurements, moveCount, prBool) {
+  this.smallFirst = function (measurements, prBool) {
     var j = measurements[0];
     var k = measurements[1];
+    var moveCount = 0;
     while (true) {
       if (this.reachedGoal(measurements)) break;
       if (j === bucketOne && moveCount === 0) {
@@ -73,21 +74,20 @@ function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
     }
     return moveCount;
   };
-}
 
-TwoBucket.prototype.moves = function () {
-  var j = 0; // j will be running val of bucket one,
-  var k = 0; // k will be running val of bucket two
-  this.startBucket === 'one' ? j = this.bucketOne : k = this.bucketTwo;
-  var measurements = [j, k];
-  var moveCount = 0;
-  var prBool = true; // pour / receive boolean - need to pour or receive everbucketTwo other turn
-  if (this.startBucket === 'one') {
-    moveCount = this.smallFirst(measurements, moveCount, prBool);
-  } else {
-    moveCount = this.bigFirst(measurements, moveCount, prBool);
-  }
-  return moveCount + 1; // accounts for first move made before loop (and moveCount starts at goalero before loop)
-};
+  this.moves = function () {
+    var j = 0; // j will be running val of bucket one,
+    var k = 0; // k will be running val of bucket two
+    this.startBucket === 'one' ? j = this.bucketOne : k = this.bucketTwo;
+    var measurements = [j, k];
+    var prBool = true; // pour / receive boolean - need to pour or receive everbucketTwo other turn
+    if (this.startBucket === 'one') {
+      measurements = [this.bucketOne, 0];
+      return this.smallFirst(measurements, prBool) + 1;
+    }
+    measurements = [0, this.bucketTwo];
+    return this.bigFirst(measurements, prBool) + 1;
+  };
+}
 
 module.exports = TwoBucket;

--- a/exercises/two-bucket/example.js
+++ b/exercises/two-bucket/example.js
@@ -7,31 +7,35 @@ function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
   this.startBucket = startBucket;
 
   this.reachedGoal = function (measurements) {
-    if (measurements[0] === goal || measurements[1] === goal) {
-      if (measurements[0] === goal) {
-        this.goalBucket = 'one';
-        this.otherBucket = measurements[1];
-      } else {
-        this.goalBucket = 'two';
-        this.otherBucket = measurements[0];
-      }
-      return true;
-    }
-    return false;
+    return (measurements[0] === goal || measurements[1] === goal);
   };
 
-  this.bigFirst = function (measurements, prBool) {
+  this.recordGoal = function (measurements) {
+    if (measurements[0] === goal) {
+      this.goalBucket = 'one';
+      this.otherBucket = measurements[1];
+    } else {
+      this.goalBucket = 'two';
+      this.otherBucket = measurements[0];
+    }
+  };
+
+  this.bigFirst = function (measurements) {
     var j = measurements[0];
     var k = measurements[1];
     var moveCount = 0;
+    var pourOrReceive = true;
     while (true) {
-      if (this.reachedGoal(measurements)) break;
+      if (this.reachedGoal(measurements)) {
+        this.recordGoal(measurements);
+        break;
+      }
       if (k > bucketOne && j === 0 && moveCount === 0) {
         j = bucketOne;
         k = bucketTwo - j;
       } else if (j === bucketOne) {
         j = 0;
-      } else if ((k > bucketOne && j !== 0) || (k > bucketOne && prBool)) {
+      } else if ((k > bucketOne && j !== 0) || (k > bucketOne && pourOrReceive)) {
         k = k - (bucketOne - j);
         j = bucketOne;
       } else if (k > bucketOne || j === 0) {
@@ -42,17 +46,21 @@ function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
       }
       measurements = [j, k];
       moveCount++;
-      prBool ? prBool = false : prBool = true;
+      pourOrReceive ? pourOrReceive = false : pourOrReceive = true;
     }
     return moveCount;
   };
 
-  this.smallFirst = function (measurements, prBool) {
+  this.smallFirst = function (measurements) {
     var j = measurements[0];
     var k = measurements[1];
     var moveCount = 0;
+    var pourOrReceive = true;
     while (true) {
-      if (this.reachedGoal(measurements)) break;
+      if (this.reachedGoal(measurements)) {
+        this.recordGoal(measurements);
+        break;
+      }
       if (j === bucketOne && moveCount === 0) {
         j = 0;
         k = bucketOne;
@@ -70,23 +78,16 @@ function TwoBucket(bucketOne, bucketTwo, goal, startBucket) {
       }
       measurements = [j, k];
       moveCount++;
-      prBool ? prBool = false : prBool = true;
+      pourOrReceive ? pourOrReceive = false : pourOrReceive = true;
     }
     return moveCount;
   };
 
   this.moves = function () {
-    var j = 0; // j will be running val of bucket one,
-    var k = 0; // k will be running val of bucket two
-    this.startBucket === 'one' ? j = this.bucketOne : k = this.bucketTwo;
-    var measurements = [j, k];
-    var prBool = true; // pour / receive boolean - need to pour or receive everbucketTwo other turn
     if (this.startBucket === 'one') {
-      measurements = [this.bucketOne, 0];
-      return this.smallFirst(measurements, prBool) + 1;
+      return this.smallFirst([this.bucketOne, 0]) + 1;
     }
-    measurements = [0, this.bucketTwo];
-    return this.bigFirst(measurements, prBool) + 1;
+    return this.bigFirst([0, this.bucketTwo]) + 1;
   };
 }
 

--- a/exercises/two-bucket/two-bucket.spec.js
+++ b/exercises/two-bucket/two-bucket.spec.js
@@ -1,44 +1,44 @@
 var TwoBucket = require('./two-bucket');
 
 describe('TwoBucket', function () {
-  describe('works for input of 3,5,1', function () {
-    var buckOne = 3;
-    var buckTwo = 5;
+  describe('Measure using bucket one of size 3 and bucket two of size 5 - ', function () {
+    var bucketOne = 3;
+    var bucketTwo = 5;
     var goal = 1;
 
-    it('starting with bucket one', function () {
-      var starterBuck = 'one'; // indicates which bucket to fill first
-      var twoBucket = new TwoBucket(buckOne, buckTwo, goal, starterBuck);
+    it('start with bucket one', function () {
+      var twoBucket = new TwoBucket(bucketOne, bucketTwo, goal, 'one');
+
       expect(twoBucket.moves()).toEqual(4); // includes the first fill
       expect(twoBucket.goalBucket).toEqual('one'); // which bucket should end up with the desired # of liters
       expect(twoBucket.otherBucket).toEqual(5); // leftover value in the "other" bucket once the goal has been reached
     });
 
-    xit('starting with bucket two', function () {
-      var starterBuck = 'two';
-      var twoBucket = new TwoBucket(buckOne, buckTwo, goal, starterBuck);
+    xit('start with bucket two', function () {
+      var twoBucket = new TwoBucket(bucketOne, bucketTwo, goal, 'two');
+
       expect(twoBucket.moves()).toEqual(8);
       expect(twoBucket.goalBucket).toEqual('two');
       expect(twoBucket.otherBucket).toEqual(3);
     });
   });
 
-  describe('works for input of 7,11,2', function () {
-    var buckOne = 7;
-    var buckTwo = 11;
+  describe('Measure using bucket one of size 7 and bucket two of size 11 - ', function () {
+    var bucketOne = 7;
+    var bucketTwo = 11;
     var goal = 2;
 
-    xit('starting with bucket one', function () {
-      var starterBuck = 'one';
-      var twoBucket = new TwoBucket(buckOne, buckTwo, goal, starterBuck);
+    xit('start with bucket one', function () {
+      var twoBucket = new TwoBucket(bucketOne, bucketTwo, goal, 'one');
+
       expect(twoBucket.moves()).toEqual(14);
       expect(twoBucket.goalBucket).toEqual('one');
       expect(twoBucket.otherBucket).toEqual(11);
     });
 
-    xit('starting with bucket two', function () {
-      var starterBuck = 'two';
-      var twoBucket = new TwoBucket(buckOne, buckTwo, goal, starterBuck);
+    xit('start with bucket two', function () {
+      var twoBucket = new TwoBucket(bucketOne, bucketTwo, goal, 'two');
+
       expect(twoBucket.moves()).toEqual(18);
       expect(twoBucket.goalBucket).toEqual('two');
       expect(twoBucket.otherBucket).toEqual(7);


### PR DESCRIPTION
Previously: `npm run lint` would show these errors / warnings for `two-bucket`
```
/Volumes/git/personal/javascript/exercises/two-bucket/example.js
  10:25  error    Expected '===' and instead saw '=='                eqeqeq
  10:49  error    Expected '===' and instead saw '=='                eqeqeq
  11:27  error    Expected '===' and instead saw '=='                eqeqeq
  24:5   error    Split 'var' declarations into multiple statements  one-var
  25:5   warning  Unexpected constant condition                      no-constant-condition
  27:22  error    Expected '===' and instead saw '=='                eqeqeq
  27:40  error    Expected '===' and instead saw '=='                eqeqeq
  30:20  error    Expected '===' and instead saw '=='                eqeqeq
  35:29  error    Expected '===' and instead saw '=='                eqeqeq
  38:20  error    Expected '===' and instead saw '=='                eqeqeq
  41:7   error    Assignment to function parameter 'measurements'    no-param-reassign
  42:7   error    Assignment to function parameter 'moveCount'       no-param-reassign
  43:16  error    Assignment to function parameter 'prBool'          no-param-reassign
  43:33  error    Assignment to function parameter 'prBool'          no-param-reassign
  49:5   error    Split 'var' declarations into multiple statements  one-var
  50:5   warning  Unexpected constant condition                      no-constant-condition
  52:13  error    Expected '===' and instead saw '=='                eqeqeq
  52:31  error    Expected '===' and instead saw '=='                eqeqeq
  55:20  error    Expected '===' and instead saw '=='                eqeqeq
  57:20  error    Expected '===' and instead saw '=='                eqeqeq
  61:20  error    Expected '===' and instead saw '=='                eqeqeq
  63:20  error    Expected '===' and instead saw '=='                eqeqeq
  67:7   error    Assignment to function parameter 'measurements'    no-param-reassign
  68:7   error    Assignment to function parameter 'moveCount'       no-param-reassign
  69:16  error    Assignment to function parameter 'prBool'          no-param-reassign
  69:33  error    Assignment to function parameter 'prBool'          no-param-reassign
  76:3   error    Split 'var' declarations into multiple statements  one-var
  77:16  error    Expected '===' and instead saw '=='                eqeqeq
  81:20  error    Expected '===' and instead saw '=='                eqeqeq
```

Now no lint errors or warnings 🎊 
This is far from a complete refactor but I think it's an improvement