### PR TITLE
Clean up indent errors

### DIFF
--- a/exercises/alphametics/example.js
+++ b/exercises/alphametics/example.js
@@ -51,8 +51,8 @@ function testNumbers(numbers, puzzleParts, firstLetters) {
 
   const total = puzzleParts.slice(puzzleParts.length - 1)[0];
   return total === puzzleParts
-      .slice(0, puzzleParts.length - 1)
-      .reduce((acc, val) => acc + val, 0);
+    .slice(0, puzzleParts.length - 1)
+    .reduce((acc, val) => acc + val, 0);
 }
 function* generate(A) {
   const c = [];

--- a/exercises/difference-of-squares/difference-of-squares.spec.js
+++ b/exercises/difference-of-squares/difference-of-squares.spec.js
@@ -1,9 +1,9 @@
 import Squares from './difference-of-squares';
 
 describe('difference-of-squares', () => {
-    const squares1 = new Squares(1);
-    const squares5 = new Squares(5);
-    const squares100 = new Squares(100);
+  const squares1 = new Squares(1);
+  const squares5 = new Squares(5);
+  const squares100 = new Squares(100);
 
   describe('Square the sum of the numbers up to the given number', () => {
     xtest('square of sum 1', () => {

--- a/exercises/flatten-array/example.js
+++ b/exercises/flatten-array/example.js
@@ -5,7 +5,7 @@ export default class Flattener {
         Array.isArray(el)
           ? acc.concat(this.flatten(el))
           : acc.concat(el),
-        [])
+      [])
       .filter(el => el !== null && el !== undefined);
   }
 }

--- a/exercises/forth/example.js
+++ b/exercises/forth/example.js
@@ -49,9 +49,9 @@ class Forth {
       '-': { arity: 2, execute: (a, b) => [a - b] },
       '*': { arity: 2, execute: (a, b) => [a * b] },
       '/': { arity: 2, execute: (a, b) => {
-          if (b === 0) throw new Error('Division by zero');
-          return [Math.floor(a / b)];
-        } },
+        if (b === 0) throw new Error('Division by zero');
+        return [Math.floor(a / b)];
+      } },
       dup: { arity: 1, execute: a => [a, a] },
       drop: { arity: 1, execute: () => {} },
       swap: { arity: 2, execute: (a, b) => [b, a] },

--- a/exercises/minesweeper/example.js
+++ b/exercises/minesweeper/example.js
@@ -29,7 +29,8 @@ function cellToMineOrCount(cell, inputBoard, x, y) {
   if (cell === MINE) {
     return MINE;
   } 
-    return countAdjacentMines(inputBoard, x, y) || " ";
+
+  return countAdjacentMines(inputBoard, x, y) || " ";
 }
 
 function countAdjacentMines(board, x, y) {

--- a/exercises/proverb/proverb.spec.js
+++ b/exercises/proverb/proverb.spec.js
@@ -31,7 +31,7 @@ And all for the want of a nail.`);
     const result = proverb('key', 'value');
 
     expect(result).toEqual(
-        `For want of a key the value was lost.
+      `For want of a key the value was lost.
 And all for the want of a key.`);
   });
 
@@ -55,11 +55,11 @@ And all for the want of a nail.`);
 
   xtest('the use of an optional qualifier in the final consequence', () => {
     const result = proverb('nail', 'shoe', 'horse', 'rider',
-        'message', 'battle', 'kingdom',
-        { qualifier: 'horseshoe' });
+      'message', 'battle', 'kingdom',
+      { qualifier: 'horseshoe' });
 
     expect(result).toEqual(
-        `For want of a nail the shoe was lost.
+      `For want of a nail the shoe was lost.
 For want of a shoe the horse was lost.
 For want of a horse the rider was lost.
 For want of a rider the message was lost.

--- a/exercises/spiral-matrix/spiral-matrix.spec.js
+++ b/exercises/spiral-matrix/spiral-matrix.spec.js
@@ -17,7 +17,7 @@ describe('Spiral Matrix', () => {
 
   xtest('spiral of size 2', () => {
     const expected = [[1, 2],
-                      [4, 3]];
+      [4, 3]];
     const actual = SpiralMatrix.ofSize(2);
 
     expect(actual).toEqual(expected);
@@ -25,8 +25,8 @@ describe('Spiral Matrix', () => {
 
   xtest('spiral of size 3', () => {
     const expected = [[1, 2, 3],
-                      [8, 9, 4],
-                      [7, 6, 5]];
+      [8, 9, 4],
+      [7, 6, 5]];
     const actual = SpiralMatrix.ofSize(3);
 
     expect(actual).toEqual(expected);
@@ -34,9 +34,9 @@ describe('Spiral Matrix', () => {
 
   xtest('spiral of size 4', () => {
     const expected = [[1, 2, 3, 4],
-                      [12, 13, 14, 5],
-                      [11, 16, 15, 6],
-                      [10, 9, 8, 7]];
+      [12, 13, 14, 5],
+      [11, 16, 15, 6],
+      [10, 9, 8, 7]];
     const actual = SpiralMatrix.ofSize(4);
 
     expect(actual).toEqual(expected);
@@ -44,10 +44,10 @@ describe('Spiral Matrix', () => {
 
   xtest('spiral of size 5', () => {
     const expected = [[1, 2, 3, 4, 5],
-                      [16, 17, 18, 19, 6],
-                      [15, 24, 25, 20, 7],
-                      [14, 23, 22, 21, 8],
-                      [13, 12, 11, 10, 9]];
+      [16, 17, 18, 19, 6],
+      [15, 24, 25, 20, 7],
+      [14, 23, 22, 21, 8],
+      [13, 12, 11, 10, 9]];
     const actual = SpiralMatrix.ofSize(5);
 
     expect(expected).toEqual(actual);

--- a/exercises/sublist/example.js
+++ b/exercises/sublist/example.js
@@ -6,14 +6,14 @@ class List {
   compare(other) {
     return {
       '-1': isSublist(other.list, this.list)
-              ? 'SUBLIST'
-              : 'UNEQUAL',
+        ? 'SUBLIST'
+        : 'UNEQUAL',
       '0':  isSublist(other.list, this.list)
-              ? 'EQUAL'
-              : 'UNEQUAL',
+        ? 'EQUAL'
+        : 'UNEQUAL',
       '1':  isSublist(this.list, other.list)
-              ? 'SUPERLIST'
-              : 'UNEQUAL'
+        ? 'SUPERLIST'
+        : 'UNEQUAL'
     }[lengthDiff(this, other)];
   }
 }


### PR DESCRIPTION
Clean up indent errors as part of issue #480
- Fix 30 cases of ESLint issue `indent`.

As an added bonus, I've been able to remove the ISBN Identifier and Matrix exercises from .eslintignore.