### PR TITLE
Change two-fer exercise to use named exports

### DIFF
--- a/exercises/two-fer/example.js
+++ b/exercises/two-fer/example.js
@@ -1,4 +1,4 @@
-export default (name) => {
+export const twoFer = (name) => {
   const nameText = name || 'you';
   return `One for ${nameText}, one for me.`;
 };

--- a/exercises/two-fer/two-fer.spec.js
+++ b/exercises/two-fer/two-fer.spec.js
@@ -1,4 +1,4 @@
-import twoFer from './two-fer';
+import { twoFer } from './two-fer';
 
 describe('twoFer()', () => {
   test('no name given', () => {


### PR DESCRIPTION
closes #503:

Change default import `twoFer` to named import `{ twoFer }`.
Change export statement of `example.js` from a default to a named export.