### PR TITLE
Fix unit tests for Bob exercise

### DIFF
--- a/exercises/bob/bob.js
+++ b/exercises/bob/bob.js
@@ -4,13 +4,8 @@
 // convenience to get you started writing code faster.
 //
 
-class Bob {
-  hey(message) {
-    //
-    // YOUR CODE GOES HERE
-    //
-  }
+export const hey = message => {
+  //
+  // YOUR CODE GOES HERE
+  //
 }
-
-export default Bob;
-

--- a/exercises/bob/bob.spec.js
+++ b/exercises/bob/bob.spec.js
@@ -1,131 +1,129 @@
-import Bob from './bob';
+import { hey } from './bob';
 
 describe('Bob', () => {
-  const bob = new Bob();
 
   test('stating something', () => {
-    const result = bob.hey('Tom-ay-to, tom-aaaah-to.');
+    const result = hey('Tom-ay-to, tom-aaaah-to.');
     expect(result).toEqual('Whatever.');
   });
 
   xtest('shouting', () => {
-    const result = bob.hey('WATCH OUT!');
+    const result = hey('WATCH OUT!');
     expect(result).toEqual('Whoa, chill out!');
   });
 
   xtest('shouting gibberish', () => {
-    const result = bob.hey('FCECDFCAAB');
+    const result = hey('FCECDFCAAB');
     expect(result).toEqual('Whoa, chill out!');
   });
 
   xtest('asking a question', () => {
-    const result = bob.hey('Does this cryogenic chamber make me look fat?');
+    const result = hey('Does this cryogenic chamber make me look fat?');
     expect(result).toEqual('Sure.');
   });
 
   xtest('asking a numeric question', () => {
-    const result = bob.hey('You are, what, like 15?');
+    const result = hey('You are, what, like 15?');
     expect(result).toEqual('Sure.');
   });
 
   xtest('asking gibberish', () => {
-    const result = bob.hey('fffbbcbeab?');
+    const result = hey('fffbbcbeab?');
     expect(result).toEqual('Sure.');
   });
 
   xtest('talking forcefully', () => {
-    const result = bob.hey("Let's go make out behind the gym!");
+    const result = hey("Let's go make out behind the gym!");
     expect(result).toEqual('Whatever.');
   });
 
   xtest('using acronyms in regular speech', () => {
-    const result = bob.hey("It's OK if you don't want to go to the DMV.");
+    const result = hey("It's OK if you don't want to go to the DMV.");
     expect(result).toEqual('Whatever.');
   });
 
   xtest('forceful question', () => {
-    const result = bob.hey("WHAT THE HELL WERE YOU THINKING?");
+    const result = hey("WHAT THE HELL WERE YOU THINKING?");
     expect(result).toEqual('Calm down, I know what I\'m doing!');
   });
 
   xtest('shouting numbers', () => {
-    const result = bob.hey('1, 2, 3 GO!');
+    const result = hey('1, 2, 3 GO!');
     expect(result).toEqual('Whoa, chill out!');
   });
 
   xtest('only numbers', () => {
-    const result = bob.hey('1, 2, 3');
+    const result = hey('1, 2, 3');
     expect(result).toEqual('Whatever.');
   });
 
   xtest('question with only numbers', () => {
-    const result = bob.hey('4?');
+    const result = hey('4?');
     expect(result).toEqual('Sure.');
   });
 
   xtest('shouting with special characters', () => {
-    const result = bob.hey('ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!');
+    const result = hey('ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!');
     expect(result).toEqual('Whoa, chill out!');
   });
 
   xtest('shouting with no exclamation mark', () => {
-    const result = bob.hey('I HATE YOU');
+    const result = hey('I HATE YOU');
     expect(result).toEqual('Whoa, chill out!');
   });
 
   xtest('statement containing question mark', () => {
-    const result = bob.hey('Ending with a ? means a question.');
+    const result = hey('Ending with a ? means a question.');
     expect(result).toEqual('Whatever.');
   });
 
   xtest('non-letters with question', () => {
-    const result = bob.hey(':) ?');
+    const result = hey(':) ?');
     expect(result).toEqual('Sure.');
   });
 
   xtest('prattling on', () => {
-    const result = bob.hey('Wait! Hang on. Are you going to be OK?');
+    const result = hey('Wait! Hang on. Are you going to be OK?');
     expect(result).toEqual('Sure.');
   });
 
   xtest('silence', () => {
-    const result = bob.hey('');
+    const result = hey('');
     expect(result).toEqual('Fine. Be that way!');
   });
 
   xtest('prolonged silence', () => {
-    const result = bob.hey('          ');
+    const result = hey('          ');
     expect(result).toEqual('Fine. Be that way!');
   });
 
   xtest('alternate silence', () => {
-    const result = bob.hey('\t\t\t\t\t\t\t\t\t\t');
+    const result = hey('\t\t\t\t\t\t\t\t\t\t');
     expect(result).toEqual('Fine. Be that way!');
   });
 
   xtest('multiple line question', () => {
-    const result = bob.hey('\nDoes this cryogenic chamber make me look fat?\nno');
+    const result = hey('\nDoes this cryogenic chamber make me look fat?\nno');
     expect(result).toEqual('Whatever.');
   });
 
   xtest('starting with whitespace', () => {
-    const result = bob.hey('         hmmmmmmm...');
+    const result = hey('         hmmmmmmm...');
     expect(result).toEqual('Whatever.');
   });
 
   xtest('ending with whitespace', () => {
-    const result = bob.hey('Okay if like my  spacebar  quite a bit?   ');
+    const result = hey('Okay if like my  spacebar  quite a bit?   ');
     expect(result).toEqual('Sure.');
   });
 
   xtest('other whitespace', () => {
-    const result = bob.hey('\n\r \t');
+    const result = hey('\n\r \t');
     expect(result).toEqual('Fine. Be that way!');
   });
 
   xtest('non-question ending with whitespace', () => {
-    const result = bob.hey('This is a statement ending with whitespace      ');
+    const result = hey('This is a statement ending with whitespace      ');
     expect(result).toEqual('Whatever.');
   });
 });
-

--- a/exercises/bob/example.js
+++ b/exercises/bob/example.js
@@ -2,22 +2,18 @@ const isSilence = message => message.replace(/\s+/g, '') === '';
 const isShouting = message => message.toUpperCase() === message && /[A-Z]/.test(message);
 const isAQuestion = message => message[message.length - 1] === '?';
 
-class Bob {
-  hey(message) {
-    if (isSilence(message)) {
-      return 'Fine. Be that way!';
-    }
-    if (isShouting(message)) {
-      if (isAQuestion(message)) {
-        return "Calm down, I know what I'm doing!";
-      }
-      return 'Whoa, chill out!';
-    }
-    if (isAQuestion(message.trim())) {
-      return 'Sure.';
-    }
-    return 'Whatever.';
+export const hey = message => {
+  if (isSilence(message)) {
+    return 'Fine. Be that way!';
   }
+  if (isShouting(message)) {
+    if (isAQuestion(message)) {
+      return "Calm down, I know what I'm doing!";
+    }
+    return 'Whoa, chill out!';
+  }
+  if (isAQuestion(message.trim())) {
+    return 'Sure.';
+  }
+  return 'Whatever.';
 }
-
-export default Bob;


### PR DESCRIPTION
Change the unit tests for the Bob exercise to accept a named function export instead of a default class export as per issues #274 and #436:
- Change default class import `Bob` to named function import `{ hey }`.
- Remove unnecessary `const bob = new Bob();` line.
- Change `bob.hey(...` calls to `hey(...`.
- Redesign example.js and bob.js files to export a single named function.