### PR TITLE
lint roman numerals exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -30,7 +30,6 @@ pythagorean-triplet
 queen-attack
 rational-numbers
 rectangles
-roman-numerals
 rotational-cipher
 saddle-points
 say

--- a/exercises/roman-numerals/example.js
+++ b/exercises/roman-numerals/example.js
@@ -1,5 +1,6 @@
 function toRoman(number) {
   let result = '';
+  let remainingNumber = number;
   const mappings = [
     { arabic: 1000, roman: 'M' },
     { arabic: 900, roman: 'CM' },
@@ -17,9 +18,9 @@ function toRoman(number) {
   ];
 
   mappings.forEach((mapping) => {
-    while (number >= mapping.arabic) {
+    while (remainingNumber >= mapping.arabic) {
       result += mapping.roman;
-      number -= mapping.arabic;
+      remainingNumber -= mapping.arabic;
     }
   });
 


### PR DESCRIPTION
Per #480, fix the following lint errors for the roman-numerals exercise:
```
/home/eric/code/javascript/exercises/roman-numerals/example.js
  22:7  error  Assignment to function parameter 'number'  no-param-reassign
```

