### PR TITLE
Update jasmine to v3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -728,12 +728,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
-    },
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
@@ -1091,20 +1085,19 @@
       }
     },
     "jasmine": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
-      "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.1.0.tgz",
+      "integrity": "sha1-K9Wf1+xuwOistk4J9Fpo7SrRlSo=",
       "dev": true,
       "requires": {
-        "exit": "0.1.2",
         "glob": "7.1.2",
-        "jasmine-core": "2.8.0"
+        "jasmine-core": "3.1.0"
       }
     },
     "jasmine-core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
-      "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.1.0.tgz",
+      "integrity": "sha1-pHheE11d9lAk38kiSVPfWFvSdmw=",
       "dev": true
     },
     "js-tokens": {

--- a/package.json
+++ b/package.json
@@ -14,16 +14,18 @@
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jasmine": "^2.9.1",
     "eslint-plugin-react": "^7.3.0",
-    "jasmine": "^2.8.0"
+    "jasmine": "^3.1.0"
   },
   "scripts": {
     "lint": "eslint .",
     "lint-fix": "eslint . --fix"
   },
   "eslintConfig": {
-    "plugins": ["jasmine"],
+    "plugins": [
+      "jasmine"
+    ],
     "env": {
-      "jasmine": true 
+      "jasmine": true
     },
     "extends": "eslint-config-airbnb-es5",
     "rules": {


### PR DESCRIPTION
Recently [an issue](https://github.com/exercism/javascript/issues/505) came up related to jasmine v3.0.0. And I noticed that we are using v2.8. Jasmine 3 seems to have some [breaking changes](https://github.com/jasmine/jasmine/blob/master/release_notes/3.0.md) and since many of our new users will be installing recent version of jasmine, I thought it would be better to update it so we run CI using v3.