### PR TITLE
Clean up extraneous blank lines

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,13 +10,11 @@ forth
 grade-school
 grains
 hexadecimal
-isbn-verifier
 kindergarten-garden
 largest-series-product
 linked-list
 list-ops
 luhn
-matrix
 meetup
 minesweeper
 nth-prime

--- a/exercises/allergies/example.js
+++ b/exercises/allergies/example.js
@@ -24,4 +24,3 @@ class Allergies {
 }
 
 export default Allergies;
-

--- a/exercises/connect/example.js
+++ b/exercises/connect/example.js
@@ -66,4 +66,3 @@ export default class {
     return this.board[x] !== undefined && this.board[x][y] === XorO;
   }
 }
-

--- a/exercises/difference-of-squares/difference-of-squares.spec.js
+++ b/exercises/difference-of-squares/difference-of-squares.spec.js
@@ -6,7 +6,6 @@ describe('difference-of-squares', () => {
     const squares100 = new Squares(100);
 
   describe('Square the sum of the numbers up to the given number', () => {
-
     xtest('square of sum 1', () => {
       expect(squares1.squareOfSum).toBe(1);
     });
@@ -18,11 +17,9 @@ describe('difference-of-squares', () => {
     xtest('square of sum 100', () => {
       expect(squares100.squareOfSum).toBe(25502500);
     });
-
   });
 
   describe('Sum the squares of the numbers up to the given number', () => {
-
     xtest('sum of squares 1', () => {
       expect(squares1.sumOfSquares).toBe(1);
     });
@@ -34,11 +31,9 @@ describe('difference-of-squares', () => {
     xtest('sum of squares 100', () => {
       expect(squares100.sumOfSquares).toBe(338350);
     });
-
   });
 
   describe('Subtract sum of squares from square of sums', () => {
-
     xtest('difference of squares 1', () => {
       expect(squares1.difference).toBe(0);
     });

--- a/exercises/difference-of-squares/example.js
+++ b/exercises/difference-of-squares/example.js
@@ -1,5 +1,4 @@
 export default class Squares {
-
   constructor(max) {
     this.max = max;
   }
@@ -21,5 +20,4 @@ export default class Squares {
   get difference() {
     return this.squareOfSum - this.sumOfSquares;
   }
-
 }

--- a/exercises/food-chain/example.js
+++ b/exercises/food-chain/example.js
@@ -1,5 +1,4 @@
 export default class Song {
-
   /**
    * @param {Number} number
    * verse number
@@ -89,6 +88,4 @@ She's dead, of course!
     str.push('');
     return str.join('\n');
   }
-
 }
-

--- a/exercises/food-chain/food-chain.spec.js
+++ b/exercises/food-chain/food-chain.spec.js
@@ -169,4 +169,3 @@ She's dead, of course!
     expect(song.verses(1, 8)).toEqual(expected);
   });
 });
-

--- a/exercises/grade-school/example.js
+++ b/exercises/grade-school/example.js
@@ -5,7 +5,6 @@ function clone(obj) {
 
 let db;
 class School {
-
   constructor() {
     db = {};
   }
@@ -21,7 +20,6 @@ class School {
   roster() {
     return clone(db);
   }
-
 }
 
 export default School;

--- a/exercises/grains/example.js
+++ b/exercises/grains/example.js
@@ -7,7 +7,6 @@ import BigInt from './big-integer';
  * square, and doubling with each successive square.
  */
 export default class Grains {
-
   /**
    * Gets the number of grains on the nth square
    *
@@ -34,4 +33,3 @@ export default class Grains {
     return total.toString();
   }
 }
-

--- a/exercises/isbn-verifier/example.js
+++ b/exercises/isbn-verifier/example.js
@@ -1,5 +1,4 @@
 export default class ISBN {
-
   constructor(isbn) {
     this.isbn = isbn.replace(/-/g, '');
   }

--- a/exercises/kindergarten-garden/example.js
+++ b/exercises/kindergarten-garden/example.js
@@ -46,4 +46,3 @@ class Garden {
 }
 
 export default Garden;
-

--- a/exercises/largest-series-product/example.js
+++ b/exercises/largest-series-product/example.js
@@ -1,5 +1,4 @@
 export default class Series {
-
   constructor(numberString) {
     if (numberString.match('[^0-9]')) {
       throw new Error('Invalid input.');

--- a/exercises/list-ops/example.js
+++ b/exercises/list-ops/example.js
@@ -1,5 +1,4 @@
 class List {
-
   constructor(arr) {
     this.values = arr || [];
   }
@@ -71,7 +70,6 @@ class List {
     }
     return this;
   }
-
 }
 
 export default List;

--- a/exercises/luhn/example.js
+++ b/exercises/luhn/example.js
@@ -26,9 +26,7 @@ function isValid(number) {
 }
 
 export default class Luhn {
-
   constructor(number) {
     this.valid = isValid(number);
   }
-
 }

--- a/exercises/matrix/example.js
+++ b/exercises/matrix/example.js
@@ -23,4 +23,3 @@ class Matrix {
 }
 
 export default Matrix;
-

--- a/exercises/matrix/matrix.spec.js
+++ b/exercises/matrix/matrix.spec.js
@@ -1,7 +1,6 @@
 import Matrix from './matrix';
 
 describe('Matrix', () => {
-
   test('extract row from one number matrix', () => {
     expect(new Matrix('1').rows[0]).toEqual([1]);
   });
@@ -33,5 +32,4 @@ describe('Matrix', () => {
   xtest('extract column where numbers have different widths', () => {
     expect(new Matrix('89 1903 3\n18 3 1\n9 4 800').columns[1]).toEqual([1903, 3, 4]);
   });
-
 });

--- a/exercises/minesweeper/example.js
+++ b/exercises/minesweeper/example.js
@@ -30,7 +30,6 @@ function cellToMineOrCount(cell, inputBoard, x, y) {
     return MINE;
   } 
     return countAdjacentMines(inputBoard, x, y) || " ";
-  
 }
 
 function countAdjacentMines(board, x, y) {

--- a/exercises/nth-prime/example.js
+++ b/exercises/nth-prime/example.js
@@ -36,4 +36,3 @@ class Prime {
 }
 
 export default Prime;
-

--- a/exercises/ocr-numbers/example.js
+++ b/exercises/ocr-numbers/example.js
@@ -85,5 +85,4 @@ export default class Parser {
     }
     return '?';
   }
-
 }

--- a/exercises/palindrome-products/example.js
+++ b/exercises/palindrome-products/example.js
@@ -36,4 +36,3 @@ const Palindromes = (params) => {
 };
 
 export default Palindromes;
-

--- a/exercises/pythagorean-triplet/example.js
+++ b/exercises/pythagorean-triplet/example.js
@@ -1,5 +1,4 @@
 export default class Triplet {
-
   constructor(a, b, c) {
     this.a = a;
     this.b = b;
@@ -24,7 +23,6 @@ export default class Triplet {
 }
 
 class Triplets {
-
   constructor(conditions) {
     this.min = conditions.minFactor || 1;
     this.max = conditions.maxFactor;

--- a/exercises/rectangles/example.js
+++ b/exercises/rectangles/example.js
@@ -1,5 +1,4 @@
 class Rectangles {
-
   static count(diagram) {
     const rows = diagram.length;
     const cols = rows ? diagram[0].length : 0;

--- a/exercises/rotational-cipher/example.js
+++ b/exercises/rotational-cipher/example.js
@@ -1,5 +1,4 @@
 class RotationalCipher {
-
   static rotate(text, shift) {
     return [...text].map((c) => {
       const isUpper = c.match(/[A-Z]/);
@@ -10,7 +9,6 @@ class RotationalCipher {
         String.fromCharCode((((c.charCodeAt(0) - charShift) + shift) % 26) + charShift) : c;
     }).join('');
   }
-
 }
 
 export default RotationalCipher;

--- a/exercises/series/example.js
+++ b/exercises/series/example.js
@@ -1,5 +1,4 @@
 export default class Series {
-
   constructor(numberString) {
     this.numberString = numberString;
     this.digits = this.getDigits();

--- a/exercises/spiral-matrix/example.js
+++ b/exercises/spiral-matrix/example.js
@@ -1,5 +1,4 @@
 class SpiralMatrix {
-
   static ofSize(size) {
     const spiral = Array(size).fill().map(() => Array(0));
 
@@ -20,7 +19,6 @@ class SpiralMatrix {
 
     return spiral;
   }
-
 }
 
 export default SpiralMatrix;

--- a/exercises/strain/strain.spec.js
+++ b/exercises/strain/strain.spec.js
@@ -74,4 +74,3 @@ describe('strain', () => {
     expect(result).toEqual([[1, 2, 3], [2, 1, 2], [2, 2, 1]]);
   });
 });
-

--- a/exercises/sublist/example.js
+++ b/exercises/sublist/example.js
@@ -1,5 +1,4 @@
 class List {
-
   constructor(list = []) {
     this.list = list;
   }

--- a/exercises/sublist/sublist.spec.js
+++ b/exercises/sublist/sublist.spec.js
@@ -2,7 +2,6 @@ import List from './sublist';
 
 
 describe('sublist', () => {
-
   test('two empty lists are equal', () => {
     const listOne = new List();
     const listTwo = new List();
@@ -43,7 +42,6 @@ describe('sublist', () => {
     const listTwo = new List([0, 1, 2, 3, 1, 2, 5, 6]);
 
     expect(listOne.compare(listTwo)).toEqual('SUBLIST');
-
   });
 
   xtest('consecutive', () => {
@@ -122,5 +120,4 @@ describe('sublist', () => {
 
     expect(listOne.compare(listTwo)).toEqual('UNEQUAL');
   });
-
 });

--- a/exercises/trinary/example.js
+++ b/exercises/trinary/example.js
@@ -1,7 +1,6 @@
 const BASE = 3;
 
 export default class Trinary {
-
   constructor(decimal) {
     this.digits = [...decimal].reverse().map(Number);
   }
@@ -23,5 +22,4 @@ export default class Trinary {
   accumulator(decimal, digit, index) {
     return decimal += digit * Math.pow(BASE, index);
   }
-
 }


### PR DESCRIPTION
Clean up extraneous blank lines as part of issue #480
- Fix 10 cases of ESLint issue `no-multiple-empty-lines`.
- Fix 36 cases of ESLint issue `padded-blocks`.

As an added bonus, I've been able to remove the ISBN Identifier and Matrix exercises from .eslintignore.