### PR TITLE
Acronym: change default export to named export

### DIFF
--- a/exercises/acronym/acronym.spec.js
+++ b/exercises/acronym/acronym.spec.js
@@ -1,27 +1,27 @@
-import Acronyms from './acronym';
+import { parse } from './acronym';
 
 describe('Acronyms are produced from', () => {
   test('title cased phrases', () => {
-    expect(Acronyms.parse('Portable Network Graphics')).toEqual('PNG');
+    expect(parse('Portable Network Graphics')).toEqual('PNG');
   });
 
   xtest('other title cased phrases', () => {
-    expect(Acronyms.parse('Ruby on Rails')).toEqual('ROR');
+    expect(parse('Ruby on Rails')).toEqual('ROR');
   });
 
   xtest('inconsistently cased phrases', () => {
-    expect(Acronyms.parse('HyperText Markup Language')).toEqual('HTML');
+    expect(parse('HyperText Markup Language')).toEqual('HTML');
   });
 
   xtest('phrases with punctuation', () => {
-    expect(Acronyms.parse('First In, First Out')).toEqual('FIFO');
+    expect(parse('First In, First Out')).toEqual('FIFO');
   });
 
   xtest('other phrases with punctuation', () => {
-    expect(Acronyms.parse('PHP: Hypertext Preprocessor')).toEqual('PHP');
+    expect(parse('PHP: Hypertext Preprocessor')).toEqual('PHP');
   });
 
   xtest('phrases with punctuation and sentence casing', () => {
-    expect(Acronyms.parse('Complementary metal-oxide semiconductor')).toEqual('CMOS');
+    expect(parse('Complementary metal-oxide semiconductor')).toEqual('CMOS');
   });
 });

--- a/exercises/acronym/example.js
+++ b/exercises/acronym/example.js
@@ -1,6 +1,1 @@
-export default class Acronyms {
-  static parse(phrase) {
-    return phrase.match(/[A-Z]+[a-z]*|[a-z]+/g)
-      .reduce((acronym, word) => `${acronym}${word[0]}`, '').toUpperCase();
-  }
-}
+export const parse = phrase => phrase.match(/[A-Z]+[a-z]*|[a-z]+/g).reduce((acronym, word) => `${acronym}${word[0]}`, '').toUpperCase();


### PR DESCRIPTION
per #436, modify acronym exercise:
1. Change default export to named export, along with some linting.
1. Change default import `Acronym` to named import `{ parse }`.
1. Change calls to imported function from `Acronym.parse(input)` to the simpler `parse(input)`.
