### PR TITLE
Minesweeper: change default export to named export

### DIFF
--- a/exercises/minesweeper/example.js
+++ b/exercises/minesweeper/example.js
@@ -42,20 +42,16 @@ function noDataPresent(rows) {
   return rows.length === 0 || rows[0].length === 0;
 }
 
-class Minesweeper {
-  static annotate(rows) {
-    if (noDataPresent(rows)) {
-      return rows;
-    }
-
-    const inputBoard = rows.map(row => [...row]);
-
-    return stringify(
-      inputBoard.map(
-        (row, x) => [...row].map((cell, y) => cellToMineOrCount(cell, inputBoard, x, y)),
-      ),
-    );
+export function annotate(rows) {
+  if (noDataPresent(rows)) {
+    return rows;
   }
-}
 
-export default Minesweeper;
+  const inputBoard = rows.map(row => [...row]);
+
+  return stringify(
+    inputBoard.map(
+      (row, x) => [...row].map((cell, y) => cellToMineOrCount(cell, inputBoard, x, y)),
+    ),
+  );
+}

--- a/exercises/minesweeper/minesweeper.spec.js
+++ b/exercises/minesweeper/minesweeper.spec.js
@@ -1,13 +1,12 @@
-import Minesweeper from './minesweeper';
+import { annotate } from './minesweeper';
 
-
-describe('Minesweeper()', () => {
+describe(')', () => {
   test('handles no rows', () => {
-    expect(Minesweeper.annotate([])).toEqual([]);
+    expect(annotate([])).toEqual([]);
   });
 
   xtest('handles no columns', () => {
-    expect(Minesweeper.annotate([''])).toEqual(['']);
+    expect(annotate([''])).toEqual(['']);
   });
 
   xtest('handles no mines', () => {
@@ -21,7 +20,7 @@ describe('Minesweeper()', () => {
       '   ',
       '   ',
     ];
-    expect(Minesweeper.annotate(input)).toEqual(expected);
+    expect(annotate(input)).toEqual(expected);
   });
 
   xtest('handles board with only mines', () => {
@@ -35,7 +34,7 @@ describe('Minesweeper()', () => {
       '***',
       '***',
     ];
-    expect(Minesweeper.annotate(input)).toEqual(expected);
+    expect(annotate(input)).toEqual(expected);
   });
 
   xtest('handles mine surrounded by spaces', () => {
@@ -49,7 +48,7 @@ describe('Minesweeper()', () => {
       '1*1',
       '111',
     ];
-    expect(Minesweeper.annotate(input)).toEqual(expected);
+    expect(annotate(input)).toEqual(expected);
   });
 
   xtest('handles space surrounded by mines', () => {
@@ -63,7 +62,7 @@ describe('Minesweeper()', () => {
       '*8*',
       '***',
     ];
-    expect(Minesweeper.annotate(input)).toEqual(expected);
+    expect(annotate(input)).toEqual(expected);
   });
 
   xtest('handles space surrounded by mines', () => {
@@ -77,19 +76,19 @@ describe('Minesweeper()', () => {
       '*8*',
       '***',
     ];
-    expect(Minesweeper.annotate(input)).toEqual(expected);
+    expect(annotate(input)).toEqual(expected);
   });
 
   xtest('handles horizontal line', () => {
     const input = [' * * '];
     const expected = ['1*2*1'];
-    expect(Minesweeper.annotate(input)).toEqual(expected);
+    expect(annotate(input)).toEqual(expected);
   });
 
   xtest('handles horizontal line, mines at edges', () => {
     const input = ['*   *'];
     const expected = ['*1 1*'];
-    expect(Minesweeper.annotate(input)).toEqual(expected);
+    expect(annotate(input)).toEqual(expected);
   });
 
   xtest('handles vertical line', () => {
@@ -107,7 +106,7 @@ describe('Minesweeper()', () => {
       '*',
       '1',
     ];
-    expect(Minesweeper.annotate(input)).toEqual(expected);
+    expect(annotate(input)).toEqual(expected);
   });
 
   xtest('handles vertical line, mines at edges', () => {
@@ -125,7 +124,7 @@ describe('Minesweeper()', () => {
       '1',
       '*',
     ];
-    expect(Minesweeper.annotate(input)).toEqual(expected);
+    expect(annotate(input)).toEqual(expected);
   });
 
   xtest('handles cross', () => {
@@ -143,7 +142,7 @@ describe('Minesweeper()', () => {
       '25*52',
       ' 2*2 ',
     ];
-    expect(Minesweeper.annotate(input)).toEqual(expected);
+    expect(annotate(input)).toEqual(expected);
   });
 
   xtest('handles large board', () => {
@@ -163,6 +162,6 @@ describe('Minesweeper()', () => {
       '1*22*2',
       '111111',
     ];
-    expect(Minesweeper.annotate(input)).toEqual(expected);
+    expect(annotate(input)).toEqual(expected);
   });
 });


### PR DESCRIPTION
per #436, change default export to named export.  The test code now
imports and consumes differently.  Also note the `class` structure was
unnecessary from the example solution, so just export the `annotate`
function directly instead.

```js
// before
import Minesweeper from './minesweeper'
Minesweeper.annotate(...) // example usage

// after
import { annotate } from './minesweeper'
annotate(...) // example usage
```