### PR TITLE
fix: Eslint errors in wordy

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -80,4 +80,4 @@ twelve-days
 two-bucket
 variable-length-quantity
 word-search
-wordy
+# wordy

--- a/.eslintignore
+++ b/.eslintignore
@@ -80,4 +80,3 @@ twelve-days
 two-bucket
 variable-length-quantity
 word-search
-# wordy

--- a/exercises/wordy/example.js
+++ b/exercises/wordy/example.js
@@ -10,7 +10,6 @@ class ArgumentError extends Error {
 const re = new RegExp(/(plus|minus|divided by|multiplied by)+/g);
 
 class Wordy {
-
   constructor(question) {
     this.numbers = question.match(/[-]{0,1}\d+/g);
     this.operands = question.match(re);
@@ -20,38 +19,32 @@ class Wordy {
     if (!this.numbers || !this.operands) {
       throw new ArgumentError();
     }
-    let ii = 1,
-      jj = 0,
-      result = +this.numbers[0];
+    let ii = 1;
+    let jj = 0;
+    let result = +this.numbers[0];
 
     while (ii < this.numbers.length + 1) {
-      const op = this.operands[jj++],
-        b = +this.numbers[ii++] || null;
+      const op = this.operands[jj++];
+      const b = +this.numbers[ii++] || null;
       switch (op) {
-        case 'plus' :
+        case 'plus':
           result += b;
           break;
-        case 'minus' :
+        case 'minus':
           result -= b;
           break;
-        case 'multiplied by' :
+        case 'multiplied by':
           result *= b;
           break;
-        case 'divided by' :
+        case 'divided by':
           result /= b;
+          break;
+        default:
           break;
       }
     }
     return result;
   }
 }
-
-String.prototype.combine = function(x){
-  return x;
-}
-
-let f = new String('abc');
-let g = f.combine('xyz');
-
 
 export { Wordy as WordProblem, ArgumentError };

--- a/exercises/wordy/example.js
+++ b/exercises/wordy/example.js
@@ -6,7 +6,6 @@ class ArgumentError extends Error {
   }
 }
 
-
 const re = new RegExp(/(plus|minus|divided by|multiplied by)+/g);
 
 class Wordy {
@@ -19,30 +18,28 @@ class Wordy {
     if (!this.numbers || !this.operands) {
       throw new ArgumentError();
     }
-    let ii = 1;
-    let jj = 0;
     let result = +this.numbers[0];
 
-    while (ii < this.numbers.length + 1) {
-      const op = this.operands[jj++];
-      const b = +this.numbers[ii++] || null;
-      switch (op) {
+    this.operands.forEach((operand, index) => {
+      const nextNumber = +this.numbers[index + 1] || null;
+
+      switch (operand) {
         case 'plus':
-          result += b;
+          result += nextNumber;
           break;
         case 'minus':
-          result -= b;
+          result -= nextNumber;
           break;
         case 'multiplied by':
-          result *= b;
+          result *= nextNumber;
           break;
         case 'divided by':
-          result /= b;
+          result /= nextNumber;
           break;
         default:
           break;
       }
-    }
+    });
     return result;
   }
 }


### PR DESCRIPTION
Wordy lint fix associated to #480.

I got into a little bit of a rabbit hole in fixing the linting errors here. 
There was an issue with using ++, in finding ways to eliminate the use of this, I found a bug, the solution was doing an extra loop over the arrays, I think it was implemented with the perception that arrays are 1-indexed not zero  (minor fix). 
- Also, deleted unwanted code: there was a prototype method defined on the String class that wasnt needed.
- Renamed variables. 

