### PR TITLE
Fix unit tests and example for Simple Cipher exercise

### DIFF
--- a/exercises/simple-cipher/example.js
+++ b/exercises/simple-cipher/example.js
@@ -17,20 +17,23 @@ function xCode(key, inText, sign) {
 
 const mod = (n, m) => (n % m + m) % m;
 
-export default function (key) {
-  if (typeof key === 'undefined') {
-    key = generateKey();
-  } else if (key.length === 0 || key.match(/[^a-z]/, 'g')) {
-    throw new Error('Bad key');
+export class Cipher {
+
+  constructor (key) {
+    if (typeof key === 'undefined') {
+      this.key = generateKey();
+    } else if (key.length === 0 || key.match(/[^a-z]/, 'g')) {
+      throw new Error('Bad key');
+    } else {
+      this.key = key;
+    }
   }
 
-  return {
-    key,
-    encode(plainText) {
-      return xCode(this.key, plainText, 1);
-    },
-    decode(encodedText) {
-      return xCode(this.key, encodedText, -1);
-    },
-  };
+  encode(plainText) {
+    return xCode(this.key, plainText, 1);
+  }
+
+  decode(encodedText) {
+    return xCode(this.key, encodedText, -1);
+  }
 }

--- a/exercises/simple-cipher/simple-cipher.spec.js
+++ b/exercises/simple-cipher/simple-cipher.spec.js
@@ -1,4 +1,4 @@
-import Cipher from './simple-cipher';
+import { Cipher } from './simple-cipher';
 
 describe('Random key generation', () => {
   xtest('generates keys at random', () => {
@@ -54,6 +54,24 @@ describe('Incorrect key cipher', () => {
   xtest('throws an error with an empty key', () => {
     expect(() => {
       new Cipher('');
+    }).toThrow(new Error('Bad key'));
+  });
+
+  xtest('throws an error with a leading space', () => {
+    expect(() => {
+      new Cipher(' leadingspace');
+    }).toThrow(new Error('Bad key'));
+  });
+
+  xtest('throws an error with a punctuation mark', () => {
+    expect(() => {
+      new Cipher('hyphened-word');
+    }).toThrow(new Error('Bad key'));
+  });
+
+  xtest('throws an error with a single capital letter', () => {
+    expect(() => {
+      new Cipher('leonardoDavinci');
     }).toThrow(new Error('Bad key'));
   });
 });


### PR DESCRIPTION
Change the example for the Simple Cipher exercise to accept a named class export instead of a default class export as per issues #274 and #436, and expand unit tests as per issue #445:
- Refactor example.js to export a named class.
- Change default import `Cipher` to named import `{ Cipher }`.
- Add unit tests to include checks for non-alphabet characters.