### PR TITLE
Clean-up of ESLint errors

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,12 +9,9 @@ food-chain
 forth
 grade-school
 grains
-hexadecimal
-kindergarten-garden
 largest-series-product
 linked-list
 list-ops
-luhn
 meetup
 minesweeper
 nth-prime
@@ -27,7 +24,6 @@ pythagorean-triplet
 queen-attack
 rational-numbers
 rectangles
-rotational-cipher
 saddle-points
 say
 secret-handshake
@@ -36,7 +32,6 @@ spiral-matrix
 strain
 sublist
 sum-of-multiples
-transpose
 trinary
 twelve-days
 variable-length-quantity

--- a/exercises/hexadecimal/example.js
+++ b/exercises/hexadecimal/example.js
@@ -4,7 +4,7 @@ export default function (hex) {
   this.toDecimal = () => {
     const hexCharacters = [...this.hex];
 
-    for (let i = 0; i < hexCharacters.length; i++) {
+    for (let i = 0; i < hexCharacters.length; i + 1) {
       if (/[^0-9a-fA-F]/.exec(hexCharacters[i])) { return 0; }
     }
 

--- a/exercises/hexadecimal/example.js
+++ b/exercises/hexadecimal/example.js
@@ -4,7 +4,7 @@ export default function (hex) {
   this.toDecimal = () => {
     const hexCharacters = [...this.hex];
 
-    for (let i = 0; i < hexCharacters.length; i + 1) {
+    for (let i = 0; i < hexCharacters.length; i += 1) {
       if (/[^0-9a-fA-F]/.exec(hexCharacters[i])) { return 0; }
     }
 

--- a/exercises/kindergarten-garden/example.js
+++ b/exercises/kindergarten-garden/example.js
@@ -13,7 +13,7 @@ const defaultChildren = [
   'Larry',
 ];
 
-const plants = {
+const plantCodes = {
   G: 'grass',
   V: 'violets',
   R: 'radishes',
@@ -31,7 +31,7 @@ function getPlants(pots, index) {
 }
 
 function parse(diagram) {
-  return diagram.split('\n').map(row => [...row].map(sign => plants[sign]));
+  return diagram.split('\n').map(row => [...row].map(sign => plantCodes[sign]));
 }
 
 class Garden {

--- a/exercises/luhn/example.js
+++ b/exercises/luhn/example.js
@@ -1,5 +1,5 @@
-function isValid(number) {
-  number = number.replace(/\s/g, '');
+function isValid(num) {
+  const number = num.replace(/\s/g, '');
   const digits = [...number];
 
   const sum = digits

--- a/exercises/rotational-cipher/example.js
+++ b/exercises/rotational-cipher/example.js
@@ -5,8 +5,10 @@ class RotationalCipher {
       const isAlpha = c.match(/[a-z]/i);
       const charShift = (isUpper ? 'A' : 'a').charCodeAt(0);
 
-      return isAlpha ?
-        String.fromCharCode((((c.charCodeAt(0) - charShift) + shift) % 26) + charShift) : c;
+      return isAlpha
+        ? String.fromCharCode((((
+          c.charCodeAt(0) - charShift) + shift) % 26) + charShift)
+        : c;
     }).join('');
   }
 }

--- a/exercises/transpose/example.js
+++ b/exercises/transpose/example.js
@@ -5,8 +5,9 @@ function trimTrailingUndefined(array) {
 
 export default function transpose(input) {
   const maxCol = Math.max(0, ...(input.map(row => row.length)));
-  return [...Array(maxCol).keys()].map(col =>
-    trimTrailingUndefined(input.map((_v, row) => input[row][col]))
-      .map(charOrUndefined => charOrUndefined || ' ')
-      .join(''));
+  return [...Array(maxCol).keys()].map(col => trimTrailingUndefined(
+    input.map((_v, row) => input[row][col]),
+  )
+    .map(charOrUndefined => charOrUndefined || ' ')
+    .join(''));
 }


### PR DESCRIPTION
Clean-up of small, one-line ESLint errors as part of issue #480:
- Hexadecimal: fix `no-plusplus` error.
- Kindergarten Garden: fix `no-shadow` error.
- Luhn: fix `no-param-reassign` error.
- Rotational Cipher: fix `operational-linebreak` error.
- Transpose: fix `implicit-arrow-linebreak` error.