### PR TITLE
Lint simple-cipher exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -62,7 +62,6 @@ scrabble-score
 secret-handshake
 series
 sieve
-simple-cipher
 spiral-matrix
 strain
 sublist

--- a/exercises/simple-cipher/example.js
+++ b/exercises/simple-cipher/example.js
@@ -6,20 +6,18 @@ function generateKey() {
     .join('');
 }
 
+const mod = (n, m) => ((n % m) + m) % m;
+
 function xCode(key, inText, sign) {
   return [...inText]
     .reduce((outText, letter, ii) => {
       const offset = sign * ALPHA.indexOf(key[mod(ii, key.length)]);
-      outText += ALPHA[mod(ALPHA.indexOf(letter) + offset, ALPHA.length)];
-      return outText;
+      return outText + ALPHA[mod(ALPHA.indexOf(letter) + offset, ALPHA.length)];
     }, '');
 }
 
-const mod = (n, m) => (n % m + m) % m;
-
 export class Cipher {
-
-  constructor (key) {
+  constructor(key) {
     if (typeof key === 'undefined') {
       this.key = generateKey();
     } else if (key.length === 0 || key.match(/[^a-z]/, 'g')) {

--- a/exercises/simple-cipher/simple-cipher.spec.js
+++ b/exercises/simple-cipher/simple-cipher.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-new */
 import { Cipher } from './simple-cipher';
 
 describe('Random key generation', () => {
@@ -41,43 +42,43 @@ describe('Random key cipher', () => {
 describe('Incorrect key cipher', () => {
   xtest('throws an error with an all caps key', () => {
     expect(() => {
-      new Cipher('ABCDEF'); // eslint-disable-line no-new
+      new Cipher('ABCDEF');
     }).toThrow(new Error('Bad key'));
   });
 
   xtest('throws an error with a mixed-case key', () => {
     expect(() => {
-      new Cipher('ABcdEF'); // eslint-disable-line no-new
+      new Cipher('ABcdEF');
     }).toThrow(new Error('Bad key'));
   });
 
   xtest('throws an error with a numeric key', () => {
     expect(() => {
-      new Cipher('12345'); // eslint-disable-line no-new
+      new Cipher('12345');
     }).toThrow(new Error('Bad key'));
   });
 
   xtest('throws an error with an empty key', () => {
     expect(() => {
-      new Cipher(''); // eslint-disable-line no-new
+      new Cipher('');
     }).toThrow(new Error('Bad key'));
   });
 
   xtest('throws an error with a leading space', () => {
     expect(() => {
-      new Cipher(' leadingspace'); // eslint-disable-line no-new
+      new Cipher(' leadingspace');
     }).toThrow(new Error('Bad key'));
   });
 
   xtest('throws an error with a punctuation mark', () => {
     expect(() => {
-      new Cipher('hyphened-word'); // eslint-disable-line no-new
+      new Cipher('hyphened-word');
     }).toThrow(new Error('Bad key'));
   });
 
   xtest('throws an error with a single capital letter', () => {
     expect(() => {
-      new Cipher('leonardoDavinci'); // eslint-disable-line no-new
+      new Cipher('leonardoDavinci');
     }).toThrow(new Error('Bad key'));
   });
 });

--- a/exercises/simple-cipher/simple-cipher.spec.js
+++ b/exercises/simple-cipher/simple-cipher.spec.js
@@ -41,43 +41,43 @@ describe('Random key cipher', () => {
 describe('Incorrect key cipher', () => {
   xtest('throws an error with an all caps key', () => {
     expect(() => {
-      new Cipher('ABCDEF');
+      new Cipher('ABCDEF'); // eslint-disable-line no-new
     }).toThrow(new Error('Bad key'));
   });
 
   xtest('throws an error with a mixed-case key', () => {
     expect(() => {
-      new Cipher('ABcdEF');
+      new Cipher('ABcdEF'); // eslint-disable-line no-new
     }).toThrow(new Error('Bad key'));
   });
 
   xtest('throws an error with a numeric key', () => {
     expect(() => {
-      new Cipher('12345');
+      new Cipher('12345'); // eslint-disable-line no-new
     }).toThrow(new Error('Bad key'));
   });
 
   xtest('throws an error with an empty key', () => {
     expect(() => {
-      new Cipher('');
+      new Cipher(''); // eslint-disable-line no-new
     }).toThrow(new Error('Bad key'));
   });
 
   xtest('throws an error with a leading space', () => {
     expect(() => {
-      new Cipher(' leadingspace');
+      new Cipher(' leadingspace'); // eslint-disable-line no-new
     }).toThrow(new Error('Bad key'));
   });
 
   xtest('throws an error with a punctuation mark', () => {
     expect(() => {
-      new Cipher('hyphened-word');
+      new Cipher('hyphened-word'); // eslint-disable-line no-new
     }).toThrow(new Error('Bad key'));
   });
 
   xtest('throws an error with a single capital letter', () => {
     expect(() => {
-      new Cipher('leonardoDavinci');
+      new Cipher('leonardoDavinci'); // eslint-disable-line no-new
     }).toThrow(new Error('Bad key'));
   });
 });
@@ -115,7 +115,7 @@ describe('Substitution cipher', () => {
     expect(cipher.decode('zabcdefghi')).toEqual('zzzzzzzzzz');
   });
 
-  xtest('can handle messages longer than the key', function() {
+  xtest('can handle messages longer than the key', () => {
     expect(new Cipher('abc').encode('iamapandabear'))
       .toEqual('iboaqcnecbfcr');
   });


### PR DESCRIPTION
Per #480, fix the following eslint errors in `simple-cipher` exercise: 

```
/home/ericode/javascript/exercises/simple-cipher/example.js
  12:47  error  'mod' was used before it was defined          no-use-before-define
  13:7   error  Assignment to function parameter 'outText'    no-param-reassign
  13:24  error  'mod' was used before it was defined          no-use-before-define
  18:26  error  Unexpected mix of '%' and '+'                 no-mixed-operators
  18:30  error  Unexpected mix of '%' and '+'                 no-mixed-operators
  20:21  error  Block must not be padded by blank lines       padded-blocks
  22:14  error  Unexpected space before function parentheses  space-before-function-paren

/home/eric/code/javascript/exercises/simple-cipher/simple-cipher.spec.js
   44:7   error    Do not use 'new' for side effects          no-new
   50:7   error    Do not use 'new' for side effects          no-new
   56:7   error    Do not use 'new' for side effects          no-new
   62:7   error    Do not use 'new' for side effects          no-new
   68:7   error    Do not use 'new' for side effects          no-new
   74:7   error    Do not use 'new' for side effects          no-new
   80:7   error    Do not use 'new' for side effects          no-new
  118:52  warning  Unexpected unnamed function                func-names
  118:52  error    Unexpected function expression             prefer-arrow-callback
  118:60  error    Missing space before function parentheses  space-before-function-paren
```

#### Approach
1. Disable no-new rule to allow `new Cipher(..)` to remain as-is in test.  An alternate way considered was to use `(() => new Cipher('...'))()`, which I think is less readable.
2. Use parenthesis to make operator precedence explicit between `%` and `+`.
3. Prefer arrow function `() => {..}` instead of `function() {..}`.
4. Avoid re-assigning parameter `outText`.
5. Define `mod` before use.

