### PR TITLE
simple-cipher: Disallow mixed case key

### DIFF
--- a/exercises/simple-cipher/simple-cipher.spec.js
+++ b/exercises/simple-cipher/simple-cipher.spec.js
@@ -45,6 +45,12 @@ describe('Incorrect key cipher', () => {
     }).toThrow(new Error('Bad key'));
   });
 
+  xtest('throws an error with a mixed-case key', () => {
+    expect(() => {
+      new Cipher('ABcdEF');
+    }).toThrow(new Error('Bad key'));
+  });
+
   xtest('throws an error with a numeric key', () => {
     expect(() => {
       new Cipher('12345');


### PR DESCRIPTION
This test has already been [added to the TypeScript version](https://github.com/exercism/typescript/pull/219/commits/675e817a33df5bda5bce9a2a07195739bd1f4922) of this exercise. The JavaScript example implementation already passes, but I still think the test is valuable as I've seen the same error in JavaScript student submissions.

A solution that checks if the key is valid (i.e. only contains alpha ascii lower-case letters) by testing

    if (key === key.toUpperCase()) { throw new Error('Bad key') }`

passes the current "throws an error with an all caps key" test but allows mixed-case keys, which should actually be invalid.