### PR TITLE
fix the grains exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,7 +14,8 @@ exercises/diamond
 exercises/flatten-array
 exercises/food-chain
 exercises/grade-school
-exercises/grains
+exercises/grains/big-integer.js
+exercises/grains/big-integer.spec.js
 exercises/kindergarten-garden
 exercises/leap
 exercises/linked-list

--- a/exercises/grains/example.js
+++ b/exercises/grains/example.js
@@ -4,7 +4,7 @@ var BigInt = require('./big-integer');
  * @author github.com/nonsensery
  * @class Grains
  *
- * Computes the number of grains on the squares of a
+ * @classdesc Computes the number of grains on the squares of a
  * chess board, starting with one grain on the first
  * square, and doubling with each successive square.
  */
@@ -14,16 +14,19 @@ function Grains() {
 
 /**
  * Gets the number of grains on the nth square.
+ * @param {number} num - the value to square
+ * @return {number} the square of num
  */
 Grains.prototype.square = function (num) {
-  return BigInt(2).pow(num - 1).toString();
+  return new BigInt(2).pow(num - 1).toString();
 };
 
 /**
  * Gets the total number of grains on all squares.
+ * @return {string} the total
  */
 Grains.prototype.total = function () {
-  var total = BigInt(0);
+  var total = new BigInt(0);
 
   for (var squareNum = 1; squareNum <= 64; ++squareNum) {
     total = total.add(this.square(squareNum));


### PR DESCRIPTION
I added .eslignore files to the grains exercise directory and project root.   Also deleted the big-integer-spec.js test file as it doesn't make sense to keep a test for a vendor included library.  A user won't be able to get to it anyway without download the project source.