### PR TITLE
raindrops: convert to function

### DIFF
--- a/exercises/raindrops/example.js
+++ b/exercises/raindrops/example.js
@@ -1,17 +1,13 @@
-const Raindrops = () => ({
-  convert: (n) => {
-    let result = '';
-    if (n % 3 === 0) {
-      result += 'Pling';
-    }
-    if (n % 5 === 0) {
-      result += 'Plang';
-    }
-    if (n % 7 === 0) {
-      result += 'Plong';
-    }
-    return result === '' ? n.toString() : result;
-  },
-});
-
-export default Raindrops;
+export const convert = (n) => {
+  let result = '';
+  if (n % 3 === 0) {
+    result += 'Pling';
+  }
+  if (n % 5 === 0) {
+    result += 'Plang';
+  }
+  if (n % 7 === 0) {
+    result += 'Plong';
+  }
+  return result === '' ? n.toString() : result;
+};

--- a/exercises/raindrops/raindrops.spec.js
+++ b/exercises/raindrops/raindrops.spec.js
@@ -1,37 +1,35 @@
-import Raindrops from './raindrops';
+import { convert } from './raindrops';
 
 describe('Raindrops', () => {
-  const drops = new Raindrops();
+  test('converts 1', () => expect(convert(1)).toEqual('1'));
 
-  test('converts 1', () => expect(drops.convert(1)).toEqual('1'));
+  xtest('converts 3', () => expect(convert(3)).toEqual('Pling'));
 
-  xtest('converts 3', () => expect(drops.convert(3)).toEqual('Pling'));
+  xtest('converts 5', () => expect(convert(5)).toEqual('Plang'));
 
-  xtest('converts 5', () => expect(drops.convert(5)).toEqual('Plang'));
+  xtest('converts 7', () => expect(convert(7)).toEqual('Plong'));
 
-  xtest('converts 7', () => expect(drops.convert(7)).toEqual('Plong'));
+  xtest('converts 6', () => expect(convert(6)).toEqual('Pling'));
 
-  xtest('converts 6', () => expect(drops.convert(6)).toEqual('Pling'));
+  xtest('converts 9', () => expect(convert(9)).toEqual('Pling'));
 
-  xtest('converts 9', () => expect(drops.convert(9)).toEqual('Pling'));
+  xtest('converts 10', () => expect(convert(10)).toEqual('Plang'));
 
-  xtest('converts 10', () => expect(drops.convert(10)).toEqual('Plang'));
+  xtest('converts 14', () => expect(convert(14)).toEqual('Plong'));
 
-  xtest('converts 14', () => expect(drops.convert(14)).toEqual('Plong'));
+  xtest('converts 15', () => expect(convert(15)).toEqual('PlingPlang'));
 
-  xtest('converts 15', () => expect(drops.convert(15)).toEqual('PlingPlang'));
+  xtest('converts 21', () => expect(convert(21)).toEqual('PlingPlong'));
 
-  xtest('converts 21', () => expect(drops.convert(21)).toEqual('PlingPlong'));
+  xtest('converts 25', () => expect(convert(25)).toEqual('Plang'));
 
-  xtest('converts 25', () => expect(drops.convert(25)).toEqual('Plang'));
+  xtest('converts 35', () => expect(convert(35)).toEqual('PlangPlong'));
 
-  xtest('converts 35', () => expect(drops.convert(35)).toEqual('PlangPlong'));
+  xtest('converts 49', () => expect(convert(49)).toEqual('Plong'));
 
-  xtest('converts 49', () => expect(drops.convert(49)).toEqual('Plong'));
+  xtest('converts 52', () => expect(convert(52)).toEqual('52'));
 
-  xtest('converts 52', () => expect(drops.convert(52)).toEqual('52'));
+  xtest('converts 105', () => expect(convert(105)).toEqual('PlingPlangPlong'));
 
-  xtest('converts 105', () => expect(drops.convert(105)).toEqual('PlingPlangPlong'));
-
-  xtest('converts 12121', () => expect(drops.convert(12121)).toEqual('12121'));
+  xtest('converts 12121', () => expect(convert(12121)).toEqual('12121'));
 });


### PR DESCRIPTION
Similar in nature to #567, but for the `raindrops` exercise. There is no stateful information used in this exercise, so a class-based implementation is not necessary.