### PR TITLE
Linting fixes for 3 exercises

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
-acronym
 all-your-base
 allergies
 alphametics

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,6 @@
 all-your-base
 allergies
 alphametics
-anagram
 armstrong-numbers
 atbash-cipher
 beer-song

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
-accumulate
 acronym
 all-your-base
 allergies

--- a/exercises/accumulate/example.js
+++ b/exercises/accumulate/example.js
@@ -1,10 +1,11 @@
 export const accumulate = (list, accumulator) => {
   const out = [];
-  let idx = -1;
+  let idx = 0;
   const end = Array.isArray(list) ? list.length : 0;
 
-  while (++idx < end) {
+  while (idx < end) {
     out.push(accumulator(list[idx]));
+    idx += 1;
   }
 
   return out;

--- a/exercises/acronym/example.js
+++ b/exercises/acronym/example.js
@@ -1,6 +1,6 @@
 export default class Acronyms {
   static parse(phrase) {
     return phrase.match(/[A-Z]+[a-z]*|[a-z]+/g)
-      .reduce((acronym, word) => acronym += word[0].toUpperCase(), '');
+      .reduce((acronym, word) => `${acronym}${word[0]}`, '').toUpperCase();
   }
 }

--- a/exercises/anagram/anagram.spec.js
+++ b/exercises/anagram/anagram.spec.js
@@ -1,7 +1,6 @@
 import Anagram from './anagram';
 
 describe('Anagram', () => {
-
   test('no matches', () => {
     const subject = new Anagram('diaper');
     const matches = subject.matches(['hello', 'world', 'zombies', 'pants']);
@@ -85,5 +84,4 @@ describe('Anagram', () => {
 
     expect(matches).toEqual([]);
   });
-
 });

--- a/exercises/anagram/example.js
+++ b/exercises/anagram/example.js
@@ -1,11 +1,6 @@
-
-const sameWord = (word, candidate) =>
-  word.toLowerCase() === candidate.toLowerCase();
-
-const isAnagram = (word, candiate) =>
-  normalize(word) === normalize(candiate);
-
 const normalize = str => str.toLowerCase().split('').sort().join();
+const sameWord = (word, candidate) => word.toLowerCase() === candidate.toLowerCase();
+const isAnagram = (word, candiate) => normalize(word) === normalize(candiate);
 
 export default class Anagram {
   constructor(word) {
@@ -13,9 +8,8 @@ export default class Anagram {
   }
 
   matches(words) {
-    words = Array.isArray(words) ? words : Array.from(arguments);
-
-    return words.filter(candidate => !sameWord(this.word, candidate) && isAnagram(this.word, candidate));
+    const wordsCopy = Array.isArray(words) ? words : [...words];
+    return wordsCopy.filter(candidate => !sameWord(this.word, candidate)
+      && isAnagram(this.word, candidate));
   }
 }
-


### PR DESCRIPTION
Issue: https://github.com/exercism/javascript/issues/480

Addresses the linting errors in:

- `accumulate`
- `acronym`
- `anagram`

As requested, I kept it to 3 exercises, even though these are pretty small. (Alphabetically speaking, I skipped a couple where the fixes will be a little more involved.)

If everything here is acceptable, I am happy to submit more going forward--if not, I can update and re-submit.