### PR TITLE
Simple Cipher: Add tests for random key generation, 100+ character length

### DIFF
--- a/exercises/simple-cipher/simple-cipher.spec.js
+++ b/exercises/simple-cipher/simple-cipher.spec.js
@@ -1,10 +1,24 @@
 var Cipher = require('./simple-cipher');
 
+describe('Random key generation', function () {
+  xit('generates keys at random', function () {
+    // Strictly speaking, this is difficult to test with 100% certainty.
+    // But, if you have a generator that generates 100-character-long
+    // strings of lowercase letters at random, the odds of two consecutively
+    // generated keys being identical are astronomically low.
+    expect(new Cipher().key).not.toEqual(new Cipher().key);
+  });
+});
+
 describe('Random key cipher', function () {
   var cipher = new Cipher();
 
   it('has a key made of letters', function () {
     expect(cipher.key).toMatch(/^[a-z]+$/);
+  });
+
+  xit('has a key that is at least 100 characters long', function () {
+    expect(cipher.key.length).toBeGreaterThanOrEqual(100);
   });
 
   // Here we take advantage of the fact that plaintext of "aaa..."


### PR DESCRIPTION
_See also: this same PR for the typescript track: https://github.com/exercism/typescript/pull/186_

The README for this exercise describes generating random keys consisting of 100+ lowercase letters, but the only constraint enforced by the tests is that it must contain only lowercase letters. One could pass this constraint by simply defaulting the key to a hard-coded string like `lolnotrandom`.

This PR adds tests to enforce that keys are randomly generated (at least a simple test that if you generate 2 keys back to back, they are not the same key), and that they are at least 100 characters long.