### PR TITLE
Lint crypto-square exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,7 +12,6 @@ circular-buffer
 clock
 complex-numbers
 connect
-crypto-square
 diamond
 difference-of-squares
 etl

--- a/exercises/crypto-square/example.js
+++ b/exercises/crypto-square/example.js
@@ -21,27 +21,27 @@ export default class Square {
   }
 
   ciphertext() {
-    const textSegments = this.plaintextSegments(),
-      columns = [];
-    let i,
-      j,
-      currentSegment,
-      currentLetter;
+    const textSegments = this.plaintextSegments();
+    const columns = [];
+    let i;
+    let j;
+    let currentSegment;
+    let currentLetter;
 
-    for (i = 0; i < this.size(); i++) {
+    for (i = 0; i < this.size(); i += 1) {
       columns.push([]);
     }
 
-    for (i = 0; i < textSegments.length; i++) {
+    for (i = 0; i < textSegments.length; i += 1) {
       currentSegment = textSegments[i];
 
-      for (j = 0; j < currentSegment.length; j++) {
+      for (j = 0; j < currentSegment.length; j += 1) {
         currentLetter = currentSegment[j];
         columns[j].push(currentLetter);
       }
     }
 
-    for (i = 0; i < columns.length; i++) {
+    for (i = 0; i < columns.length; i += 1) {
       columns[i] = columns[i].join('');
     }
 


### PR DESCRIPTION
Per #480, it fixes the following errors on the crypto-square exercise:

```
.../javascript/exercises/crypto-square/example.js
  24:5   error  Split 'const' declarations into multiple statements  one-var
  26:5   error  Split 'let' declarations into multiple statements    one-var
  31:34  error  Unary operator '++' used                             no-plusplus
  35:42  error  Unary operator '++' used                             no-plusplus
  38:46  error  Unary operator '++' used                             no-plusplus
  44:37  error  Unary operator '++' used                             no-plusplus
```