### PR TITLE
Update secret-handshake spec file with decimal test values

### DIFF
--- a/exercises/secret-handshake/secret-handshake.spec.js
+++ b/exercises/secret-handshake/secret-handshake.spec.js
@@ -1,32 +1,32 @@
 import { secretHandshake } from './secret-handshake';
 
 describe('Secret Handshake', () => {
-  test('binary 1 (hexadecimal 0x01) is a wink', () => {
-    expect(secretHandshake(0x01)).toEqual(['wink']);
+  test('binary 1 (decimal 1) is a wink', () => {
+    expect(secretHandshake(1)).toEqual(['wink']);
   });
 
-  xtest('binary 10 (hexadecimal 0x02) is a double blink', () => {
-    expect(secretHandshake(0x02)).toEqual(['double blink']);
+  xtest('binary 10 (decimal 2) is a double blink', () => {
+    expect(secretHandshake(2)).toEqual(['double blink']);
   });
 
-  xtest('binary 100 (hexadecimal 0x04) is close your eyes', () => {
-    expect(secretHandshake(0x04)).toEqual(['close your eyes']);
+  xtest('binary 100 (decimal 4) is close your eyes', () => {
+    expect(secretHandshake(4)).toEqual(['close your eyes']);
   });
 
-  xtest('binary 1000 (hexadecimal 0x08) is jump', () => {
-    expect(secretHandshake(0x08)).toEqual(['jump']);
+  xtest('binary 1000 (decimal 8) is jump', () => {
+    expect(secretHandshake(8)).toEqual(['jump']);
   });
 
-  xtest('binary 11 (hexadecimal 0x03) is wink and double blink', () => {
-    expect(secretHandshake(0x03)).toEqual(['wink', 'double blink']);
+  xtest('binary 11 (decimal 3) is wink and double blink', () => {
+    expect(secretHandshake(3)).toEqual(['wink', 'double blink']);
   });
 
-  xtest('binary 10011 (hexadecimal 0x13) is double blink and wink', () => {
-    expect(secretHandshake(0x13)).toEqual(['double blink', 'wink']);
+  xtest('binary 10011 (decimal 19) is double blink and wink', () => {
+    expect(secretHandshake(19)).toEqual(['double blink', 'wink']);
   });
 
-  xtest('binary 11111 (hexadecimal 0x1F) is jump, close your eyes, double blink, and wink', () => {
-    expect(secretHandshake(0x1F)).toEqual(['jump', 'close your eyes', 'double blink', 'wink']);
+  xtest('binary 11111 (decimal 31) is jump, close your eyes, double blink, and wink', () => {
+    expect(secretHandshake(31)).toEqual(['jump', 'close your eyes', 'double blink', 'wink']);
   });
 
   xtest('text is an invalid secret handshake', () => {


### PR DESCRIPTION
## Current State
The spec file for `secret-handshake` passes hexadecimal values to the `secretHandshake()` constructor asked of the user.

## Changes
Per the problem specification, passes decimal values which resolve to the binary values which [should] give the expected output.

Fixes #509 