### PR TITLE
Lint meetup exercise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,7 +9,6 @@ grade-school
 grains
 linked-list
 list-ops
-meetup
 nth-prime
 palindrome-products
 point-mutations

--- a/exercises/meetup/example.js
+++ b/exercises/meetup/example.js
@@ -1,40 +1,3 @@
-export default function meetupDay(year, month, dayOfWeek, which) {
-  const candidates = getCandidates(year, month, dayOfWeek);
-  let res;
-
-  which = which.toLowerCase();
-
-  if (which === 'teenth') {
-    res = find(candidates, d => d.getDate() >= 13 && d.getDate() <= 19);
-  } else if (which === 'last') {
-    res = candidates.pop();
-  } else {
-    which = parseInt(which) - 1;
-    res = candidates.slice(which, which + 1).pop();
-  }
-
-  if (!res) { throw new MeetupDayException('Day not found!'); }
-
-  return res;
-}
-
-function getCandidates(year, month, dayOfWeek) {
-  let d,
-    i,
-    numDaysInMonth = new Date(year, month + 1, 0).getDate(),
-    res = [];
-
-  for (i = 0; i < numDaysInMonth; i++) {
-    d = new Date(year, month, i + 1);
-
-    if (d.getDay() === getDayIndex(dayOfWeek)) {
-      res.push(d);
-    }
-  }
-
-  return res;
-}
-
 function getDayIndex(day) {
   const daysInd = {
     sunday: 0,
@@ -45,19 +8,44 @@ function getDayIndex(day) {
     friday: 5,
     saturday: 6,
   };
+  return daysInd[day.toLowerCase()];
+}
 
-  day = day.toLowerCase();
-
-  return daysInd[day];
+function getCandidates(year, month, dayOfWeek) {
+  let d;
+  let i;
+  const numDaysInMonth = new Date(year, month + 1, 0).getDate();
+  const res = [];
+  for (i = 0; i < numDaysInMonth; i += 1) {
+    d = new Date(year, month, i + 1);
+    if (d.getDay() === getDayIndex(dayOfWeek)) {
+      res.push(d);
+    }
+  }
+  return res;
 }
 
 function find(ary, callback) {
-  for (let i = 0; i < ary.length; i++) {
+  for (let i = 0; i < ary.length; i += 1) {
     if (callback(ary[i], i, ary)) { return ary[i]; }
   }
+  throw new Error('Day not found!');
 }
 
-function MeetupDayException(message) {
-  this.message = message;
-  this.name = 'MeetupDayException';
+export default function meetupDay(year, month, dayOfWeek, which) {
+  const candidates = getCandidates(year, month, dayOfWeek);
+  let res;
+
+  if (which === 'teenth') {
+    res = find(candidates, d => d.getDate() >= 13 && d.getDate() <= 19);
+  } else if (which === 'last') {
+    res = candidates.pop();
+  } else {
+    const ordinal = parseInt(which, 10) - 1;
+    res = candidates.slice(ordinal, ordinal + 1).pop();
+  }
+
+  if (!res) { throw new Error('Day not found!'); }
+
+  return res;
 }


### PR DESCRIPTION
per #480, lint meetup exercise, primarily addressing `no-use-before-define`,
`no-param-reassign` lint errors, along with others:

```sh
/home/eric/code/javascript/exercises/meetup/example.js
   2:22  error  'getCandidates' was used before it was defined             no-use-before-define                                                                                                                                                                         
   5:3   error  Assignment to function parameter 'which'                   no-param-reassign
   8:11  error  'find' was used before it was defined                      no-use-before-define
  12:5   error  Assignment to function parameter 'which'                   no-param-reassign
  12:13  error  Missing radix parameter                                    radix
  16:25  error  'MeetupDayException' was used before it was defined        no-use-before-define
  22:3   error  Split 'let' declarations into multiple statements          one-var
  24:5   error  'numDaysInMonth' is never reassigned. Use 'const' instead  prefer-const       
  25:5   error  'res' is never reassigned. Use 'const' instead             prefer-const    
  27:35  error  Unary operator '++' used                                   no-plusplus        
  30:24  error  'getDayIndex' was used before it was defined               no-use-before-define
  49:3   error  Assignment to function parameter 'day'                     no-param-reassign
  54:10  error  Expected to return a value at the end of function 'find'   consistent-return  
  55:35  error  Unary operator '++' used                                   no-plusplus
```

### Approach
1. Only address immediate lint errors, not aggressively refactor, since quite a bit of code is moved around already due to addressing `no-use-before-define` type of lint errors.
1. Remove `MeetupDayException`, just use `Error`.
1. To fix `consistent-return`, throw an `Error` at the end of `find` function.
1. Remove `which = which.toLowerCase();` in `meetupDay` function since it causes a lint error, and there's no pre-existing test case indicating such input validation is required.

