### PR TITLE
Fix unit tests for Leap exercise

### DIFF
--- a/exercises/leap/example.js
+++ b/exercises/leap/example.js
@@ -1,4 +1,3 @@
-
 /**
  * @param  {number} year
  * Numeric year.
@@ -6,14 +5,5 @@
  * @return {boolean}
  * Whether given year is a leap year.
  */
-class Year {
-  constructor(year) {
-    this.year = year;
-  }
-
-  isLeap() {
-    return this.year % 400 === 0 || this.year % 4 === 0 && this.year % 100 !== 0;
-  }
-}
-
-export default Year;
+export const isLeap = year =>
+  year % 400 === 0 || year % 4 === 0 && year % 100 !== 0;

--- a/exercises/leap/leap.spec.js
+++ b/exercises/leap/leap.spec.js
@@ -1,23 +1,19 @@
-import Year from './leap';
+import { isLeap } from './leap';
 
 describe('A leap year', () => {
   test('year not divisible by 4: common year', () => {
-    const year = new Year(2015);
-    expect(year.isLeap()).toBeFalsy();
+    expect(isLeap(2015)).toBeFalsy();
   });
 
   xtest('year divisible by 4, not divisible by 100: leap year', () => {
-    const year = new Year(2016);
-    expect(year.isLeap()).toBeTruthy();
+    expect(isLeap(2016)).toBeTruthy();
   });
 
   xtest('year divisible by 100, not divisible by 400: common year', () => {
-    const year = new Year(2100);
-    expect(year.isLeap()).toBeFalsy();
+    expect(isLeap(2100)).toBeFalsy();
   });
 
   xtest('year divisible by 400: leap year', () => {
-    const year = new Year(2000);
-    expect(year.isLeap()).toBeTruthy();
+    expect(isLeap(2000)).toBeTruthy();
   });
 });


### PR DESCRIPTION
Change the unit tests for the Leap exercise to accept a named function import instead of a default named import as per issues #274 and #436:
- Change default import `Year` to named import `{ isLeap }`.
- Remove unnecessary `const year = new Year(...` calls.
- Change `year.isLeap()` calls to `isLeap(XXXX)`.
- Rewrite example.js file to export a single named function.