### PR TITLE
Use npm-ci instead of npm-install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - "lts/*"
 
 install:
-  - "npm install"
+  - "npm ci"
 
 script:
   - "make test"


### PR DESCRIPTION
Looks like `npm-ci` is meant to be used in CI environments.
https://docs.npmjs.com/cli/ci