### PR TITLE
Lint robot-name exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -37,7 +37,6 @@ pythagorean-triplet
 queen-attack
 rational-numbers
 rectangles
-robot-name
 robot-simulator
 roman-numerals
 rotational-cipher

--- a/exercises/robot-name/example.js
+++ b/exercises/robot-name/example.js
@@ -1,6 +1,6 @@
-const ALPHA = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
-  BASE = 10,
-  usedNames = {};
+const ALPHA = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const BASE = 10;
+const usedNames = {};
 
 const random = max => Math.floor(Math.random() * max);
 
@@ -8,7 +8,8 @@ const generateName = () => {
   let name = ALPHA.charAt(random(ALPHA.length))
     + ALPHA.charAt(random(ALPHA.length))
     + random(BASE) + random(BASE) + random(BASE);
-  usedNames[name] ? name = generateName() : usedNames[name] = true;
+  if (usedNames[name]) name = generateName();
+  else usedNames[name] = true;
   return name;
 };
 

--- a/exercises/robot-name/robot-name.spec.js
+++ b/exercises/robot-name/robot-name.spec.js
@@ -1,5 +1,20 @@
 import Robot from './robot-name';
 
+const areSequential = (name1, name2) => {
+  const alpha1 = name1.substr(0, 2);
+  const alpha2 = name2.substr(0, 2);
+  const num1 = +name1.substr(2, 3);
+  const num2 = +name2.substr(2, 3);
+
+  const numDiff = num2 - num1;
+  const alphaDiff = (alpha2.charCodeAt(0) - alpha1.charCodeAt(0)) * 26
+    + (alpha2.charCodeAt(1) - alpha1.charCodeAt(1));
+
+  const totalDiff = alphaDiff * 1000 + numDiff;
+
+  return Math.abs(totalDiff) <= 1;
+};
+
 describe('Robot', () => {
   let robot;
 
@@ -35,7 +50,7 @@ describe('Robot', () => {
     const usedNames = new Set();
 
     usedNames.add(robot.name);
-    for (let i = 0; i < NUMBER_OF_ROBOTS; i++) {
+    for (let i = 0; i < NUMBER_OF_ROBOTS; i += 1) {
       robot.reset();
       usedNames.add(robot.name);
     }
@@ -44,7 +59,7 @@ describe('Robot', () => {
   });
 
   xtest('internal name cannot be modified', () => {
-    const modifyInternal = () => robot.name += 'a modification';
+    const modifyInternal = () => { robot.name += 'a modification'; };
     expect(modifyInternal).toThrow();
   });
 
@@ -74,7 +89,7 @@ describe('Robot', () => {
     const NUMBER_OF_ROBOTS = 10000;
     const usedNames = new Set();
 
-    for (let i = 0; i < NUMBER_OF_ROBOTS; i++) {
+    for (let i = 0; i < NUMBER_OF_ROBOTS; i += 1) {
       const newRobot = new Robot();
       usedNames.add(newRobot.name);
     }
@@ -82,18 +97,3 @@ describe('Robot', () => {
     expect(usedNames.size).toEqual(NUMBER_OF_ROBOTS);
   });
 });
-
-const areSequential = (name1, name2) => {
-  const alpha1 = name1.substr(0, 2);
-  const alpha2 = name2.substr(0, 2);
-  const num1 = +name1.substr(2, 3);
-  const num2 = +name2.substr(2, 3);
-
-  const numDiff = num2 - num1;
-  const alphaDiff = (alpha2.charCodeAt(0) - alpha1.charCodeAt(0)) * 26
-    + (alpha2.charCodeAt(1) - alpha1.charCodeAt(1));
-
-  const totalDiff = alphaDiff * 1000 + numDiff;
-
-  return Math.abs(totalDiff) <= 1;
-};


### PR DESCRIPTION
Per #480, it fixes the following errors on the robot-name exercise:

```
.../javascript/exercises/robot-name/example.js
   1:1  error  Split 'const' declarations into multiple statements                    one-var
  11:3  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions

.../javascript/exercises/robot-name/robot-name.spec.js
  38:43  error  Unary operator '++' used                        no-plusplus
  47:28  error  Arrow function should not return assignment     no-return-assign
  56:12  error  'areSequential' was used before it was defined  no-use-before-define
  57:12  error  'areSequential' was used before it was defined  no-use-before-define
  58:12  error  'areSequential' was used before it was defined  no-use-before-define
  67:12  error  'areSequential' was used before it was defined  no-use-before-define
  68:12  error  'areSequential' was used before it was defined  no-use-before-define
  69:12  error  'areSequential' was used before it was defined  no-use-before-define
  77:43  error  Unary operator '++' used                        no-plusplus
```