### PR TITLE
Use named export for all-your-base exercise

### DIFF
--- a/exercises/all-your-base/all-your-base.spec.js
+++ b/exercises/all-your-base/all-your-base.spec.js
@@ -1,137 +1,135 @@
-import Converter from './all-your-base';
-
-const converter = new Converter();
+import { convert } from './all-your-base';
 
 describe('Converter', () => {
   test('single bit one to decimal', () => {
-    expect(converter.convert([1], 2, 10)).toEqual([1]);
+    expect(convert([1], 2, 10)).toEqual([1]);
   });
 
   xtest('binary to single decimal', () => {
-    expect(converter.convert([1, 0, 1], 2, 10)).toEqual([5]);
+    expect(convert([1, 0, 1], 2, 10)).toEqual([5]);
   });
 
   xtest('single decimal to binary', () => {
-    expect(converter.convert([5], 10, 2)).toEqual([1, 0, 1]);
+    expect(convert([5], 10, 2)).toEqual([1, 0, 1]);
   });
 
   xtest('binary to multiple decimal', () => {
-    expect(converter.convert([1, 0, 1, 0, 1, 0], 2, 10)).toEqual([4, 2]);
+    expect(convert([1, 0, 1, 0, 1, 0], 2, 10)).toEqual([4, 2]);
   });
 
   xtest('decimal to binary', () => {
-    expect(converter.convert([4, 2], 10, 2)).toEqual([1, 0, 1, 0, 1, 0]);
+    expect(convert([4, 2], 10, 2)).toEqual([1, 0, 1, 0, 1, 0]);
   });
 
   xtest('trinary to hexadecimal', () => {
-    expect(converter.convert([1, 1, 2, 0], 3, 16)).toEqual([2, 10]);
+    expect(convert([1, 1, 2, 0], 3, 16)).toEqual([2, 10]);
   });
 
   xtest('hexadecimal to trinary', () => {
-    expect(converter.convert([2, 10], 16, 3)).toEqual([1, 1, 2, 0]);
+    expect(convert([2, 10], 16, 3)).toEqual([1, 1, 2, 0]);
   });
 
   xtest('15-bit integer', () => {
-    expect(converter.convert([3, 46, 60], 97, 73)).toEqual([6, 10, 45]);
+    expect(convert([3, 46, 60], 97, 73)).toEqual([6, 10, 45]);
   });
 
   xtest('empty list', () => {
     expect(() => {
-      converter.convert([], 2, 10);
+      convert([], 2, 10);
     }).toThrow(new Error('Input has wrong format'));
   });
 
   xtest('single zero', () => {
-    expect(converter.convert([0], 10, 2)).toEqual([0]);
+    expect(convert([0], 10, 2)).toEqual([0]);
   });
 
   xtest('multiple zeros', () => {
     expect(() => {
-      converter.convert([0, 0, 0], 10, 2);
+      convert([0, 0, 0], 10, 2);
     }).toThrow(new Error('Input has wrong format'));
   });
 
   xtest('leading zeros', () => {
     expect(() => {
-      converter.convert([0, 6, 0], 7, 10);
+      convert([0, 6, 0], 7, 10);
     }).toThrow(new Error('Input has wrong format'));
   });
 
   xtest('negative digit', () => {
     expect(() => {
-      converter.convert([1, -1, 1, 0, 1, 0], 2, 10);
+      convert([1, -1, 1, 0, 1, 0], 2, 10);
     }).toThrow(new Error('Input has wrong format'));
   });
 
   xtest('invalid positive digit', () => {
     expect(() => {
-      converter.convert([1, 2, 1, 0, 1, 0], 2, 10);
+      convert([1, 2, 1, 0, 1, 0], 2, 10);
     }).toThrow(new Error('Input has wrong format'));
   });
 
   xtest('first base is one', () => {
     expect(() => {
-      converter.convert([], 1, 10);
+      convert([], 1, 10);
     }).toThrow(new Error('Wrong input base'));
   });
 
   xtest('second base is one', () => {
     expect(() => {
-      converter.convert([1, 0, 1, 0, 1, 0], 2, 1);
+      convert([1, 0, 1, 0, 1, 0], 2, 1);
     }).toThrow(new Error('Wrong output base'));
   });
 
   xtest('first base is zero', () => {
     expect(() => {
-      converter.convert([], 0, 10);
+      convert([], 0, 10);
     }).toThrow(new Error('Wrong input base'));
   });
 
   xtest('second base is zero', () => {
     expect(() => {
-      converter.convert([7], 10, 0);
+      convert([7], 10, 0);
     }).toThrow(new Error('Wrong output base'));
   });
 
   xtest('first base is negative', () => {
     expect(() => {
-      converter.convert([1], -2, 10);
+      convert([1], -2, 10);
     }).toThrow(new Error('Wrong input base'));
   });
 
   xtest('second base is negative', () => {
     expect(() => {
-      converter.convert([1], 2, -7);
+      convert([1], 2, -7);
     }).toThrow(new Error('Wrong output base'));
   });
 
   xtest('both bases are negative', () => {
     expect(() => {
-      converter.convert([1], -2, -7);
+      convert([1], -2, -7);
     }).toThrow(new Error('Wrong input base'));
   });
 
   xtest('missing input base throws an error', () => {
     expect(() => {
-      converter.convert([0]);
+      convert([0]);
     }).toThrow(new Error('Wrong input base'));
   });
 
   xtest('wrong input_base base not integer', () => {
     expect(() => {
-      converter.convert([0], 2.5);
+      convert([0], 2.5);
     }).toThrow(new Error('Wrong input base'));
   });
 
   xtest('missing output base throws an error', () => {
     expect(() => {
-      converter.convert([0], 2);
+      convert([0], 2);
     }).toThrow(new Error('Wrong output base'));
   });
 
   xtest('wrong output_base base not integer', () => {
     expect(() => {
-      converter.convert([0], 3, 2.5);
+      convert([0], 3, 2.5);
     }).toThrow(new Error('Wrong output base'));
   });
 });

