### PR TITLE
Fix ecmascript link in README files to new installation link

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -9,7 +9,7 @@
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -30,7 +30,7 @@ Solve this one yourself using other basic tools instead.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -12,7 +12,7 @@ like Portable Network Graphics to its acronym (PNG).
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -36,7 +36,7 @@ I think you got the idea!
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -34,7 +34,7 @@ score is 257, your program should only report the eggs (1) allergy.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -36,7 +36,7 @@ Write a function to solve alphametics puzzles.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -11,7 +11,7 @@ Given `"listen"` and a list of candidates like `"enlists" "google"
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -16,7 +16,7 @@ Write some code to determine whether a number is an Armstrong number.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -33,7 +33,7 @@ things based on word boundaries.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -325,7 +325,7 @@ experiment make the code better? Worse? Did you learn anything from it?
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/binary-search-tree/README.md
+++ b/exercises/binary-search-tree/README.md
@@ -58,7 +58,7 @@ And if we then added 1, 5, and 7, it would look like this
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -39,7 +39,7 @@ A binary search is a dichotomic divide and conquer search algorithm.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -35,7 +35,7 @@ So: `101 => 1*2^2 + 0*2^1 + 1*2^0 => 1*4 + 0*2 + 1*1 => 4 + 1 => 5 base 10`.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -18,7 +18,7 @@ He answers 'Whatever.' to anything else.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -65,7 +65,7 @@ support two operations:
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -9,7 +9,7 @@ and nested correctly.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -21,7 +21,7 @@ that the sum of the coins' value would equal the correct amount of change.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -55,7 +55,7 @@ the buffer is once again full.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -11,7 +11,7 @@ Two clocks that represent the same time should be equal to each other.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -31,7 +31,7 @@ Resulting in 9 steps. So for input n = 12, the return value would be 9.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/complex-numbers/README.md
+++ b/exercises/complex-numbers/README.md
@@ -33,7 +33,7 @@ Assume the programming language you are using does not have an implementation of
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -35,7 +35,7 @@ won since `O` didn't connect top and bottom.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -77,7 +77,7 @@ cyphertext back in to the original message:
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -12,7 +12,7 @@ unique elements.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -57,7 +57,7 @@ E·······E
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -17,7 +17,7 @@ natural numbers is 3025 - 385 = 2640.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -42,7 +42,7 @@ secret s.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -51,7 +51,7 @@ game while being scored at 4 in the Hawaiian-language version.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -15,7 +15,7 @@ output: [1,2,3,4,5]
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/food-chain/README.md
+++ b/exercises/food-chain/README.md
@@ -68,7 +68,7 @@ She's dead, of course!
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -30,7 +30,7 @@ Words are case-insensitive.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -9,7 +9,7 @@ A gigasecond is 10^9 (1,000,000,000) seconds.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -39,7 +39,7 @@ experiment make the code better? Worse? Did you learn anything from it?
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -31,7 +31,7 @@ experiment make the code better? Worse? Did you learn anything from it?
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -41,7 +41,7 @@ exception vs returning a special value) may differ between languages.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -19,7 +19,7 @@ If everything goes well, you will be ready to fetch your first real exercise.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -12,7 +12,7 @@ The program should handle invalid hexadecimal strings.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/house/README.md
+++ b/exercises/house/README.md
@@ -110,7 +110,7 @@ that lay in the house that Jack built.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -45,7 +45,7 @@ Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (represen
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -18,7 +18,7 @@ The word *isograms*, however, is not an isogram, because the s repeats.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/kindergarten-garden/README.md
+++ b/exercises/kindergarten-garden/README.md
@@ -64,7 +64,7 @@ While asking for Bob's plants would yield:
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -18,7 +18,7 @@ the largest product for a series of 6 digits is 23520.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -31,7 +31,7 @@ phenomenon, go watch [this youtube video][video].
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -32,7 +32,7 @@ If you want to know more about linked lists, check [Wikipedia](https://en.wikipe
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -11,7 +11,7 @@ without using existing functions.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -69,7 +69,7 @@ Sum the digits
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/matrix/README.md
+++ b/exercises/matrix/README.md
@@ -45,7 +45,7 @@ And its columns:
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -31,7 +31,7 @@ descriptor calculate the date of the actual meetup.  For example, if given
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -31,7 +31,7 @@ into this:
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -13,7 +13,7 @@ numbers, pretend they don't exist and implement them yourself.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -17,7 +17,7 @@ Here is an analogy:
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -83,7 +83,7 @@ Is converted to "123,456,789"
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/octal/README.md
+++ b/exercises/octal/README.md
@@ -51,7 +51,7 @@ So:
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -37,7 +37,7 @@ The largest palindrome product is `9009`. Its factors are `(91, 99)`.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -13,7 +13,7 @@ insensitive. Input will not contain non-ASCII symbols.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -19,7 +19,7 @@ the right and left of the current position in the previous row.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -22,7 +22,7 @@ Implement a way to determine whether a given number is **perfect**. Depending on
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -33,7 +33,7 @@ should all produce the output
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -22,7 +22,7 @@ See <http://en.wikipedia.org/wiki/Pig_latin> for more details.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/point-mutations/README.md
+++ b/exercises/point-mutations/README.md
@@ -39,7 +39,7 @@ distance function.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -34,7 +34,7 @@ You can check this yourself:
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -46,7 +46,7 @@ Learn more about [protein translation on Wikipedia](http://en.wikipedia.org/wiki
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -21,7 +21,7 @@ Note that the list of inputs may vary; your solution should be able to handle li
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -22,7 +22,7 @@ Find the product a * b * c.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -31,7 +31,7 @@ share a diagonal.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -22,7 +22,7 @@ Convert a number to a string, the contents of which depend on the number's facto
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/rational-numbers/README.md
+++ b/exercises/rational-numbers/README.md
@@ -33,7 +33,7 @@ Assume that the programming language you are using does not have an implementati
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/react/README.md
+++ b/exercises/react/README.md
@@ -20,7 +20,7 @@ state has changed from the previous stable state.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/rectangles/README.md
+++ b/exercises/rectangles/README.md
@@ -68,7 +68,7 @@ every line equals the length of the first line).
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -11,7 +11,7 @@ output: "looc"
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -23,7 +23,7 @@ each nucleotide with its complement:
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -20,7 +20,7 @@ every existing robot has a unique name.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -32,7 +32,7 @@ direction it is pointing.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -47,7 +47,7 @@ See also: http://www.novaroma.org/via_romana/numbers.html
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -35,7 +35,7 @@ Ciphertext is written out in the same formatting as the input including spaces a
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -28,7 +28,7 @@ be decoded always represent the count for the following character.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -33,7 +33,7 @@ but the tests for this exercise follow the above unambiguous definition.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -67,7 +67,7 @@ Use _and_ (correctly) when spelling out the number in English:
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -44,7 +44,7 @@ And to total:
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/secret-handshake/README.md
+++ b/exercises/secret-handshake/README.md
@@ -33,7 +33,7 @@ has caused the array to be reversed.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -25,7 +25,7 @@ in the input; the digits need not be *numerically consecutive*.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -34,7 +34,7 @@ language).
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -86,7 +86,7 @@ on Wikipedia][dh] for one of the first implementations of this scheme.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -26,7 +26,7 @@ implement your own abstract data type.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -22,7 +22,7 @@ youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/spiral-matrix/README.md
+++ b/exercises/spiral-matrix/README.md
@@ -28,7 +28,7 @@ like these examples:
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -38,7 +38,7 @@ basic tools instead.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -22,7 +22,7 @@ Examples:
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -13,7 +13,7 @@ The sum of these multiples is 78.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -63,7 +63,7 @@ the corresponding output row should contain the spaces in its right-most column(
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -27,7 +27,7 @@ a single line. Feel free to add your own code/tests to check for degenerate tria
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -26,7 +26,7 @@ conversion, pretend it doesn't exist and implement it yourself.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/twelve-days/README.md
+++ b/exercises/twelve-days/README.md
@@ -33,7 +33,7 @@ On the twelfth day of Christmas my true love gave to me, twelve Drummers Drummin
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -34,7 +34,7 @@ Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by Lind
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -17,7 +17,7 @@ If no name is given, the result should be "One for you, one for me."
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/variable-length-quantity/README.md
+++ b/exercises/variable-length-quantity/README.md
@@ -36,7 +36,7 @@ Here are examples of integers as 32-bit values, and the variable length quantiti
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -16,7 +16,7 @@ free: 1
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/word-search/README.md
+++ b/exercises/word-search/README.md
@@ -31,7 +31,7 @@ letter of each word.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -56,7 +56,7 @@ If you'd like, handle exponentials.
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -32,7 +32,7 @@ list of child nodes) a zipper might support these operations:
 Go through the setup instructions for ECMAScript to
 install the necessary dependencies:
 
-http://exercism.io/languages/ecmascript
+https://exercism.io/tracks/javascript/installation
 
 ## Requirements
 


### PR DESCRIPTION
Fixes #454

Change after ecmascript merger with javascript track.

Files auto-updated by changing template file and running `bin/configlet generate`.