### PR TITLE
lint exercises: bowling, change, circular-buffer

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,8 +1,5 @@
 allergies
 alphametics
-bowling
-change
-circular-buffer
 clock
 complex-numbers
 connect

--- a/exercises/circular-buffer/circular-buffer.spec.js
+++ b/exercises/circular-buffer/circular-buffer.spec.js
@@ -1,5 +1,4 @@
-import circularBuffer from './circular-buffer';
-import { BufferFullError, BufferEmptyError } from './circular-buffer';
+import circularBuffer, { BufferFullError, BufferEmptyError } from './circular-buffer';
 
 describe('CircularBuffer', () => {
   test('reading an empty buffer throws a BufferEmptyError', () => {

--- a/exercises/circular-buffer/example.js
+++ b/exercises/circular-buffer/example.js
@@ -1,5 +1,5 @@
-let buffer,
-  bufferMax;
+let buffer;
+let bufferMax;
 
 export class BufferEmptyError extends Error {
   constructor(message) {
@@ -25,7 +25,7 @@ const write = (value) => {
   if (buffer.length === bufferMax) {
     throw new BufferFullError();
   }
-  value ? buffer.push(value) : null;
+  return value ? buffer.push(value) : null;
 };
 
 const forceWrite = (value) => {
@@ -35,7 +35,10 @@ const forceWrite = (value) => {
   write(value);
 };
 
-const clear = () => buffer = [];
+const clear = () => {
+  buffer = [];
+  return buffer;
+};
 
 const CircularBuffer = (capacity) => {
   buffer = [];


### PR DESCRIPTION
For issue #480 

Fixes the following lint errors in the circular-buffer exercise:
```
javascript/exercises/circular-buffer/circular-buffer.spec.js
  1:28  error  './circular-buffer' imported multiple times  import/no-duplicates
  2:51  error  './circular-buffer' imported multiple times  import/no-duplicates

javascript/exercises/circular-buffer/example.js
   1:1   error  Split 'let' declarations into multiple statements                      one-var
  28:3   error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
  38:15  error  Arrow function should not return assignment                            no-return-assign
```

Also removes the bowling and change exercises from `.eslintignore`, but they did not actually cause any lint errors.

Thanks for your time!