### PR TITLE
Use named export for largest-series-product (after linting)

### DIFF
--- a/exercises/largest-series-product/example.js
+++ b/exercises/largest-series-product/example.js
@@ -1,49 +1,39 @@
-export default class Series {
-  constructor(numberString) {
-    if (numberString.match('[^0-9]')) {
-      throw new Error('Invalid input.');
-    }
+const getDigits = numberString => [...numberString].map(digit => parseInt(digit, 10));
 
-    this.numberString = numberString;
-    this.digits = this.getDigits();
+const slices = (digits, sliceSize) => {
+  const result = [];
+  let slice = [];
+
+  if (sliceSize > digits.length) {
+    throw new Error('Slice size is too big.');
   }
 
-  getDigits() {
-    return [...this.numberString].map(digit => parseInt(digit, 10));
+  for (let i = 0; i < digits.length - sliceSize + 1; i += 1) {
+    for (let j = 0; j < sliceSize; j += 1) {
+      slice.push(digits[i + j]);
+    }
+    result.push(slice);
+    slice = [];
   }
 
-  largestProduct(size) {
-    if (size < 0) {
-      throw new Error('Invalid input.');
-    }
+  return result;
+};
 
-    let product;
-    let max = 0;
-    this.slices(size).forEach((slice) => {
-      product = slice.reduce((a, b) => a * b, 1);
-      if (product > max) {
-        max = product;
-      }
-    });
-    return max;
+export const largestProduct = (numberString, size) => {
+  if (numberString.match('[^0-9]')) {
+    throw new Error('Invalid input.');
+  }
+  if (size < 0) {
+    throw new Error('Invalid input.');
   }
 
-  slices(sliceSize) {
-    const result = [];
-    let slice = [];
-
-    if (sliceSize > this.digits.length) {
-      throw new Error('Slice size is too big.');
+  let product;
+  let max = 0;
+  slices(getDigits(numberString), size).forEach((slice) => {
+    product = slice.reduce((a, b) => a * b, 1);
+    if (product > max) {
+      max = product;
     }
-
-    for (let i = 0; i < this.digits.length - sliceSize + 1; i += 1) {
-      for (let j = 0; j < sliceSize; j += 1) {
-        slice.push(this.digits[i + j]);
-      }
-      result.push(slice);
-      slice = [];
-    }
-
-    return result;
-  }
-}
+  });
+  return max;
+};

--- a/exercises/largest-series-product/largest-series-product.spec.js
+++ b/exercises/largest-series-product/largest-series-product.spec.js
@@ -1,16 +1,16 @@
-import Series from './largest-series-product';
+import { largestProduct } from './largest-series-product';
 
 describe('Series', () => {
   test('can get the largest product of 2', () => {
-    expect(new Series('0123456789').largestProduct(2)).toBe(72);
+    expect(largestProduct('0123456789', 2)).toBe(72);
   });
 
   xtest('works for a tiny number', () => {
-    expect(new Series('19').largestProduct(2)).toBe(9);
+    expect(largestProduct('19', 2)).toBe(9);
   });
 
   xtest('can get the largest product of 3', () => {
-    expect(new Series('1027839564').largestProduct(3)).toBe(270);
+    expect(largestProduct('1027839564', 3)).toBe(270);
   });
 
   xtest('can get the largest product of a big number', () => {
@@ -23,46 +23,46 @@ describe('Series', () => {
       + '99244429282308634656748139191231628245861786645835912456652947654568284891288314260769004224219022671055626321111'
       + '10937054421750694165896040807198403850962455444362981230987879927244284909188845801561660979191338754992005240636'
       + '899125607176060588611646710940507754100225698315520005593572972571636269561882670428252483600823257530420752963450';
-    expect(new Series(largeNumber).largestProduct(13)).toBe(23514624000);
+    expect(largestProduct(largeNumber, 13)).toBe(23514624000);
   });
 
   xtest('returns 0 if all digits are zero', () => {
-    expect(new Series('0000').largestProduct(2)).toBe(0);
+    expect(largestProduct('0000', 2)).toBe(0);
   });
 
   xtest('returns 0 if all spans contain zero', () => {
-    expect(new Series('99099').largestProduct(3)).toBe(0);
+    expect(largestProduct('99099', 3)).toBe(0);
   });
 
   xtest('rejects invalid character in input', () => {
     expect(() => {
-      new Series('1234a5').largestProduct('2');
+      largestProduct('1234a5', 2);
     }).toThrow(new Error('Invalid input.'));
   });
 
   xtest('rejects negative span', () => {
     expect(() => {
-      new Series('12345').largestProduct(-1);
+      largestProduct('12345', -1);
     }).toThrow(new Error('Invalid input.'));
   });
 
   xtest('returns 1 for empty string and zero slice length', () => {
-    expect(new Series('').largestProduct(0)).toBe(1);
+    expect(largestProduct('', 0)).toBe(1);
   });
 
   xtest('returns 1 for non-empty string and zero slice length', () => {
-    expect(new Series('123').largestProduct(0)).toBe(1);
+    expect(largestProduct('123', 0)).toBe(1);
   });
 
   xtest('throws an error for slices bigger than the number', () => {
     expect(() => {
-      new Series('123').largestProduct(4);
+      largestProduct('123', 4);
     }).toThrow(new Error('Slice size is too big.'));
   });
 
   xtest('throws an error for empty string and non-zero slice length', () => {
     expect(() => {
-      new Series('').largestProduct(1);
+      largestProduct('', 1);
     }).toThrow(new Error('Slice size is too big.'));
   });
 });


### PR DESCRIPTION
Per #436, convert default export to named export for largest series
product exercise. Change from class style `new
Series(numberString).largestProduct(size)`
to function `largestProduct(numberString, size)` since there is no need to
keep state.

The diffs look a little crazy due to the change in indentation and extraction of various methods from `Series`.  Details:
1. `Series.getDigits` is extracted into standalone function `getDigits`
1. `Series.slices(sliceSize)` is extracted into standalone function `slices(digits, sliceSize)`.  The additional `digits` argument replaces the use of `this.digits`.
1. `Series.largestProduct(size)` is extracted into standalone function `largestProduct(numberString, size)`.  The additional `numberString` argument replaces the use of `this.numberString`.  In addtiion, the guard class originally defined in the constructor of `Series` is moved into beginning of the standalone function to properly account for input validation.  This is the function being exported.