### PR TITLE
`concat` should be applied to a list of lists.

### DIFF
--- a/exercises/list-ops/example.js
+++ b/exercises/list-ops/example.js
@@ -10,8 +10,11 @@ class List {
     return this;
   }
 
-  concat(otherList) {
-    return this.append(otherList);
+  concat(listOfLists) {
+    for (const list of listOfLists.values) {
+      this.append(list);
+    }
+    return this;
   }
 
   filter(operation) {

--- a/exercises/list-ops/list-ops.spec.js
+++ b/exercises/list-ops/list-ops.spec.js
@@ -34,7 +34,8 @@ describe('concat lists and lists of lists into new list', () => {
     const list2 = new List([3]);
     const list3 = new List([]);
     const list4 = new List([4, 5, 6]);
-    expect(list1.concat(list2).concat(list3).concat(list4).values).toEqual([1, 2, 3, 4, 5, 6]);
+    const listOfLists = new List([list2, list3, list4])
+    expect(list1.concat(listOfLists).values).toEqual([1, 2, 3, 4, 5, 6]);
   });
 });
 


### PR DESCRIPTION
`List.concat` in the JavaScript track is just a duplicate of `List.append`.

This PR makes it more useful by expecting a list of lists as the argument instead, aligning it with, for example, the [test suite in the Python track](https://github.com/exercism/python/blob/master/exercises/list-ops/list_ops_test.py#L26).