### PR TITLE
Resolve lint issue(s) in isogram solution

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -25,7 +25,6 @@ grade-school
 grains
 hexadecimal
 isbn-verifier
-isogram
 kindergarten-garden
 largest-series-product
 linked-list

--- a/exercises/isogram/example.js
+++ b/exercises/isogram/example.js
@@ -1,5 +1,4 @@
 export default class Isogram {
-
   constructor(string) {
     this.string = string.replace(/ |-/g, '');
   }


### PR DESCRIPTION
As per #480

```sh
$ npm run lint

/exercises/isogram/example.js
  1:30  error  Block must not be padded by blank lines  padded-blocks

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```