### PR TITLE
fix: pangram tests as per canonical data

### DIFF
--- a/exercises/pangram/pangram.spec.js
+++ b/exercises/pangram/pangram.spec.js
@@ -1,9 +1,14 @@
 var Pangram = require('./pangram');
 
 describe('Pangram()', function ()  {
-  it('empty sentence', function () {
+  it('sentence empty', function () {
     var pangram = new Pangram('');
     expect(pangram.isPangram()).toBe(false);
+  });
+
+  xit('recognizes a perfect lower case pangram', function ()  {
+    var pangram = new Pangram('abcdefghijklmnopqrstuvwxyz');
+    expect(pangram.isPangram()).toBe(true);
   });
 
   xit('pangram with only lower case', function ()  {
@@ -11,13 +16,13 @@ describe('Pangram()', function ()  {
     expect(pangram.isPangram()).toBe(true);
   });
 
-  xit("missing character 'x'", function ()  {
+  xit("missing character 'x'", function () {
     var pangram = new Pangram('a quick movement of the enemy will jeopardize five gunboats');
     expect(pangram.isPangram()).toBe(false);
   });
 
-  xit("another missing character 'x'", function () {
-    var pangram = new Pangram('the quick brown fish jumps over the lazy dog');
+  xit("another missing character, e.g. 'h'", function () {
+    var pangram = new Pangram('five boxing wizards jump quickly at it');
     expect(pangram.isPangram()).toBe(false);
   });
 
@@ -27,22 +32,22 @@ describe('Pangram()', function ()  {
   });
 
   xit('pangram with numbers', function () {
-    var pangram = new Pangram('the 1 quick brown fox jumps over the 2 lazy dogs');
+    var pangram = new Pangram('the 1 quick brown fox jumps over the 2 lazy dog');
     expect(pangram.isPangram()).toBe(true);
   });
 
-  xit('missing letters replaced by numbers', function () {
+  xit('missing letters replaced by numbers', function ()  {
     var pangram = new Pangram('7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog');
     expect(pangram.isPangram()).toBe(false);
   });
 
   xit('pangram with mixed case and punctuation', function ()  {
-    var pangram = new Pangram('"Five quacking Zephyrs jolt my wax bed."');
+    var pangram = new Pangram('\"Five quacking Zephyrs jolt my wax bed.\"');
     expect(pangram.isPangram()).toBe(true);
   });
 
-  xit('pangram with non-ascii characters', function ()  {
-    var pangram = new Pangram('Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.');
-    expect(pangram.isPangram()).toBe(true);
+  xit('upper and lower case versions of the same character should not be counted separately', function ()  {
+    var pangram = new Pangram('the quick brown fox jumps over with lazy FX');
+    expect(pangram.isPangram()).toBe(false);
   });
 });


### PR DESCRIPTION
This PR updates the tests for pangram exercise according to canonical date. 
This will fix #551