### PR TITLE
lint phone-number exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -26,7 +26,6 @@ nth-prime
 ocr-numbers
 palindrome-products
 perfect-numbers
-phone-number
 point-mutations
 prime-factors
 proverb

--- a/exercises/phone-number/example.js
+++ b/exercises/phone-number/example.js
@@ -1,5 +1,4 @@
 export default class PhoneNumber {
-
   constructor(number) {
     this.rawNumber = number;
   }
@@ -9,10 +8,10 @@ export default class PhoneNumber {
       return null;
     }
 
-    return this._cleanedNumber();
+    return this.cleanedNumber();
   }
 
-  _cleanedNumber() {
+  cleanedNumber() {
     const num = this.rawNumber.replace(/\D/g, '');
 
     if (num.length === 10 && num[0] >= 2 && num[3] >= 2) {

--- a/exercises/phone-number/phone-number.spec.js
+++ b/exercises/phone-number/phone-number.spec.js
@@ -65,8 +65,8 @@ describe('PhoneNumber()', () => {
     expect(phone2.number()).toEqual(null);
   });
 
-  xtest('invalid when 11 digits starting with 1, ' +
-  'but invalid area/exchange code first digits', () => {
+  xtest('invalid when 11 digits starting with 1, '
+  + 'but invalid area/exchange code first digits', () => {
     const phone1 = new PhoneNumber('1 (023) 456-7890');
     const phone2 = new PhoneNumber('1 (123) 456-7890');
     const phone3 = new PhoneNumber('1 (223) 056-7890');


### PR DESCRIPTION
Hey, first time contributing here! This corrects the eslint error for the `phone-number` exercise: 

Biggest change I see is that the lint rules do not like the leading `_` for indicating private methods. 

```
/javascript/exercises/phone-number/example.js
   1:34  error  Block must not be padded by blank lines      padded-blocks
  12:12  error  Unexpected dangling '_' in '_cleanedNumber'  no-underscore-dangle

/javascript/exercises/phone-number/phone-number.spec.js
  68:53  error  '+' should be placed at the beginning of the line  operator-linebreak
```