### PR TITLE
Ignore `package-lock.json` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ bin/configlet.exe
 .idea
 
 *.js~
+
+package-lock.json


### PR DESCRIPTION
I create this PR to ignore `package-lock.json` file. But, is it something we @exercism/ecmascripts want?

Should `package-lock.json` file be commited into the repo? `npm` recommends it, but I'm not a fan of doing that. It might change very frecuently, and it makes the repo a bit more dirty.

`npm` recomendation...

![image](https://user-images.githubusercontent.com/612688/33765494-54009d0c-dc19-11e7-9872-6cb360ec7711.png)
