### PR TITLE
space-age: add test case for reassigning seconds

### DIFF
--- a/exercises/space-age/example.js
+++ b/exercises/space-age/example.js
@@ -12,7 +12,10 @@ const EARTH_TO_OTHER_PLANETS = {
 export class SpaceAge {
   constructor(seconds) {
     this.seconds = seconds;
-    this.earthYears = seconds / 31557600;
+  }
+
+  get earthYears() {
+    return this.seconds / 31557600;
   }
 
   yearsOnPlanet(planet) {

--- a/exercises/space-age/space-age.spec.js
+++ b/exercises/space-age/space-age.spec.js
@@ -52,4 +52,10 @@ describe('Space Age', () => {
     expect(age.onEarth()).toEqual(260.16);
     expect(age.onNeptune()).toEqual(1.58);
   });
+
+  test('reassigning seconds', () => {
+    const age = new SpaceAge(1000000);
+    age.seconds = 3210123456;
+    expect(age.onEarth()).toEqual(101.72);
+  });
 });


### PR DESCRIPTION
The example exposes two properties but breaks if those properties are reassigned. I think that's bad practise. If you expose properties you should expect them to be changed. However, if somebody changes `earthYears`, `seconds` won't adapt and if somebody changes `seconds`, `earthYears` and therefore all the methods won't adapt.

There are two solutions for this issue: Either change the example so it doesn't expose any properties or to expose the `seconds` property and make the `earthYears` property a getter. I did the latter and added a test that ensures that the `seconds` parameter can be changed without breaking the module.