### PR TITLE
Lint fixes for exercises: complex-numbers, etl, gigasecond

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,6 @@
 allergies
 alphametics
 clock
-complex-numbers
 connect
 diamond
 difference-of-squares

--- a/.eslintignore
+++ b/.eslintignore
@@ -7,7 +7,6 @@ difference-of-squares
 flatten-array
 food-chain
 forth
-gigasecond
 grade-school
 grains
 hexadecimal

--- a/.eslintignore
+++ b/.eslintignore
@@ -4,7 +4,6 @@ clock
 connect
 diamond
 difference-of-squares
-etl
 flatten-array
 food-chain
 forth

--- a/exercises/complex-numbers/complex-numbers.spec.js
+++ b/exercises/complex-numbers/complex-numbers.spec.js
@@ -42,7 +42,7 @@ describe('Complex numbers', () => {
 
     expect(actual).toEqual(expected);
   });
-  
+
   xtest('Add purely real numbers', () => {
     const expected = new ComplexNumber(3, 0);
     const actual = new ComplexNumber(1, 0).add(new ComplexNumber(2, 0));

--- a/exercises/complex-numbers/example.js
+++ b/exercises/complex-numbers/example.js
@@ -1,5 +1,4 @@
 export default class ComplexNumber {
-
   constructor(real, imag) {
     this.real = real;
     this.imag = imag;
@@ -16,7 +15,8 @@ export default class ComplexNumber {
   mul(other) {
     return new ComplexNumber(
       (this.real * other.real) - (this.imag * other.imag),
-      (this.imag * other.real) + (this.real * other.imag));
+      (this.imag * other.real) + (this.real * other.imag),
+    );
   }
 
   div(other) {
@@ -24,7 +24,8 @@ export default class ComplexNumber {
       ((this.real * other.real) + (this.imag * other.imag))
       / ((other.real * other.real) + (other.imag * other.imag)),
       ((this.imag * other.real) - (this.real * other.imag))
-      / ((other.real * other.real) + (other.imag * other.imag)));
+      / ((other.real * other.real) + (other.imag * other.imag)),
+    );
   }
 
   get abs() {
@@ -38,6 +39,7 @@ export default class ComplexNumber {
   get exp() {
     return new ComplexNumber(
       Math.exp(this.real) * Math.cos(this.imag),
-      Math.exp(this.real) * Math.sin(this.imag));
+      Math.exp(this.real) * Math.sin(this.imag),
+    );
   }
 }

--- a/exercises/etl/etl.spec.js
+++ b/exercises/etl/etl.spec.js
@@ -10,14 +10,18 @@ describe('Transform', () => {
 
   xtest('transforms more values', () => {
     const old = { 1: ['A', 'E', 'I', 'O', 'U'] };
-    const expected = { a: 1, e: 1, i: 1, o: 1, u: 1 };
+    const expected = {
+      a: 1, e: 1, i: 1, o: 1, u: 1,
+    };
 
     expect(transform(old)).toEqual(expected);
   });
 
   xtest('transforms more keys', () => {
     const old = { 1: ['A', 'E'], 2: ['D', 'G'] };
-    const expected = { a: 1, e: 1, d: 2, g: 2 };
+    const expected = {
+      a: 1, e: 1, d: 2, g: 2,
+    };
 
     expect(transform(old)).toEqual(expected);
   });

--- a/exercises/gigasecond/example.js
+++ b/exercises/gigasecond/example.js
@@ -1,6 +1,6 @@
-const GIGASECOND_IN_MILIS = 1e9 * 1e3;
+const GIGASECOND_IN_MILLIS = 1e9 * 1e3;
 
-export const gigasecond = dateOfBirth => {
+export const gigasecond = (dateOfBirth) => {
   const birthTime = dateOfBirth.getTime();
-  return new Date(birthTime + GIGASECOND_IN_MILIS);
-}
+  return new Date(birthTime + GIGASECOND_IN_MILLIS);
+};


### PR DESCRIPTION
For issue #480 

Bundled up a few simple ESLint fixes in one convenient PR.

complex-numbers:
```
javascript/exercises/complex-numbers/complex-numbers.spec.js
  45:1  error  Trailing spaces not allowed  no-trailing-spaces

javascript/exercises/complex-numbers/example.js
   1:36  error  Block must not be padded by blank lines  padded-blocks
  19:58  error  Expected newline before ')'              function-paren-newline
  27:64  error  Expected newline before ')'              function-paren-newline
  41:48  error  Expected newline before ')'              function-paren-newline
```

etl:
(I actually don't love these changes, but they make ESLint happy)
```
javascript/exercises/etl/etl.spec.js
  13:22  error  Expected a line break after this opening brace   object-curly-newline
  13:53  error  Expected a line break before this closing brace  object-curly-newline
  20:22  error  Expected a line break after this opening brace   object-curly-newline
  20:47  error  Expected a line break before this closing brace  object-curly-newline
```

gigasecond:
```
javascript/exercises/gigasecond/example.js
  3:27  error  Expected parentheses around arrow function argument having a body with curly braces  arrow-parens
  6:2   error  Missing semicolon                                                                    semi
```

Happy to squash this into one commit if deemed appropriate.

Thank you for your time!