### PR TITLE
redo the bowling exericse to match the canonical tests and description

### DIFF
--- a/exercises/bowling/bowling.spec.js
+++ b/exercises/bowling/bowling.spec.js
@@ -1,147 +1,211 @@
 var Bowling = require('./bowling');
 
 describe('Bowling', function () {
+  function previousRolls(bowling, rolls) {
+    for (var i = 0; i < rolls.length; i++) {
+      bowling.roll(rolls[i]);
+    }
+  }
   describe('Check game can be scored correctly.', function () {
     it('should be able to score a game with all gutterballs', function () {
       var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-      expect(new Bowling(rolls).score()).toEqual(0);
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(bowling.score()).toEqual(0);
     });
 
-    xit('should be able to score a game with all open frames', function () {
+    xit('should be able to score a game with no strikes or spares', function () {
       var rolls = [3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6];
-      expect(new Bowling(rolls).score()).toEqual(90);
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(bowling.score()).toEqual(90);
     });
 
-    xit('a spare followed by zeros is worth 10 points', function () {
+    xit('a spare followed by zeros is worth ten points', function () {
       var rolls = [6, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-      expect(new Bowling(rolls).score()).toEqual(10);
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(bowling.score()).toEqual(10);
     });
 
     xit('points scored in the roll after a spare are counted twice', function () {
       var rolls = [6, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-      expect(new Bowling(rolls).score()).toEqual(16);
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(bowling.score()).toEqual(16);
     });
 
     xit('consecutive spares each get a one-roll bonus', function () {
       var rolls = [5, 5, 3, 7, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-      expect(new Bowling(rolls).score()).toEqual(31);
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(bowling.score()).toEqual(31);
     });
 
-    xit('should allow fill ball when the last frame is a spare', function () {
+    xit('should allow fill ball the last frame is a spare', function () {
       var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 7];
-      expect(new Bowling(rolls).score()).toEqual(17);
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(bowling.score()).toEqual(17);
     });
 
-    xit('a strike earns 10 points in a frame with a single roll', function () {
+    xit('a strike earns ten  points in a frame with a single roll', function () {
       var rolls = [10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-      expect(new Bowling(rolls).score()).toEqual(10);
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(bowling.score()).toEqual(10);
     });
 
     xit('points scored in the two rolls after a strike are counted twice as a bonus', function () {
       var rolls = [10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-      expect(new Bowling(rolls).score()).toEqual(26);
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(bowling.score()).toEqual(26);
     });
 
     xit('should be able to score multiple strikes in a row', function () {
       var rolls = [10, 10, 10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-      expect(new Bowling(rolls).score()).toEqual(81);
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(bowling.score()).toEqual(81);
     });
 
     xit('should allow fill balls when the last frame is a strike', function () {
       var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 1];
-      expect(new Bowling(rolls).score()).toEqual(18);
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(bowling.score()).toEqual(18);
     });
 
     xit('rolling a spare with the two-roll bonus does not get a bonus roll', function () {
       var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 3];
-      expect(new Bowling(rolls).score()).toEqual(20);
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(bowling.score()).toEqual(20);
     });
 
     xit('strikes with the two-roll bonus do not get bonus rolls', function () {
       var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 10];
-      expect(new Bowling(rolls).score()).toEqual(30);
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(bowling.score()).toEqual(30);
     });
 
     xit('a strike with the one-roll bonus after a spare in the last frame does not get a bonus', function () {
       var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 10];
-      expect(new Bowling(rolls).score()).toEqual(20);
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(bowling.score()).toEqual(20);
     });
 
     xit('should be able to score a perfect game', function () {
       var rolls = [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10];
-      expect(new Bowling(rolls).score()).toEqual(300);
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(bowling.score()).toEqual(300);
     });
   });
 
   describe('Check game rules.', function () {
     xit('rolls cannot score negative points', function () {
-      var rolls = [-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-      expect(function () { new Bowling(rolls).score(); }).toThrow(
-        new Error('Pins must have a value from 0 to 10'));
+      var bowling = new Bowling();
+      expect(function () {bowling.roll(-1);}).toThrow(new Error('Negative roll is invalid'));
     });
 
     xit('a roll cannot score more than 10 points', function () {
-      var rolls = [11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-      expect(function () { new Bowling(rolls).score(); }).toThrow(
-        new Error('Pins must have a value from 0 to 10'));
+      var bowling = new Bowling();
+      expect(function () {bowling.roll(11);}).toThrow( new Error('Pin count exceeds pins on the lane'));
     });
 
     xit('two rolls in a frame cannot score more than 10 points', function () {
-      var rolls = [5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-      expect(function () { new Bowling(rolls).score(); }).toThrow(
+      var bowling = new Bowling();
+      bowling.roll(5);
+      expect(function () {bowling.roll(6);}).toThrow( new Error('Pin count exceeds pins on the lane'));
+    });
+
+    xit('bonus roll after a strike in the last frame cannot score more than 10 points', function () {
+      var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10];
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(function () { bowling.roll(11); }).toThrow(
         new Error('Pin count exceeds pins on the lane'));
     });
 
     xit('two bonus rolls after a strike in the last frame cannot score more than 10 points', function () {
-      var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5, 6];
-      expect(function () { new Bowling(rolls).score(); }).toThrow(
-        new Error('Pin count exceeds pins on the lane'));
+      var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5];
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(function () {bowling.roll(6);}).toThrow( new Error('Pin count exceeds pins on the lane'));
     });
 
     xit('two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike', function () {
       var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 6];
-      expect(new Bowling(rolls).score()).toEqual(26);
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(bowling.score()).toEqual(26);
     });
 
     xit('the second bonus roll after a strike in the last frame cannot be a strike if the first one is not a strike', function () {
-      var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 6, 10];
-      expect(function () { new Bowling(rolls).score(); }).toThrow(
+      var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 6];
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(function () { bowling.roll(10); }).toThrow(
+        new Error('Pin count exceeds pins on the lane'));
+    });
+
+    xit('the second bonus roll after a strike in the last frame cannot score more than 10 points', function () {
+      var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10];
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(function () { bowling.roll(11); }).toThrow(
         new Error('Pin count exceeds pins on the lane'));
     });
 
     xit('an unstarted game cannot be scored', function () {
       var rolls = [];
-      expect(function () { new Bowling(rolls).score(); }).toThrow(
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(function () { bowling.score(); }).toThrow(
         new Error('Score cannot be taken until the end of the game'));
     });
 
     xit('an incomplete game cannot be scored', function () {
       var rolls = [0, 0];
-      expect(function () { new Bowling(rolls).score(); }).toThrow(
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(function () { bowling.score(); }).toThrow(
         new Error('Score cannot be taken until the end of the game'));
     });
 
-    xit('a game with more than 10 frames and no last frame spare or strike cannot be scored', function () {
-      var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-      expect(function () { new Bowling(rolls).score(); }).toThrow(
-        new Error('Should not be able to roll after game is over'));
+    xit('cannot roll if game already has 10 frames', function () {
+      var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(function () { bowling.roll(0); }).toThrow(
+        new Error('Cannot roll after game is over'));
     });
 
     xit('bonus rolls for a strike in the last frame must be rolled before score can be calculated', function () {
       var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10];
-      expect(function () { new Bowling(rolls).score(); }).toThrow(
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(function () { bowling.score(); }).toThrow(
         new Error('Score cannot be taken until the end of the game'));
     });
 
     xit('both bonus rolls for a strike in the last frame must be rolled before score can be calculated', function () {
       var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10];
-      expect(function () { new Bowling(rolls).score(); }).toThrow(
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(function () {bowling.score(); }).toThrow(
         new Error('Score cannot be taken until the end of the game'));
     });
 
     xit('bonus roll for a spare in the last frame must be rolled before score can be calculated', function () {
       var rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3];
-      expect(function () { new Bowling(rolls).score(); }).toThrow(
+      var bowling = new Bowling();
+      previousRolls(bowling, rolls);
+      expect(function () { bowling.score(); }).toThrow(
         new Error('Score cannot be taken until the end of the game'));
     });
   });

--- a/exercises/bowling/example.js
+++ b/exercises/bowling/example.js
@@ -1,82 +1,135 @@
 'use strict';
 
-function Bowling(rolls) {
-  this.rolls = rolls;
-}
-
-Bowling.prototype.score = function () {
-  var maxFrames = 10;
+function Bowling() {
   var maxPins = 10;
+  var maxFrames = 10;
+  var frames = [];
+  var frameScores = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
-  var initialState = {
-    frameNumber: 1,
-    rollNumber: 1,
-    pinsRemaining: 10,
-    spareLastFrame: false,
-    strikeLastFrame: false,
-    twoStrikesInARow: false,
-    fillBall: false,
-    score: 0
-  };
+  var currentFrame = 0;
+  var frameRoll = 1;
+  var remainingPins = maxPins;
 
-  var finalState = this.rolls.reduce(function (state, roll) {
-    if (roll < 0 || roll > maxFrames ) {
-      throw new Error('Pins must have a value from 0 to 10');
+  initializeFrame();
+
+  function initializeFrame() {
+    frameRoll = 1;
+    remainingPins = maxPins;
+    currentFrame++;
+  }
+
+  function incrementScore(pins) {
+    if (currentFrame > maxFrames) return;
+    frameScores[currentFrame - 1] += pins;
+  }
+
+  function scoreStrike() {
+    frames[currentFrame - 1] = 'X';
+    applyStrikeBonus(maxPins);
+    applySpareBonus(maxPins);
+    frameRoll++;
+  }
+
+  function scoreFirstRoll(pins) {
+    remainingPins = remainingPins - pins;
+    applySpareBonus(pins);
+    applyStrikeBonus(pins);
+    frameRoll++;
+  }
+
+  function scoreSpare(pins) {
+    frames[currentFrame - 1] = 'S';
+    applyStrikeBonus(pins);
+    frameRoll++;
+  }
+
+  function scoreOpenFrame(pins) {
+    frames[currentFrame - 1] = (maxPins - remainingPins) + pins;
+    applyStrikeBonus(pins);
+    frameRoll++;
+  }
+
+  function applySpareBonus(pins) {
+    // pins on the first roll after a spare are counted twice (on the frame of spare)
+    if (frames[currentFrame - 2] === 'S' ) {
+      frameScores[currentFrame - 2] += pins;
+    }
+  }
+
+  function applyStrikeBonus(pins) {
+    // on the two rolls after a strike are counted twice (on the frame of the strike)
+    if (frames[currentFrame - 3] === 'X' && frames[currentFrame - 2] === 'X' &&
+        frameRoll === 1  && currentFrame <= (maxFrames + 2)) {
+      frameScores[currentFrame - 3] += pins;
+    }
+    if (frames[currentFrame - 2] === 'X' && currentFrame <= (maxFrames + 1)) {
+      frameScores[currentFrame - 2] += pins;
+    }
+  }
+
+  function isGameOver() {
+    if (currentFrame <= maxFrames) return false;
+
+    if (frames[maxFrames - 1] !== 'X' && frames[maxFrames - 1] !== 'S') return true;
+
+    // spare in the last frame gets no more than bonus roll
+    if (frames[maxFrames - 1] === 'S' && frameRoll > 1) return true;
+
+    // bonus roll after the spare in the last frame may get a strike but then the games ends without another roll
+    if (frames[maxFrames - 1] === 'S' && frames[maxFrames] === 'X') return true;
+
+    if (frames[maxFrames - 1] === 'X') {
+      // if the first bonus roll is not a strike then finish the bonus frame
+      if (frames[maxFrames] !== 'X' && currentFrame > maxFrames + 1) return true;
+
+      if (frames[maxFrames] === 'X') {
+        // if the second bonus roll is a strike, but was still used, the game is over
+        if (frames[maxFrames + 1] !== 'X' && frameRoll > 1) return true;
+        // if the second bonus roll is a strike the game is over
+        if (frames[maxFrames + 1] === 'X') return true;
+      }
+    }
+    return false;
+  }
+
+  this.roll = function (pins) {
+    if (pins < 0) {
+      throw new Error( 'Negative roll is invalid');
     }
 
-    if (roll > state.pinsRemaining) {
+    if (pins > remainingPins) {
       throw new Error('Pin count exceeds pins on the lane');
     }
 
-    if (state.frameNumber > maxFrames ) {
-      throw new Error('Should not be able to roll after game is over');
+    if (isGameOver()) {
+      throw new Error('Cannot roll after game is over');
     }
 
-    var finalFrame = state.frameNumber === maxFrames;
-    var strike = state.rollNumber === 1 && roll === 10;
-    var spare = state.rollNumber === 2 && roll === state.pinsRemaining;
-    var frameOver = finalFrame
-      ? (!state.fillBall && !spare && state.rollNumber === 2) || state.rollNumber === 3
-      : strike || spare || state.rollNumber === 2;
+    incrementScore(pins);
 
-    var score = state.score + roll;
-
-    if (state.strikeLastFrame && state.rollNumber < 3) { score = incrementScore(score, roll); }
-    if (state.spareLastFrame && state.rollNumber === 1) { score = incrementScore(score, roll); }
-    if (state.twoStrikesInARow && state.rollNumber === 1) { score = incrementScore(score, roll); }
-
-    var next = {};
-
-    next.frameNumber = frameOver ? state.frameNumber + 1 : state.frameNumber;
-    next.rollNumber = frameOver ? 1 : state.rollNumber + 1;
-    if ( finalFrame ) {
-      next.pinsRemaining = (strike || spare) ? maxPins : pinsRemaining(state.pinsRemaining, roll);
+    if (frameRoll === 1) {
+      if (pins === maxPins) {
+        scoreStrike();
+        initializeFrame();
+      } else {
+        scoreFirstRoll(pins);
+      }
     } else {
-      next.pinsRemaining = frameOver ? maxPins : pinsRemaining(state.pinsRemaining, roll);
+      if (pins === remainingPins) {
+        scoreSpare(pins);
+      } else {
+        scoreOpenFrame(pins);
+      }
+      initializeFrame();
     }
-    next.spareLastFrame = frameOver ? spare : state.spareLastFrame;
-    next.strikeLastFrame = frameOver ? strike : state.strikeLastFrame;
-    next.twoStrikesInARow = frameOver ? strike && state.strikeLastFrame : state.twoStrikesInARow;
-    next.fillBall = next.fillBall || (finalFrame && (strike || spare));
-    next.score = score;
+  };
 
-    return next;
-  }, initialState);
-
-  if (finalState.frameNumber <= maxFrames ) {
-    throw new Error('Score cannot be taken until the end of the game');
-  }
-
-  return finalState.score;
-};
-
-function incrementScore(score, roll) {
-  return score + roll;
+  this.score = function () {
+    if (!isGameOver()) {
+      throw new Error('Score cannot be taken until the end of the game');
+    }
+    return frameScores.reduce(function (total, num) {return total + num;});
+  };
 }
-
-function pinsRemaining(pins, roll) {
-  return pins - roll;
-}
-
 
 module.exports = Bowling;


### PR DESCRIPTION
#488 
the bowling exercise now strictly matches the canonical [tests](https://github.com/exercism/problem-specifications/blob/master/exercises/bowling/canonical-data.json) 