### PR TITLE
Fix crypto square, largest series product, sieve examples

### DIFF
--- a/exercises/crypto-square/example.js
+++ b/exercises/crypto-square/example.js
@@ -22,7 +22,8 @@ module.exports = function (input) {
 
   this.ciphertext = function () {
     var textSegments = this.plaintextSegments();
-    var i, j;
+    var i;
+    var j;
     var columns = [];
     var currentSegment;
     var currentLetter;

--- a/exercises/largest-series-product/example.js
+++ b/exercises/largest-series-product/example.js
@@ -14,7 +14,8 @@ Series.prototype.getDigits = function () {
 
 Series.prototype.largestProduct = function (size) {
   if (size < 0) throw new Error('Invalid input.');
-  var product, max = 0;
+  var product;
+  var max = 0;
   this.slices(size).forEach(function (slice) {
     product = slice.reduce(function (a, b) {
       return a * b;

--- a/exercises/sieve/example.js
+++ b/exercises/sieve/example.js
@@ -1,7 +1,8 @@
 'use strict';
 
 function newArrayWithRange(first, last) {
-  var i, array = [];
+  var i;
+  var array = [];
   for ( i = first; i <= last; i++ ) {
     array.push(i);
   }
@@ -13,7 +14,9 @@ function indivisibleBy(value) {
 }
 
 function sieve(n) {
-  var i, prime, possibilities, primes = [];
+  var prime;
+  var possibilities;
+  var primes = [];
 
   possibilities = newArrayWithRange(2, n);
 


### PR DESCRIPTION
Part of https://github.com/exercism/javascript/issues/399

Fix `error  Split 'var' declarations into multiple statements  one-var` errors to clean up three examples. These were the only errors on these three examples.