### PR TITLE
Update example and tests for simple-linked-list

### DIFF
--- a/exercises/simple-linked-list/example.js
+++ b/exercises/simple-linked-list/example.js
@@ -1,111 +1,45 @@
-export class ElementValueRequiredException extends Error {}
-export class ElementNextNotInstanceException extends Error {}
-
 export class Element {
-  constructor(value, next) {
-    if (value === undefined) {
-      throw new ElementValueRequiredException();
-    }
-
-    if (next !== undefined && !(next instanceof Element)) {
-      throw new ElementNextNotInstanceException();
-    }
-
+  constructor(value) {
     this.value = value;
-    this.next = next;
+    this.next = null;
   }
 }
 
 export class List {
-  static fromArray(array) {
-    const list = new List();
-    array.forEach(item => list.push(new Element(item)));
-
-    return list;
-  }
-
-  push(value) {
-    const newEl = (value instanceof Element)
-      ? value
-      : new Element(value);
-
-    if (!this.head) {
-      this.head = newEl;
-      return;
-    }
-
-    let lastEl = this.head;
-    while (lastEl.next) {
-      lastEl = lastEl.next;
-    }
-
-    lastEl.next = newEl;
-  }
-
-  unshift(value) {
-    const newEl = (value instanceof Element)
-      ? value
-      : new Element(value);
-
-    newEl.next = this.head;
-    this.head = newEl;
-  }
-
-  shift() {
-    if (!this.head) {
-      return;
-    }
-
-    this.head = this.head.next;
-  }
-
-  pop() {
-    if (!this.head) {
-      return;
-    }
-
-    let penultEl;
-    let lastEl = this.head;
-
-    while (lastEl.next) {
-      penultEl = lastEl;
-      lastEl = lastEl.next;
-    }
-
-    if (!penultEl) {
-      this.head = undefined;
-    } else {
-      penultEl.next = undefined;
+  constructor(arr) {
+    this.head = null;
+    if (arr) {
+      arr.forEach(el => this.add(new Element(el)));
     }
   }
 
-  reverse() {
-    if (!this.head) {
-      return;
-    }
-
-    let current;
-    let previous;
-
-    while (this.head) {
-      current = this.head;
-      this.shift();
-      current.next = previous;
-      previous = current;
-    }
-
-    this.head = previous;
+  get length() {
+    return this.head ? this.countElements(1, this.head) : 0;
   }
 
-  toArray() {
-    const array = [];
-    let current = this.head;
+  add(el) {
+    const element = el;
+    element.next = this.head;
+    this.head = element;
+  }
 
-    while (current) {
-      array.push(current.value);
-      current = current.next;
+  countElements(count, element) {
+    return element.next ? this.countElements(count + 1, element.next) : count;
+  }
+
+  toArray(arr = [], element = this.head) {
+    arr.push(element.value);
+    return element && element.next ? this.toArray(arr, element.next) : arr;
+  }
+
+  reverse(prev = null) {
+    if (this.head.next) {
+      const current = this.head;
+      this.head = this.head.next;
+      current.next = prev;
+      return this.reverse(current);
     }
-
-    return array;
+    this.head.next = prev;
+    return this;
   }
 }

--- a/exercises/simple-linked-list/simple-linked-list.spec.js
+++ b/exercises/simple-linked-list/simple-linked-list.spec.js
@@ -1,146 +1,122 @@
-import {
-  List,
-  Element,
-  ElementValueRequiredException,
-  ElementNextNotInstanceException,
-} from './simple-linked-list';
+import { List, Element } from './simple-linked-list';
 
-describe('simple-linked-list', () => {
-  test('exports a List constructor', () => {
-    expect(List).toBeDefined();
+describe('Element class', () => {
+  test('has constructor', () => {
+    const element = new Element(1);
+    expect(element.value).toEqual(1);
   });
-
-  xtest('exports a Element constructor', () => {
-    expect(Element).toBeDefined();
+  xtest('value reflects constructor arg', () => {
+    const element = new Element(2);
+    expect(element.value).toEqual(2);
   });
-
-  describe('Element', () => {
-    xtest('is a constructor', () => {
-      const el = new Element(1);
-      expect(el).toBeDefined();
-
-      expect(() => {
-        Element(1);
-      }).toThrow();
-    });
-
-    xtest('requires an argument', () => {
-      const el = new Element(1);
-      expect(el).toBeDefined();
-
-      expect(() => new Element()).toThrow(ElementValueRequiredException);
-    });
-
-    xtest('has as a value', () => {
-      const el = new Element(1);
-      expect(el.value).toBe(1);
-    });
-
-    xtest('reference to next is undefined by default', () => {
-      const el = new Element(1);
-      expect(el.next).toBeUndefined();
-    });
+  xtest('has null for next by default', () => {
+    const element = new Element(1);
+    expect(element.next).toEqual(null);
   });
+});
 
-  xtest('accepts a reference to the next element', () => {
-    const elOne = new Element(1);
-    const elTwo = new Element(2, elOne);
-    expect(elTwo.next).toBe(elOne);
+describe('List class', () => {
+  xtest('has constructor', () => {
+    const list = new List();
+    expect(list).toBeDefined();
   });
-
-  xtest('requires an instance of Element as next element', () => {
-    expect(() => new Element(1, true)).toThrow(ElementNextNotInstanceException);
-    expect(() => new Element(1, 'lorem ipsum')).toThrow(ElementNextNotInstanceException);
-    expect(() => new Element(1, [])).toThrow(ElementNextNotInstanceException);
-    expect(() => new Element(1, {})).toThrow(ElementNextNotInstanceException);
+  xtest('new lists should have length 0', () => {
+    const list = new List();
+    expect(list.length).toEqual(0);
   });
+  xtest('can add a element', () => {
+    const list = new List();
+    const element = new Element(1);
+    expect(() => list.add(element)).not.toThrow();
+  });
+  xtest('adding a element increments length', () => {
+    const list = new List();
+    const element = new Element(1);
+    list.add(element);
+    expect(list.length).toEqual(1);
+  });
+  xtest('adding two elements increments twice', () => {
+    const list = new List();
+    const element1 = new Element(1);
+    const element2 = new Element(3);
+    list.add(element1);
+    list.add(element2);
+    expect(list.length).toEqual(2);
+  });
+  xtest('new Lists have a null head element', () => {
+    const list = new List();
+    expect(list.head).toEqual(null);
+  });
+  xtest('adding an Element to an empty list sets the head Element', () => {
+    const list = new List();
+    const element = new Element(1);
+    list.add(element);
+    expect(list.head.value).toEqual(1);
+  });
+  xtest('adding a second Element updates the head Element', () => {
+    const list = new List();
+    const element1 = new Element(1);
+    const element2 = new Element(3);
+    list.add(element1);
+    list.add(element2);
+    expect(list.head.value).toEqual(3);
+  });
+  xtest('can get the next Element from the head', () => {
+    const list = new List();
+    const element1 = new Element(1);
+    const element2 = new Element(3);
+    list.add(element1);
+    list.add(element2);
+    expect(list.head.next.value).toEqual(1);
+  });
+  xtest('can be initialized with an array', () => {
+    const list = new List([1, 2, 3]);
+    expect(list.length).toEqual(3);
+    expect(list.head.value).toEqual(3);
+  });
+});
 
-  describe('List', () => {
-    xtest('is a constructor', () => {
-      const ll = new List();
-      expect(ll).toBeDefined();
-    });
-
-    xtest('allows you to append an element', () => {
-      const ll = new List();
-      const el = new Element(1);
-      ll.push(el);
-      expect(ll.head).toBe(el);
-
-      const ll2 = new List();
-      const elOne = new Element(1);
-      const elTwo = new Element(2);
-      ll2.push(elOne);
-      ll2.push(elTwo);
-      expect(ll2.head.next).toBe(elTwo);
-    });
-
-    xtest('allows you to prepend an element', () => {
-      const ll = new List();
-      const el = new Element(1);
-      ll.unshift(el);
-      expect(ll.head).toBe(el);
-
-      const ll2 = new List();
-      const elOne = new Element(1);
-      const elTwo = new Element(2);
-      ll2.unshift(elOne);
-      ll2.unshift(elTwo);
-      expect(ll2.head).toBe(elTwo);
-    });
-
-    xtest('allows you to remove the first element', () => {
-      const ll = new List();
-      ll.push(new Element(1));
-      ll.shift();
-      expect(ll.head).toBeUndefined();
-
-      ll.push(new Element(2));
-      ll.push(new Element(3));
-      ll.shift();
-      expect(ll.head.value).toBe(3);
-    });
-
-    xtest('allows you to remove the last element', () => {
-      const ll = new List();
-      ll.push(new Element(1));
-      ll.pop();
-      expect(ll.head).toBeUndefined();
-
-      ll.push(new Element(2));
-      ll.push(new Element(3));
-      ll.pop();
-      expect(ll.head.next).toBeUndefined();
-    });
-
-    xtest('allows you to convert an array to a List', () => {
-      const ll = List.fromArray([1, 2]);
-
-      expect(ll.head.value).toBe(1);
-      expect(ll.head.next.value).toBe(2);
-    });
-
-    xtest('allows you to convert a List into an array', () => {
-      const ll = new List();
-      ll.push(new Element(1));
-      ll.push(new Element(2));
-      const a = ll.toArray();
-
-      expect(a instanceof Array).toBe(true);
-      expect(a.length).toBe(2);
-      expect(a[0]).toBe(1);
-      expect(a[1]).toBe(2);
-
-      expect(ll.head.value).toBe(1);
-    });
-
-    xtest('allows you to reverse a List', () => {
-      const ll = List.fromArray([1, 2, 3]);
-      ll.reverse();
-
-      expect(ll.head.value).toBe(3);
-      expect(ll.head.next.value).toBe(2);
-      expect(ll.head.next.next.value).toBe(1);
-    });
+describe('Lists with multiple elements', () => {
+  let list;
+  beforeEach(() => {
+    list = new List([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+  xtest('with correct length', () => {
+    expect(list.length).toEqual(10);
+  });
+  xtest('with correct head value', () => {
+    expect(list.head.value).toEqual(10);
+  });
+  xtest('can traverse the list', () => {
+    expect(list.head.next.next.next.value).toEqual(7);
+  });
+  xtest('can convert to an array', () => {
+    const oneList = new List([1]);
+    expect(oneList.toArray()).toEqual([1]);
+  });
+  xtest('head of list is final element from input array', () => {
+    const twoList = new List([1, 2]);
+    expect(twoList.head.value).toEqual(2);
+  });
+  xtest('can convert to an array', () => {
+    const oneList = new List([1]);
+    expect(oneList.toArray()).toEqual([1]);
+  });
+  xtest('can convert longer list to an array', () => {
+    expect(list.toArray()).toEqual([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+  });
+  xtest('can be reversed', () => {
+    const twoList = new List([1, 2]);
+    expect(twoList.reverse().toArray()).toEqual([1, 2]);
+  });
+  xtest('can be reversed when it has more elements', () => {
+    const threeList = new List([1, 2, 3]);
+    expect(threeList.reverse().toArray()).toEqual([1, 2, 3]);
+  });
+  xtest('can reverse with many elements', () => {
+    expect(list.reverse().toArray()).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+  xtest('can reverse a reversal', () => {
+    expect(list.reverse().reverse().toArray()).toEqual([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
   });
 });


### PR DESCRIPTION
This exercise was implemented in a way that really deviated from the README in the problem-specifications repo.

The README is very simple in its requirements:
1. Implement List and Element classes.
2. Implement the List class so that it can:
a) be reversed
b) return an array of element values
c) accept an array as initial data

There's nothing about `pop`, `shift`, etc. The existing implementation is relatively complicated compared to these requirements, as is the test suite, which requires validation that isn't specified in the metadata.

This exercise is already a bit of a mind-bender without all the extra complications-- let's make it simpler by focusing on the core problem.  There are two other exercises that focus on list implementations, so I think we're pretty well covered here.