### PR TITLE
Fix unit tests and example for Pangram exercise

### DIFF
--- a/exercises/pangram/example.js
+++ b/exercises/pangram/example.js
@@ -3,16 +3,8 @@ const notAlpha = /[^a-z]+/gi,
 let cleaned,
   sortedSet;
 
-class Pangram {
-
-  constructor(candidate) {
-    cleaned = (candidate.replace(notAlpha, '')).toLowerCase();
-    sortedSet = new Set([...cleaned].sort());
-  }
-
-  isPangram() {
-    return sortedSet.size === alphaLength;
-  }
+export const isPangram = candidate => {
+  cleaned = (candidate.replace(notAlpha, '')).toLowerCase();
+  sortedSet = new Set([...cleaned].sort());
+  return sortedSet.size === alphaLength;
 }
-
-export default Pangram;

--- a/exercises/pangram/pangram.spec.js
+++ b/exercises/pangram/pangram.spec.js
@@ -1,54 +1,44 @@
-import Pangram from './pangram';
+import { isPangram } from './pangram';
 
 describe('Pangram()', () => {
   test('empty sentence', () => {
-    const pangram = new Pangram('');
-    expect(pangram.isPangram()).toBe(false);
+    expect(isPangram('')).toBe(false);
   });
 
   xtest('recognizes a perfect lower case pangram', () => {
-    const pangram = new Pangram('abcdefghijklmnopqrstuvwxyz');
-    expect(pangram.isPangram()).toBe(true);
+    expect(isPangram('abcdefghijklmnopqrstuvwxyz')).toBe(true);
   });
 
   xtest('pangram with only lower case', () => {
-    const pangram = new Pangram('the quick brown fox jumps over the lazy dog');
-    expect(pangram.isPangram()).toBe(true);
+    expect(isPangram('the quick brown fox jumps over the lazy dog')).toBe(true);
   });
 
   xtest("missing character 'x'", () => {
-    const pangram = new Pangram('a quick movement of the enemy will jeopardize five gunboats');
-    expect(pangram.isPangram()).toBe(false);
+    expect(isPangram('a quick movement of the enemy will jeopardize five gunboats')).toBe(false);
   });
 
   xtest("another missing character, e.g. 'h'", () => {
-    const pangram = new Pangram('five boxing wizards jump quickly at it');
-    expect(pangram.isPangram()).toBe(false);
+    expect(isPangram('five boxing wizards jump quickly at it')).toBe(false);
   });
 
   xtest('pangram with underscores', () => {
-    const pangram = new Pangram('the_quick_brown_fox_jumps_over_the_lazy_dog');
-    expect(pangram.isPangram()).toBe(true);
+    expect(isPangram('the_quick_brown_fox_jumps_over_the_lazy_dog')).toBe(true);
   });
 
   xtest('pangram with numbers', () => {
-    const pangram = new Pangram('the 1 quick brown fox jumps over the 2 lazy dogs');
-    expect(pangram.isPangram()).toBe(true);
+    expect(isPangram('the 1 quick brown fox jumps over the 2 lazy dogs')).toBe(true);
   });
 
   xtest('missing letters replaced by numbers', () => {
-    const pangram = new Pangram('7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog');
-    expect(pangram.isPangram()).toBe(false);
+    expect(isPangram('7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog')).toBe(false);
   });
 
   xtest('pangram with mixed case and punctuation', () => {
-    const pangram = new Pangram('"Five quacking Zephyrs jolt my wax bed."');
-    expect(pangram.isPangram()).toBe(true);
+    expect(isPangram('"Five quacking Zephyrs jolt my wax bed."')).toBe(true);
   });
 
   xtest('upper and lower case versions of the same character should not be counted separately', () => {
-    const pangram = new Pangram('the quick brown fox jumps over with lazy FX');
-    expect(pangram.isPangram()).toBe(false);
+    expect(isPangram('the quick brown fox jumps over with lazy FX')).toBe(false);
   });
 
 });


### PR DESCRIPTION
Change the unit tests for the Pangram exercise to accept a named function export instead of a default class export as per issues #274 and #436:
- Change default class import `Pangram` to named function import `{ isPangram }`.
- Remove unnecessary `const pangram = new Pangram(...` lines.
- Change `pangram.isPangram(...` calls to `isPangram(...`.
- Redesign example.js file to export a single named function.