### PR TITLE
Lint bob exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,7 +5,6 @@ beer-song
 binary
 binary-search
 binary-search-tree
-bob
 bowling
 bracket-push
 change

--- a/exercises/bob/bob.js
+++ b/exercises/bob/bob.js
@@ -4,8 +4,8 @@
 // convenience to get you started writing code faster.
 //
 
-export const hey = message => {
+export const hey = (message) => {
   //
   // YOUR CODE GOES HERE
   //
-}
+};

--- a/exercises/bob/bob.spec.js
+++ b/exercises/bob/bob.spec.js
@@ -1,7 +1,6 @@
 import { hey } from './bob';
 
 describe('Bob', () => {
-
   test('stating something', () => {
     const result = hey('Tom-ay-to, tom-aaaah-to.');
     expect(result).toEqual('Whatever.');
@@ -43,7 +42,7 @@ describe('Bob', () => {
   });
 
   xtest('forceful question', () => {
-    const result = hey("WHAT THE HELL WERE YOU THINKING?");
+    const result = hey('WHAT THE HELL WERE YOU THINKING?');
     expect(result).toEqual('Calm down, I know what I\'m doing!');
   });
 

--- a/exercises/bob/example.js
+++ b/exercises/bob/example.js
@@ -2,7 +2,7 @@ const isSilence = message => message.replace(/\s+/g, '') === '';
 const isShouting = message => message.toUpperCase() === message && /[A-Z]/.test(message);
 const isAQuestion = message => message[message.length - 1] === '?';
 
-export const hey = message => {
+export const hey = (message) => {
   if (isSilence(message)) {
     return 'Fine. Be that way!';
   }
@@ -16,4 +16,4 @@ export const hey = message => {
     return 'Sure.';
   }
   return 'Whatever.';
-}
+};


### PR DESCRIPTION
Per #480, fix the following lint errors for the bob exercise:

```
/home/eric/code/javascript/exercises/bob/bob.js
   7:20  error  Expected parentheses around arrow function argument having a body with curly braces  arrow-parens
  11:2   error  Missing semicolon                                                                    semi

/home/eric/code/javascript/exercises/bob/bob.spec.js
   3:23  error  Block must not be padded by blank lines  padded-blocks
  46:24  error  Strings must use singlequote             quotes

/home/eric/code/javascript/exercises/bob/example.js
   5:20  error  Expected parentheses around arrow function argument having a body with curly braces  arrow-parens
  19:2   error  Missing semicolon                                                                    semi
```