### PR TITLE
Lint fix for Accumulate exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,4 @@
 big-integer.js
-exercises/accumulate
 exercises/alphametics
 exercises/anagram
 exercises/binary-search

--- a/exercises/accumulate/example.js
+++ b/exercises/accumulate/example.js
@@ -1,4 +1,4 @@
-var accumulate = module.exports = function (list, accumulator) {
+module.exports = function (list, accumulator) {
   var out = [];
   var idx = -1;
   var end = Array.isArray(list) ? list.length : 0;
@@ -9,4 +9,3 @@ var accumulate = module.exports = function (list, accumulator) {
 
   return out;
 };
-


### PR DESCRIPTION
Fix 1 error: 
```
/javascript/exercises/accumulate/example.js
  1:5  error  'accumulate' is assigned a value but never used  no-unused-vars

✖ 1 problem (1 error, 0 warnings)
```