### PR TITLE
Fix unit tests for Gigasecond exercise

### DIFF
--- a/exercises/gigasecond/example.js
+++ b/exercises/gigasecond/example.js
@@ -1,14 +1,6 @@
 const GIGASECOND_IN_MILIS = 1e9 * 1e3;
 
-export default class Gigasecond {
-
-  constructor(dateOfBirth) {
-    this.dateOfBirth = dateOfBirth;
-  }
-
-  date() {
-    const birthTime = this.dateOfBirth.getTime();
-    return new Date(birthTime + GIGASECOND_IN_MILIS);
-  }
-
+export const gigasecond = dateOfBirth => {
+  const birthTime = dateOfBirth.getTime();
+  return new Date(birthTime + GIGASECOND_IN_MILIS);
 }

--- a/exercises/gigasecond/gigasecond.spec.js
+++ b/exercises/gigasecond/gigasecond.spec.js
@@ -1,28 +1,21 @@
-import Gigasecond from './gigasecond';
+import { gigasecond } from './gigasecond';
 
 describe('Gigasecond', () => {
   test('tells a gigasecond anniversary since midnight', () => {
-    const gs = new Gigasecond(new Date(Date.UTC(2015, 8, 14)));
+    const gs = gigasecond(new Date(Date.UTC(2015, 8, 14)));
     const expectedDate = new Date(Date.UTC(2047, 4, 23, 1, 46, 40));
-    expect(gs.date()).toEqual(expectedDate);
+    expect(gs).toEqual(expectedDate);
   });
 
   xtest('tells the anniversary is next day when you are born at night', () => {
-    const gs = new Gigasecond(new Date(Date.UTC(2015, 8, 14, 23, 59, 59)));
+    const gs = gigasecond(new Date(Date.UTC(2015, 8, 14, 23, 59, 59)));
     const expectedDate = new Date(Date.UTC(2047, 4, 24, 1, 46, 39));
-    expect(gs.date()).toEqual(expectedDate);
+    expect(gs).toEqual(expectedDate);
   });
 
   xtest('even works before 1970 (beginning of Unix epoch)', () => {
-    const gs = new Gigasecond(new Date(Date.UTC(1959, 6, 19, 5, 13, 45)));
+    const gs = gigasecond(new Date(Date.UTC(1959, 6, 19, 5, 13, 45)));
     const expectedDate = new Date(Date.UTC(1991, 2, 27, 7, 0, 25));
-    expect(gs.date()).toEqual(expectedDate);
-  });
-
-  xtest('make sure calling "date" doesn\'t mutate value', () => {
-    const gs = new Gigasecond(new Date(Date.UTC(1959, 6, 19, 5, 13, 45)));
-    const expectedDate = new Date(Date.UTC(1991, 2, 27, 7, 0, 25));
-    gs.date();
-    expect(gs.date()).toEqual(expectedDate);
+    expect(gs).toEqual(expectedDate);
   });
 });


### PR DESCRIPTION
Change the unit tests for the Gigasecond exercise to accept a named function export instead of a default class export as per issues #274 and #436:
- Change default class import `Gigasecond` to named function import `{ gigasecond }`.
- Change `new Gigasecond(...` calls to `gigasecond(...`.
- Change `gs.date()` calls to `gs` calls.
- Remove mutation test which is no longer relevant.
- Redesign example.js file to export a single named function.