### PR TITLE
Isogram: change default export to named export

### DIFF
--- a/exercises/isogram/example.js
+++ b/exercises/isogram/example.js
@@ -1,10 +1,5 @@
-export default class Isogram {
-  constructor(string) {
-    this.string = string.replace(/ |-/g, '');
-  }
-
-  isIsogram() {
-    const uniqueLetters = this.string.toLowerCase().split('').filter((element, index, self) => self.indexOf(element) === index);
-    return uniqueLetters.length === this.string.length;
-  }
-}
+export const isIsogram = (string) => {
+  const stringNoSpaceOrHyphen = string.replace(/ |-/g, '');
+  const uniqueLetters = stringNoSpaceOrHyphen.toLowerCase().split('').filter((element, index, self) => self.indexOf(element) === index);
+  return uniqueLetters.length === stringNoSpaceOrHyphen.length;
+};

--- a/exercises/isogram/isogram.spec.js
+++ b/exercises/isogram/isogram.spec.js
@@ -1,75 +1,51 @@
-import Isogram from './isogram';
+import { isIsogram } from './isogram';
 
 describe('Isogram Test Suite', () => {
   test('empty string', () => {
-    const word = new Isogram('');
-
-    expect(word.isIsogram()).toEqual(true);
+    expect(isIsogram('')).toEqual(true);
   });
 
   xtest('isogram with only lower case characters', () => {
-    const word = new Isogram('isogram');
-
-    expect(word.isIsogram()).toEqual(true);
+    expect(isIsogram('isogram')).toEqual(true);
   });
 
   xtest('word with one duplicated character', () => {
-    const word = new Isogram('eleven');
-
-    expect(word.isIsogram()).toEqual(false);
+    expect(isIsogram('eleven')).toEqual(false);
   });
 
   xtest('word with one duplicated character from the end of the alphabet', () => {
-    const word = new Isogram('zzyzx');
-
-    expect(word.isIsogram()).toEqual(false);
+    expect(isIsogram('zzyzx')).toEqual(false);
   });
 
   xtest('longest reported english isogram', () => {
-    const word = new Isogram('subdermatoglyphic');
-
-    expect(word.isIsogram()).toEqual(true);
+    expect(isIsogram('subdermatoglyphic')).toEqual(true);
   });
 
   xtest('word with duplicated character in mixed case', () => {
-    const word = new Isogram('Alphabet');
-
-    expect(word.isIsogram()).toEqual(false);
+    expect(isIsogram('Alphabet')).toEqual(false);
   });
 
   xtest('word with duplicated character in mixed case, lowercase first', () => {
-    const word = new Isogram('alphAbet');
-
-    expect(word.isIsogram()).toEqual(false);
+    expect(isIsogram('alphAbet')).toEqual(false);
   });
 
   xtest('hypothetical isogrammic word with hyphen', () => {
-    const word = new Isogram('thumbscrew-japingly');
-
-    expect(word.isIsogram()).toEqual(true);
+    expect(isIsogram('thumbscrew-japingly')).toEqual(true);
   });
 
   xtest('isogram with duplicated hyphen', () => {
-    const word = new Isogram('six-year-old');
-
-    expect(word.isIsogram()).toEqual(true);
+    expect(isIsogram('six-year-old')).toEqual(true);
   });
 
   xtest('made-up name that is an isogram', () => {
-    const word = new Isogram('Emily Jung Schwartzkopf');
-
-    expect(word.isIsogram()).toEqual(true);
+    expect(isIsogram('Emily Jung Schwartzkopf')).toEqual(true);
   });
 
   xtest('duplicated character in the middle', () => {
-    const word = new Isogram('accentor');
-
-    expect(word.isIsogram()).toEqual(false);
+    expect(isIsogram('accentor')).toEqual(false);
   });
 
   xtest('same first and last characters', () => {
-    const word = new Isogram('angola');
-
-    expect(word.isIsogram()).toEqual(false);
+    expect(isIsogram('angola')).toEqual(false);
   });
 });


### PR DESCRIPTION
per #436, change `Isogram.isIsogram` to `isIsogram` because named export is
preferred over default export. 

1. Change default export to named export.
1. Change default import `Isogram` to named import `{ isIsogram }`.
1. Change calls to imported function from `new Isogram(input).isIsogram()` to the simpler `isIsogram(input)`.  I changed from class style to just a function to make it easier to consume (i.e. simpler test).

