### PR TITLE
Fix unit test and example solution for Prime Factors exercise

### DIFF
--- a/exercises/prime-factors/example.js
+++ b/exercises/prime-factors/example.js
@@ -1,19 +1,15 @@
-class PrimeFactors {
-  for(num) {
-    const factors = [];
-    let currentFactor = 2;
+export const primeFactors = (num) => {
+  const factors = [];
+  let currentFactor = 2;
 
-    while (num !== 1) {
-      if (num % currentFactor === 0) {
-        factors.push(currentFactor);
-        num /= currentFactor;
-        currentFactor = 2;
-      } else {
-        currentFactor++;
-      }
+  while (num !== 1) {
+    if (num % currentFactor === 0) {
+      factors.push(currentFactor);
+      num /= currentFactor;
+      currentFactor = 2;
+    } else {
+      currentFactor++;
     }
-    return factors;
   }
-}
-
-export default PrimeFactors;
+  return factors;
+};

--- a/exercises/prime-factors/prime-factors.spec.js
+++ b/exercises/prime-factors/prime-factors.spec.js
@@ -1,26 +1,25 @@
-import PrimeFactors from './prime-factors';
-const primeFactors = new PrimeFactors();
+import { primeFactors } from './prime-factors';
 
 describe('primeFactors', () => {
-  test('returns an empty array for 1', () => expect(primeFactors.for(1)).toEqual([]));
+  test('returns an empty array for 1', () => expect(primeFactors(1)).toEqual([]));
 
-  xtest('factors 2', () => expect(primeFactors.for(2)).toEqual([2]));
+  xtest('factors 2', () => expect(primeFactors(2)).toEqual([2]));
 
-  xtest('factors 3', () => expect(primeFactors.for(3)).toEqual([3]));
+  xtest('factors 3', () => expect(primeFactors(3)).toEqual([3]));
 
-  xtest('factors 4', () => expect(primeFactors.for(4)).toEqual([2, 2]));
+  xtest('factors 4', () => expect(primeFactors(4)).toEqual([2, 2]));
 
-  xtest('factors 6', () => expect(primeFactors.for(6)).toEqual([2, 3]));
+  xtest('factors 6', () => expect(primeFactors(6)).toEqual([2, 3]));
 
-  xtest('factors 8', () => expect(primeFactors.for(8)).toEqual([2, 2, 2]));
+  xtest('factors 8', () => expect(primeFactors(8)).toEqual([2, 2, 2]));
 
-  xtest('factors 9', () => expect(primeFactors.for(9)).toEqual([3, 3]));
+  xtest('factors 9', () => expect(primeFactors(9)).toEqual([3, 3]));
 
-  xtest('factors 27', () => expect(primeFactors.for(27)).toEqual([3, 3, 3]));
+  xtest('factors 27', () => expect(primeFactors(27)).toEqual([3, 3, 3]));
 
-  xtest('factors 625', () => expect(primeFactors.for(625)).toEqual([5, 5, 5, 5]));
+  xtest('factors 625', () => expect(primeFactors(625)).toEqual([5, 5, 5, 5]));
 
-  xtest('factors 901255', () => expect(primeFactors.for(901255)).toEqual([5, 17, 23, 461]));
+  xtest('factors 901255', () => expect(primeFactors(901255)).toEqual([5, 17, 23, 461]));
 
-  xtest('factors 93819012551', () => expect(primeFactors.for(93819012551)).toEqual([11, 9539, 894119]));
+  xtest('factors 93819012551', () => expect(primeFactors(93819012551)).toEqual([11, 9539, 894119]));
 });


### PR DESCRIPTION
Change the unit tests for the Prime Factors exercise to accept a named 
function export instead of a default class export as per issues #274 and 
#436:
- Change default class import `PrimeFactors` to named function import `{ 
primeFactors }`.
- Remove unneeded `new PrimeFactors();` call.
- Change `primeFactors.for(` calls to `primeFactors(` calls.
- Redesign example.js file to export a single named function.