### PR TITLE
lint minesweeper exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,7 +11,6 @@ grains
 linked-list
 list-ops
 meetup
-minesweeper
 nth-prime
 ocr-numbers
 palindrome-products

--- a/exercises/minesweeper/example.js
+++ b/exercises/minesweeper/example.js
@@ -11,26 +11,12 @@ const DELTAS = [
   [0, -1],
 ];
 
-class Minesweeper {
-  annotate(rows) {
-    if (noDataPresent(rows)) {
-      return rows;
-    }
-
-    const inputBoard = rows.map(row => [...row]);
-
-    return stringify(
-      inputBoard.map((row, x) => [...row].map((cell, y) => cellToMineOrCount(cell, inputBoard, x, y))),
-    );
-  }
+function adjacentSquareIsOnBoard(board, x, d) {
+  return board[x + d[0]];
 }
 
-function cellToMineOrCount(cell, inputBoard, x, y) {
-  if (cell === MINE) {
-    return MINE;
-  } 
-
-  return countAdjacentMines(inputBoard, x, y) || " ";
+function adjacentSquareHasMine(board, x, y, d) {
+  return board[x + d[0]][y + d[1]] === MINE;
 }
 
 function countAdjacentMines(board, x, y) {
@@ -38,6 +24,14 @@ function countAdjacentMines(board, x, y) {
     .filter(d => adjacentSquareIsOnBoard(board, x, d))
     .filter(d => adjacentSquareHasMine(board, x, y, d))
     .length;
+}
+
+function cellToMineOrCount(cell, inputBoard, x, y) {
+  if (cell === MINE) {
+    return MINE;
+  }
+
+  return countAdjacentMines(inputBoard, x, y) || ' ';
 }
 
 function stringify(board) {
@@ -48,13 +42,20 @@ function noDataPresent(rows) {
   return rows.length === 0 || rows[0].length === 0;
 }
 
-function adjacentSquareIsOnBoard(board, x, d) {
-  return board[x + d[0]];
-}
+class Minesweeper {
+  static annotate(rows) {
+    if (noDataPresent(rows)) {
+      return rows;
+    }
 
-function adjacentSquareHasMine(board, x, y, d) {
-  return board[x + d[0]][y + d[1]] === MINE;
-}
+    const inputBoard = rows.map(row => [...row]);
 
+    return stringify(
+      inputBoard.map(
+        (row, x) => [...row].map((cell, y) => cellToMineOrCount(cell, inputBoard, x, y)),
+      ),
+    );
+  }
+}
 
 export default Minesweeper;

--- a/exercises/minesweeper/minesweeper.spec.js
+++ b/exercises/minesweeper/minesweeper.spec.js
@@ -2,18 +2,12 @@ import Minesweeper from './minesweeper';
 
 
 describe('Minesweeper()', () => {
-  let minesweeper;
-
-  beforeEach(() => {
-    minesweeper = new Minesweeper();
-  });
-
   test('handles no rows', () => {
-    expect(minesweeper.annotate([])).toEqual([]);
+    expect(Minesweeper.annotate([])).toEqual([]);
   });
 
   xtest('handles no columns', () => {
-    expect(minesweeper.annotate([''])).toEqual(['']);
+    expect(Minesweeper.annotate([''])).toEqual(['']);
   });
 
   xtest('handles no mines', () => {
@@ -27,7 +21,7 @@ describe('Minesweeper()', () => {
       '   ',
       '   ',
     ];
-    expect(minesweeper.annotate(input)).toEqual(expected);
+    expect(Minesweeper.annotate(input)).toEqual(expected);
   });
 
   xtest('handles board with only mines', () => {
@@ -41,7 +35,7 @@ describe('Minesweeper()', () => {
       '***',
       '***',
     ];
-    expect(minesweeper.annotate(input)).toEqual(expected);
+    expect(Minesweeper.annotate(input)).toEqual(expected);
   });
 
   xtest('handles mine surrounded by spaces', () => {
@@ -55,7 +49,7 @@ describe('Minesweeper()', () => {
       '1*1',
       '111',
     ];
-    expect(minesweeper.annotate(input)).toEqual(expected);
+    expect(Minesweeper.annotate(input)).toEqual(expected);
   });
 
   xtest('handles space surrounded by mines', () => {
@@ -69,7 +63,7 @@ describe('Minesweeper()', () => {
       '*8*',
       '***',
     ];
-    expect(minesweeper.annotate(input)).toEqual(expected);
+    expect(Minesweeper.annotate(input)).toEqual(expected);
   });
 
   xtest('handles space surrounded by mines', () => {
@@ -83,19 +77,19 @@ describe('Minesweeper()', () => {
       '*8*',
       '***',
     ];
-    expect(minesweeper.annotate(input)).toEqual(expected);
+    expect(Minesweeper.annotate(input)).toEqual(expected);
   });
 
   xtest('handles horizontal line', () => {
     const input = [' * * '];
     const expected = ['1*2*1'];
-    expect(minesweeper.annotate(input)).toEqual(expected);
+    expect(Minesweeper.annotate(input)).toEqual(expected);
   });
 
   xtest('handles horizontal line, mines at edges', () => {
     const input = ['*   *'];
     const expected = ['*1 1*'];
-    expect(minesweeper.annotate(input)).toEqual(expected);
+    expect(Minesweeper.annotate(input)).toEqual(expected);
   });
 
   xtest('handles vertical line', () => {
@@ -113,7 +107,7 @@ describe('Minesweeper()', () => {
       '*',
       '1',
     ];
-    expect(minesweeper.annotate(input)).toEqual(expected);
+    expect(Minesweeper.annotate(input)).toEqual(expected);
   });
 
   xtest('handles vertical line, mines at edges', () => {
@@ -131,7 +125,7 @@ describe('Minesweeper()', () => {
       '1',
       '*',
     ];
-    expect(minesweeper.annotate(input)).toEqual(expected);
+    expect(Minesweeper.annotate(input)).toEqual(expected);
   });
 
   xtest('handles cross', () => {
@@ -149,7 +143,7 @@ describe('Minesweeper()', () => {
       '25*52',
       ' 2*2 ',
     ];
-    expect(minesweeper.annotate(input)).toEqual(expected);
+    expect(Minesweeper.annotate(input)).toEqual(expected);
   });
 
   xtest('handles large board', () => {
@@ -169,6 +163,6 @@ describe('Minesweeper()', () => {
       '1*22*2',
       '111111',
     ];
-    expect(minesweeper.annotate(input)).toEqual(expected);
+    expect(Minesweeper.annotate(input)).toEqual(expected);
   });
 });


### PR DESCRIPTION
per #480, fix the following lint errors in minesweeper exercise:
```
/home/eric/code/javascript/exercises/minesweeper/example.js
  15:11  error  Expected 'this' to be used by class method 'annotate'     class-methods-use-this
  16:9   error  'noDataPresent' was used before it was defined            no-use-before-define
  22:12  error  'stringify' was used before it was defined                no-use-before-define
  23:1   error  Line 23 exceeds the maximum line length of 100            max-len
  23:60  error  'cellToMineOrCount' was used before it was defined        no-use-before-define
  31:4   error  Trailing spaces not allowed                               no-trailing-spaces
  33:10  error  'countAdjacentMines' was used before it was defined       no-use-before-define
  33:50  error  Strings must use singlequote                              quotes
  38:18  error  'adjacentSquareIsOnBoard' was used before it was defined  no-use-before-define
  39:18  error  'adjacentSquareHasMine' was used before it was defined    no-use-before-define
```
Notable linting approach:
1. re-ordering functions so they are defined before use.
2. turn `annotate` into static method.