### PR TITLE
(#480) Armstrong numbers linting fixes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,6 @@
 all-your-base
 allergies
 alphametics
-armstrong-numbers
 atbash-cipher
 beer-song
 binary

--- a/exercises/accumulate/package.json
+++ b/exercises/accumulate/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/acronym/package.json
+++ b/exercises/acronym/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/all-your-base/package.json
+++ b/exercises/all-your-base/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/allergies/package.json
+++ b/exercises/allergies/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/alphametics/package.json
+++ b/exercises/alphametics/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/anagram/package.json
+++ b/exercises/anagram/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/armstrong-numbers/example.js
+++ b/exercises/armstrong-numbers/example.js
@@ -1,7 +1,7 @@
 export const validate = (input) => {
   const digits = [...String(input)];
   const sum = digits.reduce((total, current) => (
-    total + Math.pow(current, digits.length)
+    total + (current ** digits.length)
   ), 0);
   return sum === input;
 };

--- a/exercises/armstrong-numbers/package.json
+++ b/exercises/armstrong-numbers/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/atbash-cipher/package.json
+++ b/exercises/atbash-cipher/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/beer-song/package.json
+++ b/exercises/beer-song/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/binary-search-tree/package.json
+++ b/exercises/binary-search-tree/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/binary-search/package.json
+++ b/exercises/binary-search/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/binary/package.json
+++ b/exercises/binary/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/bob/package.json
+++ b/exercises/bob/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/bowling/package.json
+++ b/exercises/bowling/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/bracket-push/package.json
+++ b/exercises/bracket-push/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/change/package.json
+++ b/exercises/change/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/circular-buffer/package.json
+++ b/exercises/circular-buffer/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/clock/package.json
+++ b/exercises/clock/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/collatz-conjecture/package.json
+++ b/exercises/collatz-conjecture/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/complex-numbers/package.json
+++ b/exercises/complex-numbers/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/connect/package.json
+++ b/exercises/connect/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/crypto-square/package.json
+++ b/exercises/crypto-square/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/custom-set/package.json
+++ b/exercises/custom-set/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/diamond/package.json
+++ b/exercises/diamond/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/difference-of-squares/package.json
+++ b/exercises/difference-of-squares/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/diffie-hellman/package.json
+++ b/exercises/diffie-hellman/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/etl/package.json
+++ b/exercises/etl/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/flatten-array/package.json
+++ b/exercises/flatten-array/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/food-chain/package.json
+++ b/exercises/food-chain/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/forth/package.json
+++ b/exercises/forth/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/gigasecond/package.json
+++ b/exercises/gigasecond/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/grade-school/package.json
+++ b/exercises/grade-school/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/grains/package.json
+++ b/exercises/grains/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/hamming/package.json
+++ b/exercises/hamming/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/hello-world/package.json
+++ b/exercises/hello-world/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/hexadecimal/package.json
+++ b/exercises/hexadecimal/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/house/package.json
+++ b/exercises/house/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/isbn-verifier/package.json
+++ b/exercises/isbn-verifier/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/isogram/package.json
+++ b/exercises/isogram/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/kindergarten-garden/package.json
+++ b/exercises/kindergarten-garden/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/largest-series-product/package.json
+++ b/exercises/largest-series-product/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/leap/package.json
+++ b/exercises/leap/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/linked-list/package.json
+++ b/exercises/linked-list/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/list-ops/package.json
+++ b/exercises/list-ops/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/luhn/package.json
+++ b/exercises/luhn/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/matrix/package.json
+++ b/exercises/matrix/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/meetup/package.json
+++ b/exercises/meetup/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/minesweeper/package.json
+++ b/exercises/minesweeper/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/nth-prime/package.json
+++ b/exercises/nth-prime/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/nucleotide-count/package.json
+++ b/exercises/nucleotide-count/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/ocr-numbers/package.json
+++ b/exercises/ocr-numbers/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/octal/package.json
+++ b/exercises/octal/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/palindrome-products/package.json
+++ b/exercises/palindrome-products/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/pangram/package.json
+++ b/exercises/pangram/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/pascals-triangle/package.json
+++ b/exercises/pascals-triangle/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/perfect-numbers/package.json
+++ b/exercises/perfect-numbers/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/phone-number/package.json
+++ b/exercises/phone-number/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/pig-latin/package.json
+++ b/exercises/pig-latin/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/point-mutations/package.json
+++ b/exercises/point-mutations/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/prime-factors/package.json
+++ b/exercises/prime-factors/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/protein-translation/package.json
+++ b/exercises/protein-translation/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/proverb/package.json
+++ b/exercises/proverb/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/pythagorean-triplet/package.json
+++ b/exercises/pythagorean-triplet/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/queen-attack/package.json
+++ b/exercises/queen-attack/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/raindrops/package.json
+++ b/exercises/raindrops/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/rational-numbers/package.json
+++ b/exercises/rational-numbers/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/react/package.json
+++ b/exercises/react/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/rectangles/package.json
+++ b/exercises/rectangles/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/reverse-string/package.json
+++ b/exercises/reverse-string/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/rna-transcription/package.json
+++ b/exercises/rna-transcription/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/robot-name/package.json
+++ b/exercises/robot-name/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/robot-simulator/package.json
+++ b/exercises/robot-simulator/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/roman-numerals/package.json
+++ b/exercises/roman-numerals/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/rotational-cipher/package.json
+++ b/exercises/rotational-cipher/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/run-length-encoding/package.json
+++ b/exercises/run-length-encoding/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/saddle-points/package.json
+++ b/exercises/saddle-points/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/say/package.json
+++ b/exercises/say/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/scrabble-score/package.json
+++ b/exercises/scrabble-score/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/secret-handshake/package.json
+++ b/exercises/secret-handshake/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/series/package.json
+++ b/exercises/series/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/sieve/package.json
+++ b/exercises/sieve/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/simple-cipher/package.json
+++ b/exercises/simple-cipher/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/simple-linked-list/package.json
+++ b/exercises/simple-linked-list/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/space-age/package.json
+++ b/exercises/space-age/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/spiral-matrix/package.json
+++ b/exercises/spiral-matrix/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/strain/package.json
+++ b/exercises/strain/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/sublist/package.json
+++ b/exercises/sublist/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/sum-of-multiples/package.json
+++ b/exercises/sum-of-multiples/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/transpose/package.json
+++ b/exercises/transpose/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/triangle/package.json
+++ b/exercises/triangle/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/trinary/package.json
+++ b/exercises/trinary/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/twelve-days/package.json
+++ b/exercises/twelve-days/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/two-bucket/package.json
+++ b/exercises/two-bucket/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/two-fer/package.json
+++ b/exercises/two-fer/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/variable-length-quantity/package.json
+++ b/exercises/variable-length-quantity/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/word-count/package.json
+++ b/exercises/word-count/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/word-search/package.json
+++ b/exercises/word-search/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/wordy/package.json
+++ b/exercises/wordy/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/exercises/zipper/package.json
+++ b/exercises/zipper/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {
@@ -73,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,62 @@
         "@babel/highlight": "^7.0.0"
       }
     },
