### PR TITLE
Fix ESLint errors in Flatten Array test script

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,7 +4,6 @@ clock
 connect
 diamond
 difference-of-squares
-flatten-array
 food-chain
 forth
 grade-school

--- a/exercises/flatten-array/example.js
+++ b/exercises/flatten-array/example.js
@@ -1,11 +1,9 @@
 export default class Flattener {
   flatten(arr) {
     return arr
-      .reduce((acc, el) =>
-        Array.isArray(el)
-          ? acc.concat(this.flatten(el))
-          : acc.concat(el),
-      [])
+      .reduce((acc, el) => (Array.isArray(el)
+        ? acc.concat(this.flatten(el))
+        : acc.concat(el)), [])
       .filter(el => el !== null && el !== undefined);
   }
 }

--- a/exercises/flatten-array/flatten-array.spec.js
+++ b/exercises/flatten-array/flatten-array.spec.js
@@ -19,22 +19,28 @@ describe('FlattenArray', () => {
   });
 
   xtest('flattens a  3 level nested list', () => {
-    expect(flattener.flatten([1, [2, 3, 4], 5, [6, [7, 8]]])).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(flattener.flatten([1, [2, 3, 4], 5, [6, [7, 8]]]))
+      .toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
   });
 
   xtest('flattens a 5 level nested list', () => {
-    expect(flattener.flatten([0, 2, [[2, 3], 8, 100, 4, [[[50]]]], -2])).toEqual([0, 2, 2, 3, 8, 100, 4, 50, -2]);
+    expect(flattener.flatten([0, 2, [[2, 3], 8, 100, 4, [[[50]]]], -2]))
+      .toEqual([0, 2, 2, 3, 8, 100, 4, 50, -2]);
   });
 
   xtest('flattens a 6 level nested list', () => {
-    expect(flattener.flatten([1, [2, [[3]], [4, [[5]]], 6, 7], 8])).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(flattener.flatten([1, [2, [[3]], [4, [[5]]], 6, 7], 8]))
+      .toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
   });
 
   xtest('flattens a 6 level nested list with null values', () => {
-    expect(flattener.flatten([0, 2, [[2, 3], 8, [[100]], null, [[null]]], -2])).toEqual([0, 2, 2, 3, 8, 100, -2]);
+    expect(flattener.flatten([0, 2, [[2, 3], 8, [[100]], null, [[null]]], -2]))
+      .toEqual([0, 2, 2, 3, 8, 100, -2]);
   });
 
   xtest('returns an empty list if all values in nested list are null', () => {
-    expect(flattener.flatten([null, [[[null]]], null, null, [[null, null], null], null])).toEqual([]);
+    expect(flattener
+      .flatten([null, [[[null]]], null, null, [[null, null], null], null]))
+      .toEqual([]);
   });
 });


### PR DESCRIPTION
As per issue #480:
- Fix all `max-len` ESLint errors in flatten-array.spec.js file.
- Remove flatten-array from .eslintignore file.