### PR TITLE
Fixes: Alphametic Lint Fixes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,4 @@
 big-integer.js
-exercises/alphametics
 exercises/binary-search
 exercises/binary-search-tree
 exercises/bracket-push


### PR DESCRIPTION
Tested both alphametics.spec.js and example.js .
Found no eslint errors in both files.
Removed these files from .eslintignore.