+    "@babel/generator": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.2.tgz",
+      "integrity": "sha512-70A9HWLS/1RHk3Ck8tNHKxOoKQuSKocYgwDN85Pyl/RBduss6AKxUR7RIZ/lzduQMSYfWEM4DDBu6A+XGbkFig==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.1.2",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.10",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
     "@babel/highlight": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
@@ -64,6 +120,94 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.2.tgz",
+      "integrity": "sha512-x5HFsW+E/nQalGMw7hu+fvPqnBeBaIr0lWJ2SG0PPL2j+Pm9lYvCrsZJGIgauPIENx0v10INIyFjmSNUD/gSqQ==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
+      "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.1.2",
+        "@babel/types": "^7.1.2"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.0.tgz",
+      "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.0.0",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "debug": "^3.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.2.tgz",
+      "integrity": "sha512-pb1I05sZEKiSlMUV9UReaqsCPUpgbHHHu2n1piRm7JkuBkm6QxcaIzKu6FMnMtCbih/cEYTR+RGYYC96Yk9HAg==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.10",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
         }
       }
     },
@@ -329,6 +473,32 @@
         "private": "^0.1.7",
         "slash": "^1.0.0",
         "source-map": "^0.5.6"
+      }
+    },
+    "babel-eslint": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
+      "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+          "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
       }
     },
     "babel-generator": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.4.0",
@@ -56,8 +57,9 @@
     "lint-test": "eslint . && jest --no-cache ./* "
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "parserOptions": {
-      "ecmaVersion": 6,
+      "ecmaVersion": 7,
       "sourceType": "module"
     },
     "env": {

--- a/package.json
+++ b/package.json
@@ -75,8 +75,6 @@
       "import/no-default-export": "off"
     }
   },
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "dependencies": {}
 }


### PR DESCRIPTION
https://github.com/exercism/javascript/issues/480

I kept this PR to a single exercise fix, since it also required me to update ESLint config a bit, and install a new package.

- Fixes linting errors in the `armstrong-numbers` exercise
- In order to do this according to the current ruleset, we need ESLint to recognize the `**` operator, which requires the `babel-eslint` parser. I installed this and switched it over--ultimately, this is really what we want to be using anyway, so that ESLint can handle any other future syntax that may be required to fix all of these in accordance with the `airbnb` ruleset.
- Updated the `license` info in `package.json` to the correct format

Note: updating the root `package.json` required me to commit the updated file to all exercises as well, lest TravisCI would fail. Hence why there are 103 file changes. The last commit is just updating all of these and the `npm lockfile`, so it may be easier code-review wise to filter to just the first 3 commits.