### PR TITLE
change tests to correctly check the first digits of area/exchange codes

### DIFF
--- a/exercises/phone-number/phone-number.spec.js
+++ b/exercises/phone-number/phone-number.spec.js
@@ -2,52 +2,78 @@ import PhoneNumber from './phone-number';
 
 describe('PhoneNumber()', () => {
   test('cleans the number', () => {
-    const phone = new PhoneNumber('(123) 456-7890');
-    expect(phone.number()).toEqual('1234567890');
+    const phone = new PhoneNumber('(223) 456-7890');
+    expect(phone.number()).toEqual('2234567890');
   });
 
   xtest('cleans numbers with dots', () => {
-    const phone = new PhoneNumber('123.456.7890');
-    expect(phone.number()).toEqual('1234567890');
+    const phone = new PhoneNumber('223.456.7890');
+    expect(phone.number()).toEqual('2234567890');
   });
 
   xtest('cleans numbers with multiple spaces', () => {
-    const phone = new PhoneNumber('123 456   7890   ');
-    expect(phone.number()).toEqual('1234567890');
+    const phone = new PhoneNumber('223 456   7890   ');
+    expect(phone.number()).toEqual('2234567890');
   });
 
   xtest('invalid when 9 digits', () => {
-    const phone = new PhoneNumber('123456789');
+    const phone = new PhoneNumber('223456789');
     expect(phone.number()).toEqual(null);
   });
 
-  xtest('invalid when 11 digits', () => {
-    const phone = new PhoneNumber('21234567890');
+  xtest('invalid when 11 digits does not start with a 1', () => {
+    const phone = new PhoneNumber('22234567890');
     expect(phone.number()).toEqual(null);
   });
 
   xtest('valid when 11 digits and starting with 1', () => {
-    const phone = new PhoneNumber('11234567890');
-    expect(phone.number()).toEqual('1234567890');
+    const phone = new PhoneNumber('12234567890');
+    expect(phone.number()).toEqual('2234567890');
+  });
+
+  xtest('valid when 11 digits and starting with 1 even with punctuation', () => {
+    const phone = new PhoneNumber('+1 (223) 456-7890');
+    expect(phone.number()).toEqual('2234567890');
   });
 
   xtest('invalid when 12 digits', () => {
-    const phone = new PhoneNumber('321234567890');
+    const phone = new PhoneNumber('322234567890');
     expect(phone.number()).toEqual(null);
   });
 
   xtest('invalid with letters', () => {
-    const phone = new PhoneNumber('123-abc-7890');
+    const phone = new PhoneNumber('223-abc-7890');
     expect(phone.number()).toEqual(null);
   });
 
   xtest('invalid with punctuations', () => {
-    const phone = new PhoneNumber('123-@:!-7890');
+    const phone = new PhoneNumber('223-@:!-7890');
     expect(phone.number()).toEqual(null);
   });
 
-  xtest('invalid with right number of digits but letters mixed in', () => {
-    const phone = new PhoneNumber('1a2b3c4d5e6f7g8h9i0j');
-    expect(phone.number()).toEqual(null);
+  xtest('invalid if area code starts with 0 or 1', () => {
+    const phone1 = new PhoneNumber('(023) 456-7890');
+    const phone2 = new PhoneNumber('(123) 456-7890');
+    expect(phone1.number()).toEqual(null);
+    expect(phone2.number()).toEqual(null);
+  });
+
+  xtest('invalid if exchange code starts with 0 or 1', () => {
+    const phone1 = new PhoneNumber('(223) 056-7890');
+    const phone2 = new PhoneNumber('(223) 156-7890');
+    expect(phone1.number()).toEqual(null);
+    expect(phone2.number()).toEqual(null);
+  });
+
+  xtest('invalid when 11 digits starting with 1, ' +
+  'but invalid area/exchange code first digits', () => {
+    const phone1 = new PhoneNumber('1 (023) 456-7890');
+    const phone2 = new PhoneNumber('1 (123) 456-7890');
+    const phone3 = new PhoneNumber('1 (223) 056-7890');
+    const phone4 = new PhoneNumber('1 (223) 156-7890');
+    expect(phone1.number()).toEqual(null);
+    expect(phone2.number()).toEqual(null);
+    expect(phone3.number()).toEqual(null);
+    expect(phone4.number()).toEqual(null);
   });
 });


### PR DESCRIPTION

* Fixed test cases of the form 123-456-7890, because those should fail as per the README (better matches canonical test cases). Additionally changed the numbers on other test cases to test only one factor at a time by not also breaking the area/exchange code rules.
* Removed 'invalid with right number of digits but letters mixed in' because of decision to remove it from the canonical tests. 
* Added missing 'valid when 11 digits and starting with 1 even with punctuation' from canonical tests.
* Added wording '... does not start with a 1' to 'invalid when 11 digits' as per canonical tests.
* Added area/exchange code testing from canonical tests.
* Added test cases to check whether 11-digit numbers starting with 1, but with incorrect area/exchange codes will fail appropriately (e.g., 1-123-456-7890, 1-223-045-7890 should fail).

Note that the example.js file needs an update. It does not test for area/exchange codes like the older js example.js test did.