### PR TITLE
fixes linting errors for nth-prime exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,7 +5,6 @@ exercises/grains/big-integer.js
 exercises/grains/big-integer.spec.js
 exercises/linked-list
 exercises/minesweeper
-exercises/nth-prime
 exercises/queen-attack
 exercises/robot-simulator
 exercises/saddle-points

--- a/exercises/nth-prime/example.js
+++ b/exercises/nth-prime/example.js
@@ -7,12 +7,13 @@ module.exports = {
     return this.realPrimes[nthPrime - 1];
   },
   generatePrimes: function (uptoNumber) {
-    var i, j, currentPrime, primeCount, possiblePrimes = [];
-
-    if (this.realPrimes) { return this.realPrimes; }
+    var i;
+    var j;
+    var currentPrime;
+    var possiblePrimes = [];
 
     for (i = 2; i <= uptoNumber; i++) {
-      possiblePrimes.push({ number: i, prime: true});
+      possiblePrimes.push({ number: i, prime: true });
     }
 
     for (i = 2; i < Math.sqrt(possiblePrimes.length); i++) {
@@ -24,8 +25,6 @@ module.exports = {
       }
     }
 
-    primeCount = 0;
-
     this.realPrimes = [];
 
     for (i = 0; i < possiblePrimes.length; i++) {
@@ -34,6 +33,7 @@ module.exports = {
         this.realPrimes.push(currentPrime.number);
       }
     }
+    return this.realPrimes;
   }
 
 };


### PR DESCRIPTION
Fixes #399.

Fixed the linting errors in the nth-prime/example.js
9:19  Expected to return a value at the end of method 'generatePrimes'
10:5  Split 'var' declarations into multiple statements          
10:29  'primeCount' is assigned a value but never used  
