### PR TITLE
Fix 2 lint errors on Acronym exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,5 @@
 big-integer.js
 exercises/accumulate
-exercises/acronym
 exercises/alphametics
 exercises/anagram
 exercises/binary-search

--- a/exercises/acronym/example.js
+++ b/exercises/acronym/example.js
@@ -2,7 +2,8 @@ module.exports = {
   parse: function (phrase) {
     return phrase.match(/[A-Z]+[a-z]*|[a-z]+/g)
       .reduce(function (acronym, word) {
-        return acronym += word[0].toUpperCase();
+        var returnAcronym = acronym + word[0].toUpperCase();
+        return returnAcronym;
       }, '');
   }
 };


### PR DESCRIPTION
Fix errors: 
```
/javascript/exercises/acronym/example.js
  5:9   error  Return statement should not contain assignment  no-return-assign
  5:16  error  Assignment to function parameter 'acronym'      no-param-reassign

✖ 2 problems (2 errors, 0 warnings)
```