### PR TITLE
Modify Reverse String exercise to use named exports

### DIFF
--- a/exercises/reverse-string/example.js
+++ b/exercises/reverse-string/example.js
@@ -1,9 +1,7 @@
-function reverseString(string) {
+export const reverseString = (string) => {
   let revString = '';
   for (let i = string.length - 1; i >= 0; i -= 1) {
     revString += string[i];
   }
   return revString;
-}
-
-export default reverseString;
+};

--- a/exercises/reverse-string/reverse-string.spec.js
+++ b/exercises/reverse-string/reverse-string.spec.js
@@ -1,4 +1,4 @@
-import reverseString from './reverse-string';
+import { reverseString } from './reverse-string';
 
 describe('ReverseString', () => {
   test('empty string', () => {


### PR DESCRIPTION
In reference to #436, changes the default export in the Reverse String exercise to a named export.

In `reverse-string/example.js`
- Change export from default to named

In `reverse-string/reverse-string.spec.js`
- In import, specify named export from `reverse-string/example.js`