### PR TITLE
Fix unit tests and example for Space Age exercise

### DIFF
--- a/exercises/space-age/example.js
+++ b/exercises/space-age/example.js
@@ -9,7 +9,7 @@ const EARTH_TO_OTHER_PLANETS = {
   neptune: 164.79132,
 };
 
-class SpaceAge {
+export class SpaceAge {
 
   constructor(seconds) {
     this.seconds = seconds;
@@ -54,6 +54,3 @@ class SpaceAge {
   }
 
 }
-
-export default SpaceAge;
-

--- a/exercises/space-age/space-age.spec.js
+++ b/exercises/space-age/space-age.spec.js
@@ -1,4 +1,4 @@
-import SpaceAge from './space-age';
+import { SpaceAge } from './space-age';
 
 describe('Space Age', () => {
   test('age in seconds', () => {
@@ -53,4 +53,3 @@ describe('Space Age', () => {
     expect(age.onNeptune()).toEqual(1.58);
   });
 });
-


### PR DESCRIPTION
Change the example for the Space Age exercise to accept a named class export instead of a default class export as per issue #436:
- Refactor example.js to export a named class.
- Change default import `SpaceAge` to named import `{ SpaceAge }`.