### PR TITLE
Fix Diamond and Sum of Multiples

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,7 +10,6 @@ exercises/bracket-push
 exercises/circular-buffer
 exercises/clock
 exercises/custom-set
-exercises/diamond
 exercises/flatten-array
 exercises/food-chain
 exercises/grade-school
@@ -37,7 +36,6 @@ exercises/scrabble-score
 exercises/secret-handshake
 exercises/simple-cipher
 exercises/simple-linked-list
-exercises/sum-of-multiples
 exercises/triangle
 exercises/trinary
 exercises/wordy

--- a/exercises/diamond/diamond.spec.js
+++ b/exercises/diamond/diamond.spec.js
@@ -4,12 +4,12 @@ describe('Diamond', function () {
   var diamond = new Diamond();
 
   it('test letter A', function () {
-    result = 'A\n';
+    var result = 'A\n';
     expect(diamond.makeDiamond('A')).toEqual(result);
   });
 
   it('test letter C', function () {
-    result = ['  A  ',
+    var result = ['  A  ',
       ' B B ',
       'C   C',
       ' B B ',
@@ -18,7 +18,7 @@ describe('Diamond', function () {
   });
 
   it('test letter E', function () {
-    result = ['    A    ',
+    var result = ['    A    ',
       '   B B   ',
       '  C   C  ',
       ' D     D ',

--- a/exercises/diamond/example.js
+++ b/exercises/diamond/example.js
@@ -5,8 +5,8 @@ var Diamond = function () {
     for (var i = 0; i <= inputIndex; i++) {
       output += getLine(inputIndex, i);
     }
-    for (i = inputIndex - 1; i >= 0; i--) {
-      output += getLine(inputIndex, i);
+    for (var j = inputIndex - 1; j >= 0; j--) {
+      output += getLine(inputIndex, j);
     }
     return output;
   };

--- a/exercises/diamond/example.js
+++ b/exercises/diamond/example.js
@@ -5,7 +5,7 @@ var Diamond = function () {
     for (var i = 0; i <= inputIndex; i++) {
       output += getLine(inputIndex, i);
     }
-    for (var i = inputIndex - 1; i >= 0; i--) {
+    for (i = inputIndex - 1; i >= 0; i--) {
       output += getLine(inputIndex, i);
     }
     return output;

--- a/exercises/sum-of-multiples/sum-of-multiples.spec.js
+++ b/exercises/sum-of-multiples/sum-of-multiples.spec.js
@@ -1,39 +1,39 @@
-var sumOfMultiples = require('./sum-of-multiples');
+var SumOfMultiples = require('./sum-of-multiples');
 
-describe('sumOfMultiples', function () {
+describe('SumOfMultiples', function () {
   it('to 1', function () {
-    expect(sumOfMultiples([3, 5]).to(1)).toBe(0);
+    expect(new SumOfMultiples([3, 5]).to(1)).toBe(0);
   });
 
   xit('to 3', function () {
-    expect(sumOfMultiples([3, 5]).to(4)).toBe(3);
+    expect(new SumOfMultiples([3, 5]).to(4)).toBe(3);
   });
 
   xit('to 10', function () {
-    expect(sumOfMultiples([3, 5]).to(10)).toBe(23);
+    expect(new SumOfMultiples([3, 5]).to(10)).toBe(23);
   });
 
   xit('to 100', function () {
-    expect(sumOfMultiples([3, 5]).to(100)).toBe(2318);
+    expect(new SumOfMultiples([3, 5]).to(100)).toBe(2318);
   });
 
   xit('to 1000', function () {
-    expect(sumOfMultiples([3, 5]).to(1000)).toBe(233168);
+    expect(new SumOfMultiples([3, 5]).to(1000)).toBe(233168);
   });
 
   xit('[7, 13, 17] to 20', function () {
-    expect(sumOfMultiples([7, 13, 17]).to(20)).toBe(51);
+    expect(new SumOfMultiples([7, 13, 17]).to(20)).toBe(51);
   });
 
   xit('[4, 6] to 15', function () {
-    expect(sumOfMultiples([4, 6]).to(15)).toBe(30);
+    expect(new SumOfMultiples([4, 6]).to(15)).toBe(30);
   });
 
   xit('[5, 6, 8] to 150', function () {
-    expect(sumOfMultiples([5, 6, 8]).to(150)).toBe(4419);
+    expect(new SumOfMultiples([5, 6, 8]).to(150)).toBe(4419);
   });
 
   xit('[43, 47] to 10000', function () {
-    expect(sumOfMultiples([43, 47]).to(10000)).toBe(2203160);
+    expect(new SumOfMultiples([43, 47]).to(10000)).toBe(2203160);
   });
 });

--- a/exercises/sum-of-multiples/sum-of-multiples.spec.js
+++ b/exercises/sum-of-multiples/sum-of-multiples.spec.js
@@ -1,39 +1,39 @@
-var SumOfMultiples = require('./sum-of-multiples');
+var sumOfMultiples = require('./sum-of-multiples');
 
-describe('SumOfMultiples', function () {
+describe('sumOfMultiples', function () {
   it('to 1', function () {
-    expect(SumOfMultiples([3, 5]).to(1)).toBe(0);
+    expect(sumOfMultiples([3, 5]).to(1)).toBe(0);
   });
 
   xit('to 3', function () {
-    expect(SumOfMultiples([3, 5]).to(4)).toBe(3);
+    expect(sumOfMultiples([3, 5]).to(4)).toBe(3);
   });
 
   xit('to 10', function () {
-    expect(SumOfMultiples([3, 5]).to(10)).toBe(23);
+    expect(sumOfMultiples([3, 5]).to(10)).toBe(23);
   });
 
   xit('to 100', function () {
-    expect(SumOfMultiples([3, 5]).to(100)).toBe(2318);
+    expect(sumOfMultiples([3, 5]).to(100)).toBe(2318);
   });
 
   xit('to 1000', function () {
-    expect(SumOfMultiples([3, 5]).to(1000)).toBe(233168);
+    expect(sumOfMultiples([3, 5]).to(1000)).toBe(233168);
   });
 
   xit('[7, 13, 17] to 20', function () {
-    expect(SumOfMultiples([7, 13, 17]).to(20)).toBe(51);
+    expect(sumOfMultiples([7, 13, 17]).to(20)).toBe(51);
   });
 
   xit('[4, 6] to 15', function () {
-    expect(SumOfMultiples([4, 6]).to(15)).toBe(30);
+    expect(sumOfMultiples([4, 6]).to(15)).toBe(30);
   });
 
   xit('[5, 6, 8] to 150', function () {
-    expect(SumOfMultiples([5, 6, 8]).to(150)).toBe(4419);
+    expect(sumOfMultiples([5, 6, 8]).to(150)).toBe(4419);
   });
 
   xit('[43, 47] to 10000', function () {
-    expect(SumOfMultiples([43, 47]).to(10000)).toBe(2203160);
+    expect(sumOfMultiples([43, 47]).to(10000)).toBe(2203160);
   });
 });


### PR DESCRIPTION
Part of https://github.com/exercism/javascript/issues/399

Fixes lint errors for Diamond and Sum of Multiples examples.

Diamond: 

```
/javascript/exercises/diamond/diamond.spec.js
   7:5   error  'result' is not defined  no-undef
   8:46  error  'result' is not defined  no-undef
  12:5   error  'result' is not defined  no-undef
  17:46  error  'result' is not defined  no-undef
  21:5   error  'result' is not defined  no-undef
  30:46  error  'result' is not defined  no-undef

/javascript/exercises/diamond/example.js
  8:14  error  'i' is already defined  no-redeclare

✖ 7 problems (7 errors, 0 warnings)
```

Sum of Multiples:
```
/javascript/exercises/sum-of-multiples/sum-of-multiples.spec.js
   5:12  error  A function with a name starting with an uppercase letter should only be used as a constructor  new-cap
   9:12  error  A function with a name starting with an uppercase letter should only be used as a constructor  new-cap
  13:12  error  A function with a name starting with an uppercase letter should only be used as a constructor  new-cap
  17:12  error  A function with a name starting with an uppercase letter should only be used as a constructor  new-cap
  21:12  error  A function with a name starting with an uppercase letter should only be used as a constructor  new-cap
  25:12  error  A function with a name starting with an uppercase letter should only be used as a constructor  new-cap
  29:12  error  A function with a name starting with an uppercase letter should only be used as a constructor  new-cap
  33:12  error  A function with a name starting with an uppercase letter should only be used as a constructor  new-cap
  37:12  error  A function with a name starting with an uppercase letter should only be used as a constructor  new-cap

✖ 9 problems (9 errors, 0 warnings)
```
