### PR TITLE
fixes linting errors for perfect numbers exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,7 +8,6 @@ exercises/kindergarten-garden
 exercises/linked-list
 exercises/minesweeper
 exercises/nth-prime
-exercises/perfect-numbers
 exercises/queen-attack
 exercises/robot-simulator
 exercises/saddle-points

--- a/exercises/perfect-numbers/example.js
+++ b/exercises/perfect-numbers/example.js
@@ -7,10 +7,12 @@ var PerfectNumbers = function () {
 /**
  * Calculate all the divisors for a given number and return them as an array.
  * Note: the actual number is not include in the returned array.
+ * @param {number} number - a number input.
+ * @returns {array} - the array of divisors
  */
 PerfectNumbers.prototype.getDivisors = function (number) {
   var i;
-  var divs = new Array();
+  var divs = [];
 
   // Accepts only natura numbers greater than 1.
   if (number <= 1) {
@@ -31,7 +33,9 @@ PerfectNumbers.prototype.getDivisors = function (number) {
 };
 
 PerfectNumbers.prototype.classify = function (number) {
-  var i, sum, result;
+  var i;
+  var sum;
+  var result;
 
   // Check if the input is valid
   if (number <= 0) {


### PR DESCRIPTION
Fixes #399. 

Fixed the linting errors in perfect-numbers/example.js

7:1  Missing JSDoc @returns for function
7:1  Missing JSDoc for parameter 'number'
13:14  The array literal notation [] is preferrable
34:3  Split 'var' declarations into multiple statements