### PR TITLE
Lint robot-simulator exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -38,7 +38,6 @@ queen-attack
 rational-numbers
 rectangles
 robot-name
-robot-simulator
 roman-numerals
 rotational-cipher
 run-length-encoding

--- a/exercises/robot-simulator/example.js
+++ b/exercises/robot-simulator/example.js
@@ -61,14 +61,17 @@ class Robot {
     }
   }
 
-  instructions(s) {
+  static instructions(s) {
     return [...s].map((character) => {
-      if (character === 'L') {
-        return 'turnLeft';
-      } else if (character === 'R') {
-        return 'turnRight';
-      } else if (character === 'A') {
-        return 'advance';
+      switch (character) {
+        case 'L':
+          return 'turnLeft';
+        case 'R':
+          return 'turnRight';
+        case 'A':
+          return 'advance';
+        default:
+          throw new InvalidInputError(`${character} is not a valid instruction character.`);
       }
     });
   }
@@ -79,13 +82,11 @@ class Robot {
   }
 
   evaluate(s) {
-    this.instructions(s).forEach((instruction) => {
+    Robot.instructions(s).forEach((instruction) => {
       this[instruction]();
     });
   }
-
 }
 
 
 export default Robot;
-

--- a/exercises/robot-simulator/robot-simulator.spec.js
+++ b/exercises/robot-simulator/robot-simulator.spec.js
@@ -1,5 +1,4 @@
-import Robot from './robot-simulator';
-import { InvalidInputError } from './robot-simulator';
+import Robot, { InvalidInputError } from './robot-simulator';
 
 describe('Robot', () => {
   const robot = new Robot();
@@ -105,19 +104,19 @@ describe('Robot', () => {
   });
 
   xtest('instructions for turning left', () => {
-    expect(robot.instructions('L')).toEqual(['turnLeft']);
+    expect(Robot.instructions('L')).toEqual(['turnLeft']);
   });
 
   xtest('instructions for turning right', () => {
-    expect(robot.instructions('R')).toEqual(['turnRight']);
+    expect(Robot.instructions('R')).toEqual(['turnRight']);
   });
 
   xtest('instructions for advancing', () => {
-    expect(robot.instructions('A')).toEqual(['advance']);
+    expect(Robot.instructions('A')).toEqual(['advance']);
   });
 
   xtest('series of instructions', () => {
-    expect(robot.instructions('RAAL'))
+    expect(Robot.instructions('RAAL'))
       .toEqual(['turnRight', 'advance', 'advance', 'turnLeft']);
   });
 


### PR DESCRIPTION
Per #480, this fixes the following errors on the robot-simulator exercise:

```
.../javascript/exercises/robot-simulator/example.js
  64:15  error  Expected 'this' to be used by class method 'instructions'  class-methods-use-this
  65:35  error  Expected to return a value at the end of arrow function    array-callback-return
  65:35  error  Expected to return a value at the end of arrow function    consistent-return
  68:14  error  Unnecessary 'else' after 'return'                          no-else-return
  87:1   error  Block must not be padded by blank lines                    padded-blocks
  91:1   error  Too many blank lines at the end of file. Max of 0 allowed  no-multiple-empty-lines

.../javascript/exercises/robot-simulator/robot-simulator.spec.js
  1:19  error  './robot-simulator' imported multiple times  import/no-duplicates
  2:35  error  './robot-simulator' imported multiple times  import/no-duplicates
```