### PR TITLE
lint run-length-encoding exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -32,7 +32,6 @@ rational-numbers
 rectangles
 roman-numerals
 rotational-cipher
-run-length-encoding
 saddle-points
 say
 secret-handshake

--- a/exercises/run-length-encoding/example.js
+++ b/exercises/run-length-encoding/example.js
@@ -2,7 +2,7 @@
 export const encode = (plainText) => {
   const consecutiveChars = /([\w\s])\1*/g;
   return plainText.replace(consecutiveChars,
-      match => (match.length > 1 ? match.length + match[0] : match[0]));
+    match => (match.length > 1 ? match.length + match[0] : match[0]));
 };
 
 


### PR DESCRIPTION
Per #480, fix the following lint errors for the run-length-encoding exercise:
```
/home/eric/code/javascript/exercises/run-length-encoding/example.js
  5:1  error  Expected indentation of 4 spaces but found 6  indent
```
