### PR TITLE
roman-numerals: use named import

### DIFF
--- a/exercises/roman-numerals/example.js
+++ b/exercises/roman-numerals/example.js
@@ -1,4 +1,4 @@
-function toRoman(number) {
+export function toRoman(number) {
   let result = '';
   let remainingNumber = number;
   const mappings = [
@@ -26,5 +26,3 @@ function toRoman(number) {
 
   return result;
 }
-
-export default toRoman;

--- a/exercises/roman-numerals/roman-numerals.spec.js
+++ b/exercises/roman-numerals/roman-numerals.spec.js
@@ -1,4 +1,4 @@
-import toRoman from './roman-numerals';
+import { toRoman } from './roman-numerals';
 
 describe('toRoman()', () => {
   test('converts 1', () => expect(toRoman(1)).toEqual('I'));


### PR DESCRIPTION
As someone new to Javascript, I have been modeling my exercise solutions after the stub for `hello-world`. When I encountered this exercise, this was the first exercise  I saw that did not use named imports (a concept I was unaware of at the time), so I was getting compile output that I could not make sense of.

I finally figured out my issue when I came here and saw #572, covering the same issue for `scrabble-score`.