### PR TITLE
Fix unit tests and example solution for Secret Handshake exercise

### DIFF
--- a/exercises/secret-handshake/example.js
+++ b/exercises/secret-handshake/example.js
@@ -1,24 +1,16 @@
-const HANDSHAKE_COMMANDS = ['wink', 'double blink', 'close your eyes', 'jump', 'REVERSE'];
+const handshakeCommands = ['wink', 'double blink', 'close your eyes', 'jump'];
 
 export const secretHandshake = (handshake) => {
   if (typeof handshake !== 'number') {
     throw new Error('Handshake must be a number');
   }
 
-  const shakeWith = [];
+  const shakeWith = handshakeCommands.filter((_, i) => (
+    handshake & (Math.pow(2, i))
+  ));
 
-  for (let i = 0; i < HANDSHAKE_COMMANDS.length; i++) {
-    const currentCommand = HANDSHAKE_COMMANDS[i];
-    const handshakeHasCommand = handshake & Math.pow(2, i);
-
-    if (handshakeHasCommand) {
-      if (currentCommand === 'REVERSE') {
-        shakeWith.reverse();
-      } else {
-        shakeWith.push(HANDSHAKE_COMMANDS[i]);
-      }
-    }
-  }
+  if (handshake & (Math.pow(2, 4)))
+    shakeWith.reverse();
 
   return shakeWith;
 };

--- a/exercises/secret-handshake/example.js
+++ b/exercises/secret-handshake/example.js
@@ -1,30 +1,24 @@
-export default function (handshake) {
-  const HANDSHAKE_COMMANDS = ['wink', 'double blink', 'close your eyes', 'jump', 'REVERSE'];
+const HANDSHAKE_COMMANDS = ['wink', 'double blink', 'close your eyes', 'jump', 'REVERSE'];
 
+export const secretHandshake = (handshake) => {
   if (typeof handshake !== 'number') {
     throw new Error('Handshake must be a number');
   }
 
-  this.commands = () => this.shakeWith;
+  const shakeWith = [];
 
-  this.calculateHandshake = (handshake) => {
-    const shakeWith = [];
+  for (let i = 0; i < HANDSHAKE_COMMANDS.length; i++) {
+    const currentCommand = HANDSHAKE_COMMANDS[i];
+    const handshakeHasCommand = handshake & Math.pow(2, i);
 
-    for (let i = 0; i < HANDSHAKE_COMMANDS.length; i++) {
-      const currentCommand = HANDSHAKE_COMMANDS[i];
-      const handshakeHasCommand = handshake & Math.pow(2, i);
-
-      if (handshakeHasCommand) {
-        if (currentCommand === 'REVERSE') {
-          shakeWith.reverse();
-        } else {
-          shakeWith.push(HANDSHAKE_COMMANDS[i]);
-        }
+    if (handshakeHasCommand) {
+      if (currentCommand === 'REVERSE') {
+        shakeWith.reverse();
+      } else {
+        shakeWith.push(HANDSHAKE_COMMANDS[i]);
       }
     }
+  }
 
-    return shakeWith;
-  };
-
-  this.shakeWith = this.calculateHandshake(handshake);
-}
+  return shakeWith;
+};

--- a/exercises/secret-handshake/secret-handshake.spec.js
+++ b/exercises/secret-handshake/secret-handshake.spec.js
@@ -1,44 +1,36 @@
-import SecretHandshake from './secret-handshake';
+import { secretHandshake } from './secret-handshake';
 
 describe('Secret Handshake', () => {
   test('binary 1 (hexadecimal 0x01) is a wink', () => {
-    const handshake = new SecretHandshake(0x01);
-    expect(handshake.commands()).toEqual(['wink']);
+    expect(secretHandshake(0x01)).toEqual(['wink']);
   });
 
   xtest('binary 10 (hexadecimal 0x02) is a double blink', () => {
-    const handshake = new SecretHandshake(0x02);
-    expect(handshake.commands()).toEqual(['double blink']);
+    expect(secretHandshake(0x02)).toEqual(['double blink']);
   });
 
   xtest('binary 100 (hexadecimal 0x04) is close your eyes', () => {
-    const handshake = new SecretHandshake(0x04);
-    expect(handshake.commands()).toEqual(['close your eyes']);
+    expect(secretHandshake(0x04)).toEqual(['close your eyes']);
   });
 
   xtest('binary 1000 (hexadecimal 0x08) is jump', () => {
-    const handshake = new SecretHandshake(0x08);
-    expect(handshake.commands()).toEqual(['jump']);
+    expect(secretHandshake(0x08)).toEqual(['jump']);
   });
 
   xtest('binary 11 (hexadecimal 0x03) is wink and double blink', () => {
-    const handshake = new SecretHandshake(0x03);
-    expect(handshake.commands()).toEqual(['wink', 'double blink']);
+    expect(secretHandshake(0x03)).toEqual(['wink', 'double blink']);
   });
 
   xtest('binary 10011 (hexadecimal 0x13) is double blink and wink', () => {
-    const handshake = new SecretHandshake(0x13);
-    expect(handshake.commands()).toEqual(['double blink', 'wink']);
+    expect(secretHandshake(0x13)).toEqual(['double blink', 'wink']);
   });
 
   xtest('binary 11111 (hexadecimal 0x1F) is jump, close your eyes, double blink, and wink', () => {
-    const handshake = new SecretHandshake(0x1F);
-    expect(handshake.commands()).toEqual(['jump', 'close your eyes', 'double blink', 'wink']);
+    expect(secretHandshake(0x1F)).toEqual(['jump', 'close your eyes', 'double blink', 'wink']);
   });
 
   xtest('text is an invalid secret handshake', () => {
-    expect(() => new SecretHandshake('piggies'))
+    expect(() => secretHandshake('piggies'))
       .toThrow(new Error('Handshake must be a number'));
   });
 });
-


### PR DESCRIPTION
Change the unit tests for the Secret Handshake exercise to accept a named 
function export instead of a default class export as per issues #274 and #436:
- Change default class import `SecretHandshake` to named function import `{ secretHandshake }`.
- Remove unneeded `new SecretHandshake(` calls.
- Change `handshake.commands(` calls to `secretHandshake(` calls.
- Redesign example.js file to export a single named function.