--- a/exercises/all-your-base/example.js
+++ b/exercises/all-your-base/example.js
@@ -24,32 +24,26 @@ const convertFromDecimalToBase = (num, outputBase) => {
   return result;
 };
 
-const Converter = () => {};
-
-Converter.prototype = {
-  convert: (array, inputBase, outputBase) => {
-    if (isValidBase(inputBase)) {
-      throw new Error('Wrong input base');
-    }
-    if (isValidBase(outputBase)) {
-      throw new Error('Wrong output base');
-    }
-    const regexp = new RegExp('^0.', 'g');
-    const str = array.join('');
-    if (str.match(regexp)
-      || !isInputValid(array, inputBase)) {
-      throw new Error('Input has wrong format');
-    }
-    if (str === '0') {
-      return [0];
-    }
-    if (str === '1') {
-      return [1];
-    }
-    const decimalValue = array
-      .reduce((accumulator, value) => accumulator * inputBase + value, 0);
-    return convertFromDecimalToBase(decimalValue, outputBase);
-  },
+export const convert = (array, inputBase, outputBase) => {
+  if (isValidBase(inputBase)) {
+    throw new Error('Wrong input base');
+  }
+  if (isValidBase(outputBase)) {
+    throw new Error('Wrong output base');
+  }
+  const regexp = new RegExp('^0.', 'g');
+  const str = array.join('');
+  if (str.match(regexp)
+    || !isInputValid(array, inputBase)) {
+    throw new Error('Input has wrong format');
+  }
+  if (str === '0') {
+    return [0];
+  }
+  if (str === '1') {
+    return [1];
+  }
+  const decimalValue = array
+    .reduce((accumulator, value) => accumulator * inputBase + value, 0);
+  return convertFromDecimalToBase(decimalValue, outputBase);
 };
-
-export default Converter;


### PR DESCRIPTION
Per #436, change from default export to named export.  In the
all-your-base exercise, export just `convert`.  The corresponding tests
can consume like `convert(args)`.