### PR TITLE
Fix unit tests for RNA Transcription exercise

### DIFF
--- a/exercises/rna-transcription/example.js
+++ b/exercises/rna-transcription/example.js
@@ -5,15 +5,13 @@ const DNA_TO_RNA = {
   A: 'U',
 };
 
-export default class Transcriptor {
-  toRna(dna) {
-    const rna = dna.replace(/./g, nucleotide => DNA_TO_RNA[nucleotide]);
+export const toRna = dna => {
+  const rna = dna.replace(/./g, nucleotide => DNA_TO_RNA[nucleotide]);
 
-    if (rna.length !== dna.length) {
-      // invalid characters in the strand
-      throw new Error('Invalid input DNA.');
-    } else {
-      return rna;
-    }
+  if (rna.length !== dna.length) {
+    // invalid characters in the strand
+    throw new Error('Invalid input DNA.');
+  } else {
+    return rna;
   }
 }

--- a/exercises/rna-transcription/rna-transcription.spec.js
+++ b/exercises/rna-transcription/rna-transcription.spec.js
@@ -1,47 +1,46 @@
-import Transcriptor from './rna-transcription';
+import { toRna } from './rna-transcription';
 
 describe('Transcriptor', () => {
-  const transcriptor = new Transcriptor();
 
   test('empty rna sequence', () => {
-    expect(transcriptor.toRna('')).toEqual('');
+    expect(toRna('')).toEqual('');
   });
 
   xtest('transcribes cytosine to guanine', () => {
-    expect(transcriptor.toRna('C')).toEqual('G');
+    expect(toRna('C')).toEqual('G');
   });
 
   xtest('transcribes guanine to cytosine', () => {
-    expect(transcriptor.toRna('G')).toEqual('C');
+    expect(toRna('G')).toEqual('C');
   });
 
   xtest('transcribes adenine to uracil', () => {
-    expect(transcriptor.toRna('A')).toEqual('U');
+    expect(toRna('A')).toEqual('U');
   });
 
   xtest('transcribes thymine to adenine', () => {
-    expect(transcriptor.toRna('T')).toEqual('A');
+    expect(toRna('T')).toEqual('A');
   });
 
   xtest('transcribes all dna nucleotides to their rna complements', () => {
-    expect(transcriptor.toRna('ACGTGGTCTTAA'))
+    expect(toRna('ACGTGGTCTTAA'))
         .toEqual('UGCACCAGAAUU');
   });
 
   xtest('correctly handles invalid input', () => {
-    expect(() => transcriptor.toRna('U')).toThrow(
+    expect(() => toRna('U')).toThrow(
       new Error('Invalid input DNA.'),
     );
   });
 
   xtest('correctly handles completely invalid input', () => {
-    expect(() => transcriptor.toRna('XXX')).toThrow(
+    expect(() => toRna('XXX')).toThrow(
       new Error('Invalid input DNA.'),
     );
   });
 
   xtest('correctly handles partially invalid input', () => {
-    expect(() => transcriptor.toRna('ACGTXXXCTTAA')).toThrow(
+    expect(() => toRna('ACGTXXXCTTAA')).toThrow(
       new Error('Invalid input DNA.'),
     );
   });


### PR DESCRIPTION
Change the unit tests for the RNA Transcription exercise to accept a named function export instead of a default class export as per issues #274 and #436:
- Change default class import `Transcriptor` to named function import `{ toRna }`.
- Remove unnecessary `const transcriptor = new Transcriptor();` line.
- Change `transcriptor.toRna(...` calls to `toRna(...`.
- Redesign example.js file to export a single named function.