### PR TITLE
remove linted exercises from lint ignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,8 +1,5 @@
 big-integer.js
-exercises/custom-set
-exercises/flatten-array
 exercises/grains/big-integer.js
 exercises/grains/big-integer.spec.js
-exercises/queen-attack
 exercises/robot-simulator
 exercises/simple-cipher


### PR DESCRIPTION
removed custom-set, flatten-array and queen-attack exercises from .eslintignore as they are properly linted. also currently #399 shows grade-school as still needing code fixes, but even that is already fixed. please update the list accordingly.