### PR TITLE
matrix: change from default to named export

### DIFF
--- a/exercises/matrix/example.js
+++ b/exercises/matrix/example.js
@@ -15,11 +15,9 @@ function parseRows(description) {
   return description.split('\n').map(row => row.split(' ').map(char => parseInt(char, 10)));
 }
 
-class Matrix {
+export class Matrix {
   constructor(description) {
     this.rows = parseRows(description);
     this.columns = columnsFromRows(this.rows);
   }
 }
-
-export default Matrix;

--- a/exercises/matrix/matrix.spec.js
+++ b/exercises/matrix/matrix.spec.js
@@ -1,4 +1,4 @@
-import Matrix from './matrix';
+import { Matrix } from './matrix';
 
 describe('Matrix', () => {
   test('extract row from one number matrix', () => {


### PR DESCRIPTION
Per #436 , for `matrix` exercise, change from default to named export.  