### PR TITLE
Removed outdated mention of Eloquent JavaScript’s edition number

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,4 +1,4 @@
-* [Eloquent JavaScript: A Modern Introduction to Programming (2nd Ed.)](http://eloquentjavascript.net)
+* [Eloquent JavaScript: A Modern Introduction to Programming](http://eloquentjavascript.net)
 * [JavaScript: The Good Parts](http://www.amazon.com/JavaScript-Good-Parts-Douglas-Crockford/dp/0596517742)
 * [Crockford on JavaScript](http://javascript.crockford.com/)
 * [idiomatic.js: Principles of Writing Consistent, Idiomatic JavaScript](https://github.com/rwaldron/idiomatic.js)


### PR DESCRIPTION
Eloquent JavaScript came out with a 3rd edition some time ago. Previously, LEARNING.md mentioned its 2nd edition instead. Now it mentions no edition. The link is thus futureproofed.

Closes #548 