### PR TITLE
Expect all Robot names to be valid

### DIFF
--- a/exercises/robot-name/robot-name.spec.js
+++ b/exercises/robot-name/robot-name.spec.js
@@ -34,7 +34,7 @@ describe('Robot', function () {
     expect(originalName).not.toEqual(newName);
   });
 
-  xit('should set a unique name after reset', function () {
+  xit('should set a unique valid name after reset', function () {
     var i;
     var numResets = 10000;
     var usedNames = {};
@@ -43,6 +43,7 @@ describe('Robot', function () {
 
     for (i = 0; i < numResets; i++) {
       robot.reset();
+      expect(robot.name).toMatch(/^[A-Z]{2}\d{3}$/);
       usedNames[robot.name] = true;
     }
 


### PR DESCRIPTION
Check each of the 10k robot names for validity. Helps prevent off-by-one errors in random letter and digit generation.

Additionally, would argue that there's an implication that if a name is accepted by a test that it has been checked for validity.

It's quite easy to pass the test most time despite an off-by-one error in one's random Robot name generator. An off-by-one in the generation of letters would otherwise be caught very infrequently (1 - 25^2/26^2, afai remember my stats). It happened to me, that mine wasn't caught until after 10+ passing full tests.

An alternative option would be to implement an entirely new test for just this scenario.

Despite an extra 10k regex calls, this only doubled the total runtime of all the tests from 5/100 of a second to 10/100 (0.01) sec on my midrange laptop.