### PR TITLE
scrabble-score: change default export to named export

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -16,7 +16,6 @@ pythagorean-triplet
 queen-attack
 rational-numbers
 saddle-points
-scrabble-score
 secret-handshake
 spiral-matrix
 sublist

--- a/exercises/scrabble-score/example.js
+++ b/exercises/scrabble-score/example.js
@@ -29,5 +29,5 @@ const letterScores = {
 
 const letterScore = letter => letterScores[letter] || 0;
 
-export default word => [...word.toLowerCase()]
+export const score = word => [...word.toLowerCase()]
   .reduce((sum, currChar) => sum + letterScore(currChar), 0);

--- a/exercises/scrabble-score/scrabble-score.spec.js
+++ b/exercises/scrabble-score/scrabble-score.spec.js
@@ -1,4 +1,4 @@
-import score from './scrabble-score';
+import { score } from './scrabble-score';
 
 describe('Scrabble', () => {
   test('lowercase letter', () => {


### PR DESCRIPTION
per #436, change default export to named export for exercise `scrabble-score`.  Also, remove
exericse's entry in eslintignore (no lint errors).