### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -73,7 +73,6 @@
         "algorithms",
         "control_flow_conditionals",
         "control_flow_loops",
-        "mathematics",
         "randomness",
         "strings",
         "text_formatting",
@@ -129,8 +128,7 @@
       "difficulty": 3,
       "topics": [
         "classes",
-        "floating_point_numbers",
-        "mathematics"
+        "floating_point_numbers"
       ]
     },
     {
@@ -144,7 +142,7 @@
         "control_flow_loops",
         "exception_handling",
         "integers",
-        "mathematics",
+        "math",
         "regular_expressions",
         "strings"
       ]
@@ -160,7 +158,7 @@
         "control_flow_conditionals",
         "control_flow_loops",
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -203,7 +201,7 @@
       "topics": [
         "control_flow_conditionals",
         "control_flow_loops",
-        "mathematics",
+        "math",
         "strings",
         "text_formatting"
       ]
@@ -298,7 +296,7 @@
       "topics": [
         "algorithms",
         "floating_point_numbers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -418,8 +416,7 @@
       "difficulty": 5,
       "topics": [
         "control_flow_loops",
-        "integers",
-        "mathematics"
+        "integers"
       ]
     },
     {
@@ -432,8 +429,7 @@
         "control_flow_conditionals",
         "control_flow_loops",
         "exception_handling",
-        "integers",
-        "mathematics"
+        "integers"
       ]
     },
     {
@@ -459,7 +455,7 @@
         "control_flow_conditionals",
         "control_flow_loops",
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -511,7 +507,6 @@
       "topics": [
         "control_flow_conditionals",
         "control_flow_loops",
-        "mathematics",
         "pattern_recognition",
         "transforming"
       ]
@@ -628,7 +623,7 @@
         "control_flow_conditionals",
         "control_flow_loops",
         "integers",
-        "mathematics",
+        "math",
         "regular_expressions",
         "strings"
       ]
@@ -643,7 +638,7 @@
         "control_flow_conditionals",
         "control_flow_loops",
         "integers",
-        "mathematics",
+        "math",
         "recursion"
       ]
     },
@@ -657,7 +652,7 @@
         "control_flow_conditionals",
         "control_flow_loops",
         "integers",
-        "mathematics",
+        "math",
         "regular_expressions",
         "strings"
       ]
@@ -672,7 +667,6 @@
         "control_flow_conditionals",
         "control_flow_loops",
         "integers",
-        "mathematics",
         "strings"
       ]
     },
@@ -702,7 +696,7 @@
         "control_flow_conditionals",
         "control_flow_loops",
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -728,7 +722,7 @@
         "algorithms",
         "control_flow_loops",
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -767,7 +761,7 @@
         "control_flow_conditionals",
         "control_flow_loops",
         "integers",
-        "mathematics",
+        "math",
         "regular_expressions",
         "strings"
       ]
@@ -783,7 +777,7 @@
         "control_flow_loops",
         "exception_handling",
         "integers",
-        "mathematics",
+        "math",
         "regular_expressions",
         "strings"
       ]
@@ -856,7 +850,7 @@
         "control_flow_loops",
         "exception_handling",
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -871,7 +865,7 @@
         "control_flow_loops",
         "exception_handling",
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -885,7 +879,6 @@
         "control_flow_loops",
         "exception_handling",
         "integers",
-        "mathematics",
         "strings",
         "text_formatting"
       ]
@@ -917,7 +910,8 @@
         "control_flow_conditionals",
         "control_flow_loops",
         "integers",
-        "lists"
+        "lists",
+        "math"
       ]
     },
     {
@@ -948,7 +942,6 @@
         "equality",
         "exception_handling",
         "integers",
-        "mathematics",
         "matrices",
         "optional_values",
         "parsing"
@@ -1058,7 +1051,7 @@
         "control_flow_loops",
         "exception_handling",
         "integers",
-        "mathematics",
+        "math",
         "parsing"
       ]
     },
@@ -1108,7 +1101,8 @@
         "arrays",
         "control_flow_conditionals",
         "control_flow_loops",
-        "exception_handling"
+        "exception_handling",
+        "math"
       ]
     },
     {
@@ -1119,7 +1113,6 @@
       "difficulty": 8,
       "topics": [
         "algorithms",
-        "mathematics",
         "performance",
         "searching"
       ]
@@ -1150,7 +1143,7 @@
         "control_flow_conditionals",
         "control_flow_loops",
         "integers",
-        "mathematics",
+        "math",
         "recursion"
       ]
     },
@@ -1281,7 +1274,7 @@
       "difficulty": 2,
       "topics": [
         "algorithms",
-        "mathematics"
+        "math"
       ]
     }
   ]


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110