### PR TITLE
Modify Darts exercise to use named exports

### DIFF
--- a/exercises/darts/darts.spec.js
+++ b/exercises/darts/darts.spec.js
@@ -1,4 +1,4 @@
-import solve from './darts';
+import { solve } from './darts';
 
 describe('Return the correct amount earned by a dart landing in a given point in the target problem', () => {
   test('A dart lands outside the target', () => {

--- a/exercises/darts/example.js
+++ b/exercises/darts/example.js
@@ -1,4 +1,4 @@
-export default function solve(x, y) {
+export const solve = (x, y) => {
   // Check for NaN
   if (Number.isNaN(Number(x)) || Number.isNaN(Number(y))) return null;
 
@@ -10,4 +10,4 @@ export default function solve(x, y) {
   if (distanceToDart > 5) return 1;
   if (distanceToDart > 1) return 5;
   return 10;
-}
+};


### PR DESCRIPTION
In reference to #436, changes the default export in the Darts exercise to a named export.

In `darts/example.js`
- Change export from default to named

In `darts/darts.spec.js`
- In import, specify named export from `darts/example.js`