### PR TITLE
Fix eslint errors in hamming exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -24,7 +24,6 @@ forth
 gigasecond
 grade-school
 grains
-hamming
 hexadecimal
 isbn-verifier
 isogram

--- a/exercises/hamming/example.js
+++ b/exercises/hamming/example.js
@@ -1,6 +1,5 @@
 class Hamming {
-
-  compute(strand1, strand2) {
+  static compute(strand1, strand2) {
     const len1 = strand1.length;
     const len2 = strand2.length;
     if (len1 !== len2) {
@@ -8,17 +7,15 @@ class Hamming {
     }
 
     let distance = 0;
-    let idx = -1;
     const end = len1; // there could be len2, they're equal
-    while (++idx < end) {
+    for (let idx = 0; idx < end; idx += 1) {
       if (strand1[idx] !== strand2[idx]) {
-        distance++;
+        distance += 1;
       }
     }
 
     return distance;
   }
-
 }
 
 export default Hamming;

--- a/exercises/hamming/example.js
+++ b/exercises/hamming/example.js
@@ -5,13 +5,8 @@ export const compute = (strand1, strand2) => {
     throw new Error('left and right strands must be of equal length');
   }
 
-  let distance = 0;
-  const end = len1; // there could be len2, they're equal
-  for (let idx = 0; idx < end; idx += 1) {
-    if (strand1[idx] !== strand2[idx]) {
-      distance += 1;
-    }
-  }
-
-  return distance;
+  return [...strand1].reduce(
+    (distance, _, i) => (strand1[i] !== strand2[i] ? distance + 1 : distance),
+    0,
+  );
 };

--- a/exercises/hamming/example.js
+++ b/exercises/hamming/example.js
@@ -5,8 +5,5 @@ export const compute = (strand1, strand2) => {
     throw new Error('left and right strands must be of equal length');
   }
 
-  return [...strand1].reduce(
-    (distance, _, i) => (strand1[i] !== strand2[i] ? distance + 1 : distance),
-    0,
-  );
+  return [...strand1].filter((element, index) => element !== strand2[index]).length;
 };

--- a/exercises/hamming/example.js
+++ b/exercises/hamming/example.js
@@ -1,21 +1,17 @@
-class Hamming {
-  static compute(strand1, strand2) {
-    const len1 = strand1.length;
-    const len2 = strand2.length;
-    if (len1 !== len2) {
-      throw new Error('left and right strands must be of equal length');
-    }
-
-    let distance = 0;
-    const end = len1; // there could be len2, they're equal
-    for (let idx = 0; idx < end; idx += 1) {
-      if (strand1[idx] !== strand2[idx]) {
-        distance += 1;
-      }
-    }
-
-    return distance;
+export const compute = (strand1, strand2) => {
+  const len1 = strand1.length;
+  const len2 = strand2.length;
+  if (len1 !== len2) {
+    throw new Error('left and right strands must be of equal length');
   }
-}
 
-export default Hamming;
+  let distance = 0;
+  const end = len1; // there could be len2, they're equal
+  for (let idx = 0; idx < end; idx += 1) {
+    if (strand1[idx] !== strand2[idx]) {
+      distance += 1;
+    }
+  }
+
+  return distance;
+};

--- a/exercises/hamming/hamming.spec.js
+++ b/exercises/hamming/hamming.spec.js
@@ -1,68 +1,66 @@
-import Hamming from './hamming';
+import { compute } from './hamming';
 
 describe('Hamming', () => {
-  const hamming = new Hamming();
-
   test('no difference between empty strands', () => {
-    expect(hamming.compute('', '')).toEqual(0);
+    expect(compute('', '')).toEqual(0);
   });
 
   xtest('no difference between identical strands', () => {
-    expect(hamming.compute('A', 'A')).toEqual(0);
+    expect(compute('A', 'A')).toEqual(0);
   });
 
   xtest('long identical strands', () => {
-    expect(hamming.compute('GGACTGA', 'GGACTGA')).toEqual(0);
+    expect(compute('GGACTGA', 'GGACTGA')).toEqual(0);
   });
 
   xtest('complete distance in single nucleotide strands', () => {
-    expect(hamming.compute('A', 'G')).toEqual(1);
+    expect(compute('A', 'G')).toEqual(1);
   });
 
   xtest('complete distance in small strands', () => {
-    expect(hamming.compute('AG', 'CT')).toEqual(2);
+    expect(compute('AG', 'CT')).toEqual(2);
   });
 
   xtest('small distance in small strands', () => {
-    expect(hamming.compute('AT', 'CT')).toEqual(1);
+    expect(compute('AT', 'CT')).toEqual(1);
   });
 
   xtest('small distance', () => {
-    expect(hamming.compute('GGACG', 'GGTCG')).toEqual(1);
+    expect(compute('GGACG', 'GGTCG')).toEqual(1);
   });
 
   xtest('small distance in long strands', () => {
-    expect(hamming.compute('ACCAGGG', 'ACTATGG')).toEqual(2);
+    expect(compute('ACCAGGG', 'ACTATGG')).toEqual(2);
   });
 
   xtest('non-unique character in first strand', () => {
-    expect(hamming.compute('AAG', 'AAA')).toEqual(1);
+    expect(compute('AAG', 'AAA')).toEqual(1);
   });
 
   xtest('non-unique character in second strand', () => {
-    expect(hamming.compute('AAA', 'AAG')).toEqual(1);
+    expect(compute('AAA', 'AAG')).toEqual(1);
   });
 
   xtest('same nucleotides in different positions', () => {
-    expect(hamming.compute('TAG', 'GAT')).toEqual(2);
+    expect(compute('TAG', 'GAT')).toEqual(2);
   });
 
   xtest('large distance', () => {
-    expect(hamming.compute('GATACA', 'GCATAA')).toEqual(4);
+    expect(compute('GATACA', 'GCATAA')).toEqual(4);
   });
 
   xtest('large distance in off-by-one strand', () => {
-    expect(hamming.compute('GGACGGATTCTG', 'AGGACGGATTCT')).toEqual(9);
+    expect(compute('GGACGGATTCTG', 'AGGACGGATTCT')).toEqual(9);
   });
 
   xtest('disallow first strand longer', () => {
-    expect(() => hamming.compute('AATG', 'AAA')).toThrow(
+    expect(() => compute('AATG', 'AAA')).toThrow(
       new Error('left and right strands must be of equal length'),
     );
   });
 
   xtest('disallow second strand longer', () => {
-    expect(() => hamming.compute('ATA', 'AGTG')).toThrow(
+    expect(() => compute('ATA', 'AGTG')).toThrow(
       new Error('left and right strands must be of equal length'),
     );
   });


### PR DESCRIPTION
Per #480, fix the following lint errors for the hamming exercise:

```sh
/home/eric/code/javascript/exercises/hamming/example.js
   1:15  error  Block must not be padded by blank lines               padded-blocks
   3:10  error  Expected 'this' to be used by class method 'compute'  class-methods-use-this
  13:12  error  Unary operator '++' used                              no-plusplus
  15:9   error  Unary operator '++' used                              no-plusplus
  22:1   error  Block must not be padded by blank lines               padded-blocks
```
Note:
1. The `while` loop is replaced with `for` to allow easier replacement from `++` to `+=`.
2. The error "Expected `this` to be used by class method `compute`" is addressed by exporting the standalone `compute` function instead of exporting an entire `Hamming` class.