### PR TITLE
Fix eslint errors allergies#480

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,4 @@
-allergies
 alphametics
-bowling
-change
 circular-buffer
 clock
 complex-numbers

--- a/exercises/allergies/example.js
+++ b/exercises/allergies/example.js
@@ -15,7 +15,6 @@ class Allergies {
   }
 
   list() {
-    // eslint-disable-next-line no-bitwise
     return possibleAllergies.filter((allergy, i) => this.allergenIndex & 2 ** i);
   }
 

--- a/exercises/allergies/example.js
+++ b/exercises/allergies/example.js
@@ -15,7 +15,7 @@ class Allergies {
   }
 
   list() {
-    return possibleAllergies.filter((allergy, i) => this.allergenIndex & Math.pow(2, i));
+    return possibleAllergies.filter((allergy, i) => this.allergenIndex && 2 ** i);
   }
 
   allergicTo(food) {
@@ -24,4 +24,3 @@ class Allergies {
 }
 
 export default Allergies;
-

--- a/exercises/allergies/example.js
+++ b/exercises/allergies/example.js
@@ -15,7 +15,8 @@ class Allergies {
   }
 
   list() {
-    return possibleAllergies.filter((allergy, i) => this.allergenIndex && 2 ** i);
+    // eslint-disable-next-line no-bitwise
+    return possibleAllergies.filter((allergy, i) => this.allergenIndex & 2 ** i);
   }
 
   allergicTo(food) {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,10 @@
       "import/no-unresolved": "off",
       "import/extensions": "off",
       "import/prefer-default-export": "off",
-      "import/no-default-export": "off"
+      "import/no-default-export": "off",
+      "no-bitwise": ["error", {
+        "allow": ["^", "|", "&", "<<", ">>", ">>>", "^=", "|=", "&=", "<<=", ">>=", ">>>=", "~"]
+      }]
     }
   },
   "license": "MIT",


### PR DESCRIPTION
Fixed ESLint errors for Allergies exercise (part of issue #480)

In detail:
- Fixed linting errors in example.js
- Removed allergies, bowling and change from .eslintignore

[Change was previously fixed by me, but I forgot to remove it from .eslintignore](https://github.com/exercism/javascript/commit/d5dfacb7bf78eedcb46be9028743decae7b194ab)
I did an `$ npm run lint` in bowling and it passed, so I'm guessing the same happened there but for someone else (which is why I removed it as well)
Allergies passes the linting test, *but only because I put a directive comment before a line using the bitwise AND operator.*

Imho, bitwise operators should be allowed so I can remove the comment completely. It might be confusing for beginners seeing the comment, and frustrating for more advanced users not to be able to use bitwise operators freely. I'll write a comment about this in #480 