### PR TITLE
Lint scrabble-score exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -44,7 +44,6 @@ rotational-cipher
 run-length-encoding
 saddle-points
 say
-scrabble-score
 secret-handshake
 series
 spiral-matrix

--- a/exercises/scrabble-score/example.js
+++ b/exercises/scrabble-score/example.js
@@ -29,16 +29,5 @@ const letterScores = {
 
 const letterScore = letter => letterScores[letter] || 0;
 
-export default (word) => {
-  word = word ? word.toLowerCase() : '';
-
-  let sum = 0;
-  let idx = -1;
-  const end = word.length;
-
-  while (++idx < end) {
-    sum += letterScore(word[idx]);
-  }
-
-  return sum;
-};
+export default word => [...word.toLowerCase()]
+  .reduce((sum, currChar) => sum + letterScore(currChar), 0);

--- a/exercises/scrabble-score/scrabble-score.spec.js
+++ b/exercises/scrabble-score/scrabble-score.spec.js
@@ -1,49 +1,47 @@
 import score from './scrabble-score';
 
 describe('Scrabble', () => {
-
-  test('lowercase letter', () => { 
-    expect(score('a')).toEqual(1)
+  test('lowercase letter', () => {
+    expect(score('a')).toEqual(1);
   });
 
-  xtest('uppercase letter', () => { 
-    expect(score('A')).toEqual(1)
+  xtest('uppercase letter', () => {
+    expect(score('A')).toEqual(1);
   });
 
-  xtest('valuable letter', () => { 
-    expect(score('f')).toEqual(4)
+  xtest('valuable letter', () => {
+    expect(score('f')).toEqual(4);
   });
 
-  xtest('short word', () => { 
-    expect(score('at')).toEqual(2)
+  xtest('short word', () => {
+    expect(score('at')).toEqual(2);
   });
 
-  xtest('short, valuable word', () => { 
-    expect(score('zoo')).toEqual(12)
+  xtest('short, valuable word', () => {
+    expect(score('zoo')).toEqual(12);
   });
 
-  xtest('medium word', () => { 
-    expect(score('street')).toEqual(6)
+  xtest('medium word', () => {
+    expect(score('street')).toEqual(6);
   });
 
-  xtest('medium, valuable word', () => { 
-    expect(score('quirky')).toEqual(22)
+  xtest('medium, valuable word', () => {
+    expect(score('quirky')).toEqual(22);
   });
 
-  xtest('long, mixed-case word', () => { 
-    expect(score('OxyphenButazone')).toEqual(41)
+  xtest('long, mixed-case word', () => {
+    expect(score('OxyphenButazone')).toEqual(41);
   });
 
-  xtest('english-like word', () => { 
-    expect(score('pinata')).toEqual(8)
+  xtest('english-like word', () => {
+    expect(score('pinata')).toEqual(8);
   });
 
-  xtest('empty input', () => { 
-    expect(score('')).toEqual(0)
+  xtest('empty input', () => {
+    expect(score('')).toEqual(0);
   });
 
-  xtest('entire alphabet available', () => { 
-    expect(score('abcdefghijklmnopqrstuvwxyz')).toEqual(87)
+  xtest('entire alphabet available', () => {
+    expect(score('abcdefghijklmnopqrstuvwxyz')).toEqual(87);
   });
-
 });


### PR DESCRIPTION
Per #480, it fixes the following errors on the scrabble-score exercise:

```
.../javascript/exercises/scrabble-score/example.js
  33:3   error  Assignment to function parameter 'word'  no-param-reassign
  39:10  error  Unary operator '++' used                 no-plusplus

.../javascript/exercises/scrabble-score/scrabble-score.spec.js
   3:28  error  Block must not be padded by blank lines  padded-blocks
   5:35  error  Trailing spaces not allowed              no-trailing-spaces
   6:34  error  Missing semicolon                        semi
   9:36  error  Trailing spaces not allowed              no-trailing-spaces
  10:34  error  Missing semicolon                        semi
  13:35  error  Trailing spaces not allowed              no-trailing-spaces
  14:34  error  Missing semicolon                        semi
  17:30  error  Trailing spaces not allowed              no-trailing-spaces
  18:35  error  Missing semicolon                        semi
  21:40  error  Trailing spaces not allowed              no-trailing-spaces
  22:37  error  Missing semicolon                        semi
  25:31  error  Trailing spaces not allowed              no-trailing-spaces
  26:39  error  Missing semicolon                        semi
  29:41  error  Trailing spaces not allowed              no-trailing-spaces
  30:40  error  Missing semicolon                        semi
  33:41  error  Trailing spaces not allowed              no-trailing-spaces
  34:49  error  Missing semicolon                        semi
  37:37  error  Trailing spaces not allowed              no-trailing-spaces
  38:39  error  Missing semicolon                        semi
  41:31  error  Trailing spaces not allowed              no-trailing-spaces
  42:33  error  Missing semicolon                        semi
  45:45  error  Trailing spaces not allowed              no-trailing-spaces
  46:60  error  Missing semicolon                        semi
  49:1   error  Block must not be padded by blank lines  padded-blocks
```