### PR TITLE
Deprecate this track

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,3 @@
 # DEPRECATION NOTICE
 
-This track will be deprecated as part of the migration of Exercism to V2.  Going forward, the EcmaScript track will replace the JavaScript track as "the new JavaScript" track.  
-- User's old submissions will be migrated
-- PRs unrelated to the deprecation will be closed as `wontfix`
-- Issues unrelated to deprecation will be closed as `wontfix`
-
-Thank you to all the many invested and hardworking contributors who have helped to make this track a success!!
-
-# JavaScript [![Build Status](https://travis-ci.org/exercism/javascript.svg?branch=master)](https://travis-ci.org/exercism/javascript)[![Join the chat at https://gitter.im/exercism/xecmascript](https://badges.gitter.im/exercism/xecmascript.svg)](https://gitter.im/exercism/xecmascript?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
-Exercism exercises in JavaScript
-
-## Installing
-
-To run the tests, you'll need NodeJS and Jasmine. For information about how to install these tools, see the [Javascript](http://exercism.io/languages/javascript/about) page.
-
-## Tasks
-
-The following commands assume that you are in the `javascript` directory:
-
-### Unit Tests: All Assignments
-
-    make test
-
-### Unit Tests: Single Assignment
-
-    make test-assignment ASSIGNMENT=wordy
-
-### Code Style
-
-    npm run lint
-
-## Contributing Guide
-
-Please see the [contributing guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data)
-
+This track is deprecated. Please see the https://github.com/exercism/javascript track.

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
-  "language": "JavaScript",
-  "active": true,
+  "language": "JavaScript (Legacy)",
+  "active": false,
   "blurb": "JavaScript is a scripting language, primarily used for creating dynamic websites and programming web servers. It's a very popular language, and supports a variety of programming paradigms.",
   "test_pattern": ".*[.]spec[.]js$",
   "exercises": [


### PR DESCRIPTION

This:

- simplifies the README for clarity
- renames the language to "JavaScript (Legacy)"
- sets `"active": false`

We will merge it after the migration has taken place.