### PR TITLE
Curriculum change: track sequence (round 1)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.js text eol=lf

--- a/bin/generate-config-tree
+++ b/bin/generate-config-tree
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+const { exercises } = require('../config.json')
+const TAG_CORE = '__core'
+const TAG_BONUS = '__bonus'
+
+// node inter-opt exports
+exports.TAG_CORE = TAG_CORE
+exports.TAG_BONUS = TAG_BONUS
+
+exports.tree = exercises.reduce((result, exercise) => {
+    const tag = exercise.slug
+    const item = {
+        slug: tag,
+        difficulty: exercise.difficulty
+    }
+
+    if (exercise.core) {
+        const current = result[TAG_CORE] || []
+
+        if (result[tag]) {
+            console.warn(`${tag} is not ordered correctly in config.json`)
+        }
+
+        return {
+            ...result,
+            __core: current.concat([item])
+        }
+    }
+
+    const parent = exercise.unlocked_by || TAG_BONUS
+    const current = result[parent] || []
+    return { ...result, [parent]: current.concat([item]) }
+}, {})

--- a/bin/generate-config-tree
+++ b/bin/generate-config-tree
@@ -12,7 +12,7 @@ exports.tree = exercises.reduce((result, exercise) => {
     const tag = exercise.slug
     const item = {
         slug: tag,
-        difficulty: exercise.difficulty
+        difficulty: exercise.difficulty,
     }
 
     if (exercise.core) {
@@ -24,7 +24,8 @@ exports.tree = exercises.reduce((result, exercise) => {
 
         return {
             ...result,
-            __core: current.concat([item])
+            __core: current.concat([item]),
+            [tag]: result[tag] || []
         }
     }
 

--- a/bin/print-config-tree
+++ b/bin/print-config-tree
@@ -22,8 +22,9 @@ printLn('core')
 printLn('----')
 Object.keys(track).forEach(slug => {
     printLn(`├─ ${slug}`)
-    track[slug].forEach(side => {
-        printLn(`│  ├─ ${side.slug} (${side.difficulty})`)
+    track[slug].forEach((side, index, self) => {
+        junction = index === self.length - 1 ? '└─' : '├─'
+        printLn(`│  ${junction} ${side.slug} (${side.difficulty})`)
     })
     printLn('│')
 })

--- a/bin/print-config-tree
+++ b/bin/print-config-tree
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+const actions = require('./generate-config-tree')
+
+const { tree, TAG_BONUS, TAG_CORE } = actions
+const { [TAG_BONUS]: __bonus, [TAG_CORE]: __core, ...track } = tree
+
+function printLn(line) {
+    process.stdout.write(`${line}\n`)
+}
+
+function printList(items) {
+    items.forEach(item => {
+        printLn(`- ${item.slug} (${item.difficulty})`)
+    })
+}
+
+printLn('Core (matches config.json) of this track:')
+printList(__core)
+printLn('\n')
+printLn('core')
+printLn('----')
+Object.keys(track).forEach(slug => {
+    printLn(`├─ ${slug}`)
+    track[slug].forEach(side => {
+        printLn(`│  ├─ ${side.slug} (${side.difficulty})`)
+    })
+    printLn('│')
+})
+
+printLn('bonus')
+printLn('----')
+printList(__bonus)

--- a/config.json
+++ b/config.json
@@ -1215,7 +1215,7 @@
       "slug": "sieve",
       "uuid": "127287d1-ba44-4400-884a-6fe5f72e210f",
       "core": false,
-      "unlocked_by": "prime-factors",
+      "unlocked_by": "space-age",
       "difficulty": 5,
       "topics": [
         "control_flow_conditionals",
@@ -1261,7 +1261,7 @@
       "slug": "nth-prime",
       "uuid": "7ce09989-f202-4c3c-8b7e-72cef18808c3",
       "core": false,
-      "unlocked_by": "prime-factors",
+      "unlocked_by": "space-age",
       "difficulty": 5,
       "topics": [
         "algorithms",
@@ -1276,7 +1276,7 @@
       "slug": "palindrome-products",
       "uuid": "f6799d10-0210-4c73-ac08-d5cac1a00ff3",
       "core": false,
-      "unlocked_by": "prime-factors",
+      "unlocked_by": "space-age",
       "difficulty": 7,
       "topics": [
         "algorithms",
@@ -1291,7 +1291,7 @@
       "slug": "sum-of-multiples",
       "uuid": "f7452f71-795b-40b6-847c-67ef4bb9db45",
       "core": false,
-      "unlocked_by": "prime-factors",
+      "unlocked_by": "secret-handshake",
       "difficulty": 5,
       "topics": [
         "control_flow_conditionals",
@@ -1348,7 +1348,7 @@
       "slug": "change",
       "uuid": "cfa5741c-9fe9-4cb5-a322-d77ba8145f4b",
       "core": false,
-      "unlocked_by": "prime-factors",
+      "unlocked_by": "secret-handshake",
       "difficulty": 8,
       "topics": [
         "algorithms",

--- a/config.json
+++ b/config.json
@@ -52,18 +52,14 @@
       ]
     },
     {
-      "slug": "bob",
-      "uuid": "a5bf36f0-5d3c-41d4-8d54-e37e484e59cd",
+      "slug": "space-age",
+      "uuid": "d9d757ed-ebe6-4d4a-aa73-f6834221cd54",
       "core": true,
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "control_flow_conditionals",
-        "pattern_recognition",
-        "polymorfism",
-        "regular_expressions",
-        "strings",
-        "unicode"
+        "classes",
+        "floating_point_numbers"
       ]
     },
     {
@@ -83,28 +79,46 @@
       ]
     },
     {
-      "slug": "space-age",
-      "uuid": "d9d757ed-ebe6-4d4a-aa73-f6834221cd54",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "classes",
-        "floating_point_numbers"
-      ]
-    },
-    {
       "slug": "matrix",
       "uuid": "dd0b5e67-81f6-437e-8334-2ec0dfeb862a",
       "core": true,
       "unlocked_by": null,
-      "difficulty": 4,
+      "difficulty": 3,
       "topics": [
         "arrays",
         "control_flow_conditionals",
         "control_flow_loops",
         "data_structures",
         "matrices",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "bob",
+      "uuid": "a5bf36f0-5d3c-41d4-8d54-e37e484e59cd",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "control_flow_conditionals",
+        "pattern_recognition",
+        "polymorfism",
+        "regular_expressions",
+        "strings",
+        "unicode"
+      ]
+    },
+    {
+      "slug": "pascals-triangle",
+      "uuid": "99493160-4673-402f-acda-62db5378148d",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "math",
+        "strings",
         "text_formatting"
       ]
     },
@@ -137,6 +151,19 @@
       ]
     },
     {
+      "slug": "list-ops",
+      "uuid": "7d9db056-5398-41b6-af3b-9707f5eb0dbc",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 6,
+      "topics": [
+        "control_flow_loops",
+        "data_structures",
+        "lists",
+        "recursion"
+      ]
+    },
+    {
       "slug": "robot-name",
       "uuid": "03f4dfea-e6db-4754-b2c8-ca06c8b81ef1",
       "core": true,
@@ -148,20 +175,6 @@
         "randomness",
         "regular_expressions",
         "sets"
-      ]
-    },
-    {
-      "slug": "pascals-triangle",
-      "uuid": "99493160-4673-402f-acda-62db5378148d",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 5,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "math",
-        "strings",
-        "text_formatting"
       ]
     },
     {
@@ -209,19 +222,6 @@
         "control_flow_conditionals",
         "control_flow_loops",
         "games"
-      ]
-    },
-    {
-      "slug": "list-ops",
-      "uuid": "7d9db056-5398-41b6-af3b-9707f5eb0dbc",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 8,
-      "topics": [
-        "control_flow_loops",
-        "data_structures",
-        "lists",
-        "recursion"
       ]
     },
     {

--- a/config.json
+++ b/config.json
@@ -35,7 +35,7 @@
       "uuid": "fd7b62d4-266b-4e84-a526-bf3d47901216",
       "core": true,
       "unlocked_by": null,
-      "difficulty": 2,
+      "difficulty": 1,
       "topics": [
         "time"
       ]
@@ -45,7 +45,7 @@
       "uuid": "342974d6-9083-4754-a6c5-ed1e19e40ec5",
       "core": true,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": [
         "strings",
         "transforming"
@@ -143,7 +143,7 @@
       "uuid": "64637322-33bc-401f-8cec-1f9810a41f75",
       "core": true,
       "unlocked_by": null,
-      "difficulty": 6,
+      "difficulty": 5,
       "topics": [
         "arrays",
         "maps",

--- a/config.json
+++ b/config.json
@@ -5,47 +5,6 @@
   "test_pattern": ".*[.]spec[.]js$",
   "exercises": [
     {
-      "slug": "zipper",
-      "uuid": "fd1575f3-3087-4cfa-8a26-168fba6d0606",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 8,
-      "topics": [
-        "recursion",
-        "searching",
-        "trees"
-      ]
-    },
-    {
-      "slug": "point-mutations",
-      "uuid": "6d43709b-3809-4a6a-ab41-2a5ab841b5fb",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 0,
-      "topics": null,
-      "deprecated": true
-    },
-    {
-      "slug": "forth",
-      "uuid": "e4035939-4375-4720-87ae-e613f925f013",
-      "core": false,
-      "unlocked_by": "matrix",
-      "difficulty": 8,
-      "topics": [
-        "domain_specific_languages",
-        "parsing",
-        "stacks"
-      ]
-    },
-    {
-      "slug": "darts",
-      "uuid": "6c64649b-ea81-4118-9e74-a0a55018ffbc",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": null
-    },
-    {
       "slug": "hello-world",
       "uuid": "9ce0f408-6d7b-4466-a390-75aeaf9492f2",
       "core": true,
@@ -72,15 +31,13 @@
       ]
     },
     {
-      "slug": "reverse-string",
-      "uuid": "e84c97eb-dbec-487c-b99f-ae9924e16293",
-      "core": false,
-      "unlocked_by": "leap",
+      "slug": "gigasecond",
+      "uuid": "fd7b62d4-266b-4e84-a526-bf3d47901216",
+      "core": true,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "for",
-        "loops",
-        "strings"
+        "time"
       ]
     },
     {
@@ -95,19 +52,18 @@
       ]
     },
     {
-      "slug": "simple-cipher",
-      "uuid": "62d60b42-93bc-4de9-90d1-1ca18a847812",
+      "slug": "bob",
+      "uuid": "a5bf36f0-5d3c-41d4-8d54-e37e484e59cd",
       "core": true,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": [
-        "algorithms",
         "control_flow_conditionals",
-        "control_flow_loops",
-        "randomness",
+        "pattern_recognition",
+        "polymorfism",
+        "regular_expressions",
         "strings",
-        "text_formatting",
-        "transforming"
+        "unicode"
       ]
     },
     {
@@ -127,31 +83,6 @@
       ]
     },
     {
-      "slug": "bob",
-      "uuid": "a5bf36f0-5d3c-41d4-8d54-e37e484e59cd",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "control_flow_conditionals",
-        "pattern_recognition",
-        "polymorfism",
-        "regular_expressions",
-        "strings",
-        "unicode"
-      ]
-    },
-    {
-      "slug": "gigasecond",
-      "uuid": "fd7b62d4-266b-4e84-a526-bf3d47901216",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "time"
-      ]
-    },
-    {
       "slug": "space-age",
       "uuid": "d9d757ed-ebe6-4d4a-aa73-f6834221cd54",
       "core": true,
@@ -160,37 +91,6 @@
       "topics": [
         "classes",
         "floating_point_numbers"
-      ]
-    },
-    {
-      "slug": "binary",
-      "uuid": "0ba4d3b9-2519-49ac-bd93-f960aca6c11f",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "exception_handling",
-        "integers",
-        "mathematics",
-        "regular_expressions",
-        "strings"
-      ],
-      "deprecated": true
-    },
-    {
-      "slug": "prime-factors",
-      "uuid": "f43cdddf-eea8-4c4a-8359-c69e20ff9661",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "algorithms",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "math"
       ]
     },
     {
@@ -225,35 +125,6 @@
       ]
     },
     {
-      "slug": "pascals-triangle",
-      "uuid": "99493160-4673-402f-acda-62db5378148d",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 5,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "math",
-        "strings",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "secret-handshake",
-      "uuid": "74bbc9e3-edc5-41e0-84d7-5b2d98dd8370",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 6,
-      "topics": [
-        "algorithms",
-        "arrays",
-        "bitwise_operations",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "games"
-      ]
-    },
-    {
       "slug": "grade-school",
       "uuid": "64637322-33bc-401f-8cec-1f9810a41f75",
       "core": true,
@@ -280,6 +151,36 @@
       ]
     },
     {
+      "slug": "pascals-triangle",
+      "uuid": "99493160-4673-402f-acda-62db5378148d",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 5,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "math",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "simple-cipher",
+      "uuid": "62d60b42-93bc-4de9-90d1-1ca18a847812",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "algorithms",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "randomness",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ]
+    },
+    {
       "slug": "wordy",
       "uuid": "9131bdb8-2e0f-4526-b113-8a77712e7216",
       "core": true,
@@ -293,6 +194,21 @@
         "pattern_recognition",
         "regular_expressions",
         "strings"
+      ]
+    },
+    {
+      "slug": "secret-handshake",
+      "uuid": "74bbc9e3-edc5-41e0-84d7-5b2d98dd8370",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 6,
+      "topics": [
+        "algorithms",
+        "arrays",
+        "bitwise_operations",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "games"
       ]
     },
     {
@@ -323,123 +239,15 @@
       ]
     },
     {
-      "slug": "hamming",
-      "uuid": "d773c4ef-c09e-40e4-a7fe-01456cb4a12a",
+      "slug": "reverse-string",
+      "uuid": "e84c97eb-dbec-487c-b99f-ae9924e16293",
       "core": false,
-      "unlocked_by": "rna-transcription",
+      "unlocked_by": "leap",
       "difficulty": 2,
       "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "equality",
+        "for",
+        "loops",
         "strings"
-      ]
-    },
-    {
-      "slug": "isogram",
-      "uuid": "3df577af-2854-40ee-b211-9b608dbbad58",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 2,
-      "topics": [
-        "filtering",
-        "strings"
-      ]
-    },
-    {
-      "slug": "beer-song",
-      "uuid": "6573f168-d8fc-4ccf-a864-1a61f432fae1",
-      "core": false,
-      "unlocked_by": "bob",
-      "difficulty": 5,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "strings"
-      ]
-    },
-    {
-      "slug": "phone-number",
-      "uuid": "82775adb-eabe-4d44-91f5-4080b8834a4a",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 3,
-      "topics": [
-        "parsing",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "anagram",
-      "uuid": "309fa4f1-e03a-4ab2-b371-cdf742501cf7",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 1,
-      "topics": [
-        "filtering",
-        "strings"
-      ]
-    },
-    {
-      "slug": "food-chain",
-      "uuid": "62672dc7-e827-4c2e-a282-d6df45b60bbd",
-      "core": false,
-      "unlocked_by": "bob",
-      "difficulty": 4,
-      "topics": [
-        "algorithms",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "etl",
-      "uuid": "db16804b-0f63-445d-8beb-99e0f7218d66",
-      "core": false,
-      "unlocked_by": "rna-transcription",
-      "difficulty": 2,
-      "topics": [
-        "control_flow_loops",
-        "integers",
-        "maps",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "sublist",
-      "uuid": "4be85b5e-6b13-11e7-907b-a6006ad3dba0",
-      "core": false,
-      "unlocked_by": "linked-list",
-      "difficulty": 4,
-      "topics": [
-        "arrays",
-        "lists"
-      ]
-    },
-    {
-      "slug": "word-search",
-      "uuid": "0125f5a7-8883-4553-a6c1-45f19544af5e",
-      "core": false,
-      "unlocked_by": "linked-list",
-      "difficulty": 8,
-      "topics": [
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "equality",
-        "optional_values",
-        "parsing",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "grains",
-      "uuid": "d003975a-9045-4f03-9ad9-c15db584dc13",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 5,
-      "topics": [
-        "control_flow_loops",
-        "integers"
       ]
     },
     {
@@ -483,59 +291,43 @@
       ]
     },
     {
-      "slug": "perfect-numbers",
-      "uuid": "c6691fd2-e10d-47df-acbf-3adeac5a2f89",
+      "slug": "meetup",
+      "uuid": "98617798-b49d-4d43-9f65-7131ee73d626",
       "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 3,
+      "unlocked_by": "gigasecond",
+      "difficulty": 7,
       "topics": [
-        "arrays",
         "control_flow_conditionals",
+        "control_flow_loops",
+        "dates",
+        "equality",
+        "exception_handling",
+        "time"
+      ]
+    },
+    {
+      "slug": "hamming",
+      "uuid": "d773c4ef-c09e-40e4-a7fe-01456cb4a12a",
+      "core": false,
+      "unlocked_by": "rna-transcription",
+      "difficulty": 2,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "equality",
+        "strings"
+      ]
+    },
+    {
+      "slug": "etl",
+      "uuid": "db16804b-0f63-445d-8beb-99e0f7218d66",
+      "core": false,
+      "unlocked_by": "rna-transcription",
+      "difficulty": 2,
+      "topics": [
         "control_flow_loops",
         "integers",
-        "math"
-      ]
-    },
-    {
-      "slug": "word-count",
-      "uuid": "0073ff9a-cd6a-43cf-b8bf-4d5d8117b81b",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 1,
-      "topics": [
-        "control_flow_loops",
-        "lists",
-        "regular_expressions",
-        "strings",
-        "unicode"
-      ]
-    },
-    {
-      "slug": "run-length-encoding",
-      "uuid": "6ac4ad5f-a64a-4646-91c5-169d53f289f9",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "control_flow_conditionals",
-        "exception_handling",
-        "parsing",
-        "pattern_recognition",
-        "regular_expressions",
-        "strings",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "acronym",
-      "uuid": "440d78d1-9dea-466f-9bd4-935eed067409",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 2,
-      "topics": [
-        "control_flow_loops",
-        "regular_expressions",
-        "strings",
+        "maps",
         "transforming"
       ]
     },
@@ -550,46 +342,6 @@
         "control_flow_loops",
         "maps",
         "strings"
-      ]
-    },
-    {
-      "slug": "roman-numerals",
-      "uuid": "2fc4f834-a51c-42b8-a4d9-5263229e7648",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "pattern_recognition",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "circular-buffer",
-      "uuid": "bf0b1f95-3425-4345-8a12-3a80d49b49c9",
-      "core": false,
-      "unlocked_by": "linked-list",
-      "difficulty": 8,
-      "topics": [
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "data_structures",
-        "exception_handling",
-        "lists"
-      ]
-    },
-    {
-      "slug": "react",
-      "uuid": "303c6969-9446-41aa-871a-11223a43e810",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 8,
-      "topics": [
-        "algorithms",
-        "events",
-        "reactive_programming"
       ]
     },
     {
@@ -619,19 +371,598 @@
       ]
     },
     {
-      "slug": "strain",
-      "uuid": "8407f9d5-7a7e-40c8-aace-a6a8294ae5e9",
+      "slug": "nucleotide-count",
+      "uuid": "be6f3ab3-1593-4c2d-8a35-5f39c1d5c91f",
       "core": false,
-      "unlocked_by": "list-ops",
+      "unlocked_by": "rna-transcription",
+      "difficulty": 4,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "6573f168-d8fc-4ccf-a864-1a61f432fae1",
+      "core": false,
+      "unlocked_by": "bob",
+      "difficulty": 5,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "strings"
+      ]
+    },
+    {
+      "slug": "food-chain",
+      "uuid": "62672dc7-e827-4c2e-a282-d6df45b60bbd",
+      "core": false,
+      "unlocked_by": "bob",
       "difficulty": 4,
       "topics": [
         "algorithms",
-        "arrays",
-        "callbacks",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "pig-latin",
+      "uuid": "16e25a38-7ce3-4ccd-b2f0-1550b837fe9b",
+      "core": false,
+      "unlocked_by": "bob",
+      "difficulty": 4,
+      "topics": [
         "control_flow_conditionals",
         "control_flow_loops",
+        "games",
+        "regular_expressions",
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "proverb",
+      "uuid": "5626f5b6-207b-458b-92b6-eff2cadb240a",
+      "core": false,
+      "unlocked_by": "bob",
+      "difficulty": 4,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "optional_values",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "house",
+      "uuid": "a8b7187d-12eb-4efc-b966-87823654ccda",
+      "core": false,
+      "unlocked_by": "bob",
+      "difficulty": 4,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "recursion",
+        "strings"
+      ]
+    },
+    {
+      "slug": "twelve-days",
+      "uuid": "64de1776-d5c6-43fe-9abf-7e3aa08ae342",
+      "core": false,
+      "unlocked_by": "bob",
+      "difficulty": 4,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "pattern_recognition",
+        "polymorfism",
+        "regular_expressions",
+        "strings"
+      ]
+    },
+    {
+      "slug": "say",
+      "uuid": "12989bb3-c593-4f68-bea4-e2c5b76bc3c0",
+      "core": false,
+      "unlocked_by": "bob",
+      "difficulty": 6,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "exception_handling",
+        "integers",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "isbn-verifier",
+      "uuid": "b902c746-60d1-4645-a5bc-dafadec0ef32",
+      "core": false,
+      "unlocked_by": "bob",
+      "difficulty": 4,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "pattern_recognition",
+        "regular_expressions"
+      ]
+    },
+    {
+      "slug": "isogram",
+      "uuid": "3df577af-2854-40ee-b211-9b608dbbad58",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 2,
+      "topics": [
         "filtering",
+        "strings"
+      ]
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "82775adb-eabe-4d44-91f5-4080b8834a4a",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 3,
+      "topics": [
+        "parsing",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "anagram",
+      "uuid": "309fa4f1-e03a-4ab2-b371-cdf742501cf7",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 1,
+      "topics": [
+        "filtering",
+        "strings"
+      ]
+    },
+    {
+      "slug": "word-count",
+      "uuid": "0073ff9a-cd6a-43cf-b8bf-4d5d8117b81b",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 1,
+      "topics": [
+        "control_flow_loops",
+        "lists",
+        "regular_expressions",
+        "strings",
+        "unicode"
+      ]
+    },
+    {
+      "slug": "acronym",
+      "uuid": "440d78d1-9dea-466f-9bd4-935eed067409",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 2,
+      "topics": [
+        "control_flow_loops",
+        "regular_expressions",
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "series",
+      "uuid": "5178ae53-5364-46c9-bee3-70e6e8a8c2e3",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 3,
+      "topics": [
+        "control_flow_loops",
+        "exception_handling",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "1f84305d-ea76-4fe2-9858-3b53576d683d",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 7,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "exception_handling",
+        "integers",
+        "math",
+        "regular_expressions",
+        "strings"
+      ]
+    },
+    {
+      "slug": "bracket-push",
+      "uuid": "4d456646-3a9b-4393-9558-6b30e5c1039c",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 3,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "exception_handling",
+        "parsing",
+        "strings"
+      ]
+    },
+    {
+      "slug": "high-scores",
+      "uuid": "19b41c4a-1466-5c19-b547-40284189fd18",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 2,
+      "topics": [
+        "arrays"
+      ]
+    },
+    {
+      "slug": "grains",
+      "uuid": "d003975a-9045-4f03-9ad9-c15db584dc13",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 5,
+      "topics": [
+        "control_flow_loops",
+        "integers"
+      ]
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "c6691fd2-e10d-47df-acbf-3adeac5a2f89",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 3,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "math"
+      ]
+    },
+    {
+      "slug": "luhn",
+      "uuid": "28872cc9-f1ef-487f-9a79-6bf7983148bf",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 4,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "strings"
+      ]
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "394755a3-c743-4b85-b9b8-387907f4e32d",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 5,
+      "topics": [
+        "algorithms",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "math"
+      ]
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "7dfa878c-83a6-48ef-9170-b6633d51d601",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 3,
+      "topics": [
+        "algorithms",
+        "control_flow_loops",
+        "integers",
+        "math"
+      ]
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "ea9a9a3e-ae6a-470d-8bb4-2afead507f24",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 4,
+      "topics": [
+        "math"
+      ]
+    },
+    {
+      "slug": "forth",
+      "uuid": "e4035939-4375-4720-87ae-e613f925f013",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 8,
+      "topics": [
+        "domain_specific_languages",
+        "parsing",
+        "stacks"
+      ]
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "a01aa48c-65c4-4b1f-b3d9-3ec7da2ef754",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 6,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "equality",
+        "exception_handling",
+        "integers",
+        "matrices",
+        "optional_values",
+        "parsing"
+      ]
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "24c197ee-d492-4083-8615-629cb4b836b2",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 5,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "equality",
+        "exception_handling",
+        "integers",
+        "parsing",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "transpose",
+      "uuid": "9c140fb7-cc8b-411b-b613-a0e0081a9c3f",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 1,
+      "topics": [
+        "arrays",
+        "lists",
+        "loops",
+        "matrices",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "c1abafcc-0d44-4fb5-afae-bff3ce2e1b39",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 4,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "data_structures",
+        "matrices"
+      ]
+    },
+    {
+      "slug": "rectangles",
+      "uuid": "f8c6786e-bf93-4f35-b649-03f4e39bb094",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 4,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "matrices",
+        "strings"
+      ]
+    },
+    {
+      "slug": "sublist",
+      "uuid": "4be85b5e-6b13-11e7-907b-a6006ad3dba0",
+      "core": false,
+      "unlocked_by": "linked-list",
+      "difficulty": 4,
+      "topics": [
+        "arrays",
         "lists"
+      ]
+    },
+    {
+      "slug": "word-search",
+      "uuid": "0125f5a7-8883-4553-a6c1-45f19544af5e",
+      "core": false,
+      "unlocked_by": "linked-list",
+      "difficulty": 8,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "equality",
+        "optional_values",
+        "parsing",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "circular-buffer",
+      "uuid": "bf0b1f95-3425-4345-8a12-3a80d49b49c9",
+      "core": false,
+      "unlocked_by": "linked-list",
+      "difficulty": 8,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "data_structures",
+        "exception_handling",
+        "lists"
+      ]
+    },
+    {
+      "slug": "binary-search",
+      "uuid": "7c569e5d-bb00-44b8-8adc-34253790c19b",
+      "core": false,
+      "unlocked_by": "linked-list",
+      "difficulty": 7,
+      "topics": [
+        "algorithms",
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "recursion"
+      ]
+    },
+    {
+      "slug": "binary-search-tree",
+      "uuid": "6c4b4e25-c115-4789-9058-d28ab6ca0d26",
+      "core": false,
+      "unlocked_by": "linked-list",
+      "difficulty": 6,
+      "topics": [
+        "algorithms",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "recursion"
+      ]
+    },
+    {
+      "slug": "custom-set",
+      "uuid": "75199d72-4cac-49ce-bffb-23fb659c57ae",
+      "core": false,
+      "unlocked_by": "linked-list",
+      "difficulty": 6,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "data_structures",
+        "equality",
+        "lists",
+        "recursion",
+        "sets"
+      ]
+    },
+    {
+      "slug": "simple-linked-list",
+      "uuid": "a1591026-2f02-45f9-b189-24b2359eb43f",
+      "core": false,
+      "unlocked_by": "linked-list",
+      "difficulty": 8,
+      "topics": [
+        "arrays",
+        "data_structures",
+        "lists"
+      ]
+    },
+    {
+      "slug": "two-bucket",
+      "uuid": "0bc6b478-40a8-47ab-889b-c403b922f7e5",
+      "core": false,
+      "unlocked_by": "grade-school",
+      "difficulty": 6,
+      "topics": [
+        "algorithms",
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "exception_handling",
+        "games",
+        "parsing"
+      ]
+    },
+    {
+      "slug": "bowling",
+      "uuid": "dbf26ef1-62ff-4cb1-8ac7-09b022df3b2f",
+      "core": false,
+      "unlocked_by": "grade-school",
+      "difficulty": 8,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "exception_handling",
+        "games",
+        "parsing",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "alphametics",
+      "uuid": "a602bd33-69fc-4b67-a3d3-95198853095e",
+      "core": false,
+      "unlocked_by": "grade-school",
+      "difficulty": 7,
+      "topics": [
+        "algorithms",
+        "games"
+      ]
+    },
+    {
+      "slug": "connect",
+      "uuid": "2fa2c262-77ae-409b-bfd8-1d643faae772",
+      "core": false,
+      "unlocked_by": "grade-school",
+      "difficulty": 7,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "games",
+        "maps",
+        "parsing"
+      ]
+    },
+    {
+      "slug": "variable-length-quantity",
+      "uuid": "6be39d1f-f68d-4a52-bd72-85a38ffd509e",
+      "core": false,
+      "unlocked_by": "grade-school",
+      "difficulty": 5,
+      "topics": [
+        "bitwise_operations",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "diamond",
+      "uuid": "6a1eee0e-f8d4-446d-9c52-f31c3700af1b",
+      "core": false,
+      "unlocked_by": "pascals-triangle",
+      "difficulty": 5,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "exception_handling",
+        "games",
+        "parsing",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "rational-numbers",
+      "uuid": "d8da6cdd-3804-40b0-9821-0dd5765876ff",
+      "core": false,
+      "unlocked_by": "pascals-triangle",
+      "difficulty": 5,
+      "topics": [
+        "algorithms",
+        "floating_point_numbers",
+        "math"
       ]
     },
     {
@@ -650,19 +981,6 @@
       ]
     },
     {
-      "slug": "accumulate",
-      "uuid": "6ebe247c-3d11-48b7-8e6f-39f98359d233",
-      "core": false,
-      "unlocked_by": "list-ops",
-      "difficulty": 5,
-      "topics": [
-        "algorithms",
-        "callbacks",
-        "control_flow_loops",
-        "lists"
-      ]
-    },
-    {
       "slug": "crypto-square",
       "uuid": "4dc30879-a589-4dd3-b7b6-22261f9d1520",
       "core": false,
@@ -677,6 +995,204 @@
         "sorting",
         "text_formatting",
         "transforming"
+      ]
+    },
+    {
+      "slug": "diffie-hellman",
+      "uuid": "127eccbd-3009-4a8f-95c1-7d8aeb608550",
+      "core": false,
+      "unlocked_by": "simple-cipher",
+      "difficulty": 3,
+      "topics": [
+        "algorithms",
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "exception_handling",
+        "math"
+      ]
+    },
+    {
+      "slug": "rotational-cipher",
+      "uuid": "34625b04-844e-41e3-b02b-3443b6b0b7cb",
+      "core": false,
+      "unlocked_by": "simple-cipher",
+      "difficulty": 2,
+      "topics": [
+        "control_flow_conditionals",
+        "strings",
+        "text_formatting",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "kindergarten-garden",
+      "uuid": "13444eff-005a-405e-9737-7b64d99c1a61",
+      "core": false,
+      "unlocked_by": "wordy",
+      "difficulty": 7,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "5174bd15-eee2-4b53-b3ee-ca3a8c958a31",
+      "core": false,
+      "unlocked_by": "wordy",
+      "difficulty": 5,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "exception_handling",
+        "games",
+        "parsing",
+        "strings"
+      ]
+    },
+    {
+      "slug": "strain",
+      "uuid": "8407f9d5-7a7e-40c8-aace-a6a8294ae5e9",
+      "core": false,
+      "unlocked_by": "list-ops",
+      "difficulty": 4,
+      "topics": [
+        "algorithms",
+        "arrays",
+        "callbacks",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "filtering",
+        "lists"
+      ]
+    },
+    {
+      "slug": "accumulate",
+      "uuid": "6ebe247c-3d11-48b7-8e6f-39f98359d233",
+      "core": false,
+      "unlocked_by": "list-ops",
+      "difficulty": 5,
+      "topics": [
+        "algorithms",
+        "callbacks",
+        "control_flow_loops",
+        "lists"
+      ]
+    },
+    {
+      "slug": "flatten-array",
+      "uuid": "1a6c4a3b-d5db-4a5a-b123-66cf085defe6",
+      "core": false,
+      "unlocked_by": "list-ops",
+      "difficulty": 5,
+      "topics": [
+        "arrays",
+        "recursion"
+      ]
+    },
+    {
+      "slug": "zipper",
+      "uuid": "fd1575f3-3087-4cfa-8a26-168fba6d0606",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 8,
+      "topics": [
+        "recursion",
+        "searching",
+        "trees"
+      ]
+    },
+    {
+      "slug": "point-mutations",
+      "uuid": "6d43709b-3809-4a6a-ab41-2a5ab841b5fb",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 0,
+      "topics": null,
+      "deprecated": true
+    },
+    {
+      "slug": "darts",
+      "uuid": "6c64649b-ea81-4118-9e74-a0a55018ffbc",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": null
+    },
+    {
+      "slug": "binary",
+      "uuid": "0ba4d3b9-2519-49ac-bd93-f960aca6c11f",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "exception_handling",
+        "integers",
+        "mathematics",
+        "regular_expressions",
+        "strings"
+      ],
+      "deprecated": true
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "f43cdddf-eea8-4c4a-8359-c69e20ff9661",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "algorithms",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "math"
+      ]
+    },
+    {
+      "slug": "run-length-encoding",
+      "uuid": "6ac4ad5f-a64a-4646-91c5-169d53f289f9",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "control_flow_conditionals",
+        "exception_handling",
+        "parsing",
+        "pattern_recognition",
+        "regular_expressions",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "2fc4f834-a51c-42b8-a4d9-5263229e7648",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "pattern_recognition",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "react",
+      "uuid": "303c6969-9446-41aa-871a-11223a43e810",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 8,
+      "topics": [
+        "algorithms",
+        "events",
+        "reactive_programming"
       ]
     },
     {
@@ -726,100 +1242,6 @@
       "deprecated": true
     },
     {
-      "slug": "luhn",
-      "uuid": "28872cc9-f1ef-487f-9a79-6bf7983148bf",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 4,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "strings"
-      ]
-    },
-    {
-      "slug": "pig-latin",
-      "uuid": "16e25a38-7ce3-4ccd-b2f0-1550b837fe9b",
-      "core": false,
-      "unlocked_by": "bob",
-      "difficulty": 4,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "games",
-        "regular_expressions",
-        "strings",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "pythagorean-triplet",
-      "uuid": "394755a3-c743-4b85-b9b8-387907f4e32d",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 5,
-      "topics": [
-        "algorithms",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "math"
-      ]
-    },
-    {
-      "slug": "series",
-      "uuid": "5178ae53-5364-46c9-bee3-70e6e8a8c2e3",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 3,
-      "topics": [
-        "control_flow_loops",
-        "exception_handling",
-        "strings",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "difference-of-squares",
-      "uuid": "7dfa878c-83a6-48ef-9170-b6633d51d601",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 3,
-      "topics": [
-        "algorithms",
-        "control_flow_loops",
-        "integers",
-        "math"
-      ]
-    },
-    {
-      "slug": "proverb",
-      "uuid": "5626f5b6-207b-458b-92b6-eff2cadb240a",
-      "core": false,
-      "unlocked_by": "bob",
-      "difficulty": 4,
-      "topics": [
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "optional_values",
-        "strings",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "flatten-array",
-      "uuid": "1a6c4a3b-d5db-4a5a-b123-66cf085defe6",
-      "core": false,
-      "unlocked_by": "list-ops",
-      "difficulty": 5,
-      "topics": [
-        "arrays",
-        "recursion"
-      ]
-    },
-    {
       "slug": "hexadecimal",
       "uuid": "8ed2c9fe-a13f-4313-abf9-125f351c85c9",
       "core": false,
@@ -834,92 +1256,6 @@
         "strings"
       ],
       "deprecated": true
-    },
-    {
-      "slug": "largest-series-product",
-      "uuid": "1f84305d-ea76-4fe2-9858-3b53576d683d",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 7,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "exception_handling",
-        "integers",
-        "math",
-        "regular_expressions",
-        "strings"
-      ]
-    },
-    {
-      "slug": "kindergarten-garden",
-      "uuid": "13444eff-005a-405e-9737-7b64d99c1a61",
-      "core": false,
-      "unlocked_by": "wordy",
-      "difficulty": 7,
-      "topics": [
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "strings",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "house",
-      "uuid": "a8b7187d-12eb-4efc-b966-87823654ccda",
-      "core": false,
-      "unlocked_by": "bob",
-      "difficulty": 4,
-      "topics": [
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "recursion",
-        "strings"
-      ]
-    },
-    {
-      "slug": "binary-search",
-      "uuid": "7c569e5d-bb00-44b8-8adc-34253790c19b",
-      "core": false,
-      "unlocked_by": "linked-list",
-      "difficulty": 7,
-      "topics": [
-        "algorithms",
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "recursion"
-      ]
-    },
-    {
-      "slug": "binary-search-tree",
-      "uuid": "6c4b4e25-c115-4789-9058-d28ab6ca0d26",
-      "core": false,
-      "unlocked_by": "linked-list",
-      "difficulty": 6,
-      "topics": [
-        "algorithms",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "recursion"
-      ]
-    },
-    {
-      "slug": "robot-simulator",
-      "uuid": "5174bd15-eee2-4b53-b3ee-ca3a8c958a31",
-      "core": false,
-      "unlocked_by": "wordy",
-      "difficulty": 5,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "exception_handling",
-        "games",
-        "parsing",
-        "strings"
-      ]
     },
     {
       "slug": "nth-prime",
@@ -949,38 +1285,6 @@
         "exception_handling",
         "integers",
         "math"
-      ]
-    },
-    {
-      "slug": "say",
-      "uuid": "12989bb3-c593-4f68-bea4-e2c5b76bc3c0",
-      "core": false,
-      "unlocked_by": "bob",
-      "difficulty": 6,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "exception_handling",
-        "integers",
-        "strings",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "custom-set",
-      "uuid": "75199d72-4cac-49ce-bffb-23fb659c57ae",
-      "core": false,
-      "unlocked_by": "linked-list",
-      "difficulty": 6,
-      "topics": [
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "data_structures",
-        "equality",
-        "lists",
-        "recursion",
-        "sets"
       ]
     },
     {
@@ -1014,116 +1318,6 @@
       ]
     },
     {
-      "slug": "saddle-points",
-      "uuid": "a01aa48c-65c4-4b1f-b3d9-3ec7da2ef754",
-      "core": false,
-      "unlocked_by": "matrix",
-      "difficulty": 6,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "equality",
-        "exception_handling",
-        "integers",
-        "matrices",
-        "optional_values",
-        "parsing"
-      ]
-    },
-    {
-      "slug": "ocr-numbers",
-      "uuid": "24c197ee-d492-4083-8615-629cb4b836b2",
-      "core": false,
-      "unlocked_by": "matrix",
-      "difficulty": 5,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "equality",
-        "exception_handling",
-        "integers",
-        "parsing",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "meetup",
-      "uuid": "98617798-b49d-4d43-9f65-7131ee73d626",
-      "core": false,
-      "unlocked_by": "gigasecond",
-      "difficulty": 7,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "dates",
-        "equality",
-        "exception_handling",
-        "time"
-      ]
-    },
-    {
-      "slug": "bracket-push",
-      "uuid": "4d456646-3a9b-4393-9558-6b30e5c1039c",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 3,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "exception_handling",
-        "parsing",
-        "strings"
-      ]
-    },
-    {
-      "slug": "two-bucket",
-      "uuid": "0bc6b478-40a8-47ab-889b-c403b922f7e5",
-      "core": false,
-      "unlocked_by": "grade-school",
-      "difficulty": 6,
-      "topics": [
-        "algorithms",
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "exception_handling",
-        "games",
-        "parsing"
-      ]
-    },
-    {
-      "slug": "bowling",
-      "uuid": "dbf26ef1-62ff-4cb1-8ac7-09b022df3b2f",
-      "core": false,
-      "unlocked_by": "grade-school",
-      "difficulty": 8,
-      "topics": [
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "exception_handling",
-        "games",
-        "parsing",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "diamond",
-      "uuid": "6a1eee0e-f8d4-446d-9c52-f31c3700af1b",
-      "core": false,
-      "unlocked_by": "pascals-triangle",
-      "difficulty": 5,
-      "topics": [
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "exception_handling",
-        "games",
-        "parsing",
-        "text_formatting"
-      ]
-    },
-    {
       "slug": "all-your-base",
       "uuid": "d2d3cd13-b06c-4c24-9964-fb1554f70dd4",
       "core": false,
@@ -1151,59 +1345,6 @@
       ]
     },
     {
-      "slug": "alphametics",
-      "uuid": "a602bd33-69fc-4b67-a3d3-95198853095e",
-      "core": false,
-      "unlocked_by": "grade-school",
-      "difficulty": 7,
-      "topics": [
-        "algorithms",
-        "games"
-      ]
-    },
-    {
-      "slug": "simple-linked-list",
-      "uuid": "a1591026-2f02-45f9-b189-24b2359eb43f",
-      "core": false,
-      "unlocked_by": "linked-list",
-      "difficulty": 8,
-      "topics": [
-        "arrays",
-        "data_structures",
-        "lists"
-      ]
-    },
-    {
-      "slug": "connect",
-      "uuid": "2fa2c262-77ae-409b-bfd8-1d643faae772",
-      "core": false,
-      "unlocked_by": "grade-school",
-      "difficulty": 7,
-      "topics": [
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "games",
-        "maps",
-        "parsing"
-      ]
-    },
-    {
-      "slug": "diffie-hellman",
-      "uuid": "127eccbd-3009-4a8f-95c1-7d8aeb608550",
-      "core": false,
-      "unlocked_by": "simple-cipher",
-      "difficulty": 3,
-      "topics": [
-        "algorithms",
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "exception_handling",
-        "math"
-      ]
-    },
-    {
       "slug": "change",
       "uuid": "cfa5741c-9fe9-4cb5-a322-d77ba8145f4b",
       "core": false,
@@ -1213,59 +1354,6 @@
         "algorithms",
         "performance",
         "searching"
-      ]
-    },
-    {
-      "slug": "twelve-days",
-      "uuid": "64de1776-d5c6-43fe-9abf-7e3aa08ae342",
-      "core": false,
-      "unlocked_by": "bob",
-      "difficulty": 4,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "pattern_recognition",
-        "polymorfism",
-        "regular_expressions",
-        "strings"
-      ]
-    },
-    {
-      "slug": "complex-numbers",
-      "uuid": "ea9a9a3e-ae6a-470d-8bb4-2afead507f24",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 4,
-      "topics": [
-        "math"
-      ]
-    },
-    {
-      "slug": "isbn-verifier",
-      "uuid": "b902c746-60d1-4645-a5bc-dafadec0ef32",
-      "core": false,
-      "unlocked_by": "bob",
-      "difficulty": 4,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "pattern_recognition",
-        "regular_expressions"
-      ]
-    },
-    {
-      "slug": "transpose",
-      "uuid": "9c140fb7-cc8b-411b-b613-a0e0081a9c3f",
-      "core": false,
-      "unlocked_by": "matrix",
-      "difficulty": 1,
-      "topics": [
-        "arrays",
-        "lists",
-        "loops",
-        "matrices",
-        "strings",
-        "text_formatting"
       ]
     },
     {
@@ -1282,61 +1370,6 @@
       ]
     },
     {
-      "slug": "spiral-matrix",
-      "uuid": "c1abafcc-0d44-4fb5-afae-bff3ce2e1b39",
-      "core": false,
-      "unlocked_by": "matrix",
-      "difficulty": 4,
-      "topics": [
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "data_structures",
-        "matrices"
-      ]
-    },
-    {
-      "slug": "rectangles",
-      "uuid": "f8c6786e-bf93-4f35-b649-03f4e39bb094",
-      "core": false,
-      "unlocked_by": "matrix",
-      "difficulty": 4,
-      "topics": [
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "matrices",
-        "strings"
-      ]
-    },
-    {
-      "slug": "rotational-cipher",
-      "uuid": "34625b04-844e-41e3-b02b-3443b6b0b7cb",
-      "core": false,
-      "unlocked_by": "simple-cipher",
-      "difficulty": 2,
-      "topics": [
-        "control_flow_conditionals",
-        "strings",
-        "text_formatting",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "nucleotide-count",
-      "uuid": "be6f3ab3-1593-4c2d-8a35-5f39c1d5c91f",
-      "core": false,
-      "unlocked_by": "rna-transcription",
-      "difficulty": 4,
-      "topics": [
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "strings",
-        "text_formatting"
-      ]
-    },
-    {
       "slug": "armstrong-numbers",
       "uuid": "b28c34f4-f7af-47db-95c6-f920e020bbba",
       "core": false,
@@ -1345,39 +1378,6 @@
       "topics": [
         "algorithms",
         "math"
-      ]
-    },
-    {
-      "slug": "rational-numbers",
-      "uuid": "d8da6cdd-3804-40b0-9821-0dd5765876ff",
-      "core": false,
-      "unlocked_by": "pascals-triangle",
-      "difficulty": 5,
-      "topics": [
-        "algorithms",
-        "floating_point_numbers",
-        "math"
-      ]
-    },
-    {
-      "slug": "variable-length-quantity",
-      "uuid": "6be39d1f-f68d-4a52-bd72-85a38ffd509e",
-      "core": false,
-      "unlocked_by": "grade-school",
-      "difficulty": 5,
-      "topics": [
-        "bitwise_operations",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "high-scores",
-      "uuid": "19b41c4a-1466-5c19-b547-40284189fd18",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 2,
-      "topics": [
-        "arrays"
       ]
     }
   ]

--- a/config.json
+++ b/config.json
@@ -169,7 +169,7 @@
       "uuid": "62d60b42-93bc-4de9-90d1-1ca18a847812",
       "core": true,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 6,
       "topics": [
         "algorithms",
         "control_flow_conditionals",

--- a/config.json
+++ b/config.json
@@ -384,6 +384,313 @@
         "text_formatting"
       ]
     },
+
+    {
+      "slug": "grains",
+      "uuid": "d003975a-9045-4f03-9ad9-c15db584dc13",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 5,
+      "topics": [
+        "control_flow_loops",
+        "integers"
+      ]
+    },
+    {
+      "slug": "word-count",
+      "uuid": "0073ff9a-cd6a-43cf-b8bf-4d5d8117b81b",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 1,
+      "topics": [
+        "control_flow_loops",
+        "lists",
+        "regular_expressions",
+        "strings",
+        "unicode"
+      ]
+    },
+    {
+      "slug": "perfect-numbers",
+      "uuid": "c6691fd2-e10d-47df-acbf-3adeac5a2f89",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 3,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "math"
+      ]
+    },
+    {
+      "slug": "luhn",
+      "uuid": "28872cc9-f1ef-487f-9a79-6bf7983148bf",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 4,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "strings"
+      ]
+    },
+    {
+      "slug": "pythagorean-triplet",
+      "uuid": "394755a3-c743-4b85-b9b8-387907f4e32d",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 5,
+      "topics": [
+        "algorithms",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "math"
+      ]
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "7dfa878c-83a6-48ef-9170-b6633d51d601",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 3,
+      "topics": [
+        "algorithms",
+        "control_flow_loops",
+        "integers",
+        "math"
+      ]
+    },
+    {
+      "slug": "complex-numbers",
+      "uuid": "ea9a9a3e-ae6a-470d-8bb4-2afead507f24",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 4,
+      "topics": [
+        "math"
+      ]
+    },
+    {
+      "slug": "prime-factors",
+      "uuid": "f43cdddf-eea8-4c4a-8359-c69e20ff9661",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 4,
+      "topics": [
+        "algorithms",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "math"
+      ]
+    },
+    {
+      "slug": "palindrome-products",
+      "uuid": "f6799d10-0210-4c73-ac08-d5cac1a00ff3",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 7,
+      "topics": [
+        "algorithms",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "exception_handling",
+        "integers",
+        "math"
+      ]
+    },
+    {
+      "slug": "isogram",
+      "uuid": "3df577af-2854-40ee-b211-9b608dbbad58",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 2,
+      "topics": [
+        "filtering",
+        "strings"
+      ]
+    },
+    {
+      "slug": "phone-number",
+      "uuid": "82775adb-eabe-4d44-91f5-4080b8834a4a",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 3,
+      "topics": [
+        "parsing",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "anagram",
+      "uuid": "309fa4f1-e03a-4ab2-b371-cdf742501cf7",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 1,
+      "topics": [
+        "filtering",
+        "strings"
+      ]
+    },
+    {
+      "slug": "acronym",
+      "uuid": "440d78d1-9dea-466f-9bd4-935eed067409",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 2,
+      "topics": [
+        "control_flow_loops",
+        "regular_expressions",
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "series",
+      "uuid": "5178ae53-5364-46c9-bee3-70e6e8a8c2e3",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 3,
+      "topics": [
+        "control_flow_loops",
+        "exception_handling",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "1f84305d-ea76-4fe2-9858-3b53576d683d",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 7,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "exception_handling",
+        "integers",
+        "math",
+        "regular_expressions",
+        "strings"
+      ]
+    },
+    {
+      "slug": "bracket-push",
+      "uuid": "4d456646-3a9b-4393-9558-6b30e5c1039c",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 3,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "exception_handling",
+        "parsing",
+        "strings"
+      ]
+    },
+    {
+      "slug": "high-scores",
+      "uuid": "19b41c4a-1466-5c19-b547-40284189fd18",
+      "core": false,
+      "unlocked_by": "pangram",
+      "difficulty": 2,
+      "topics": [
+        "arrays"
+      ]
+    },
+    {
+      "slug": "forth",
+      "uuid": "e4035939-4375-4720-87ae-e613f925f013",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 8,
+      "topics": [
+        "domain_specific_languages",
+        "parsing",
+        "stacks"
+      ]
+    },
+    {
+      "slug": "saddle-points",
+      "uuid": "a01aa48c-65c4-4b1f-b3d9-3ec7da2ef754",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 6,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "equality",
+        "exception_handling",
+        "integers",
+        "matrices",
+        "optional_values",
+        "parsing"
+      ]
+    },
+    {
+      "slug": "ocr-numbers",
+      "uuid": "24c197ee-d492-4083-8615-629cb4b836b2",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 5,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "equality",
+        "exception_handling",
+        "integers",
+        "parsing",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "transpose",
+      "uuid": "9c140fb7-cc8b-411b-b613-a0e0081a9c3f",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 1,
+      "topics": [
+        "arrays",
+        "lists",
+        "loops",
+        "matrices",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "spiral-matrix",
+      "uuid": "c1abafcc-0d44-4fb5-afae-bff3ce2e1b39",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 4,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "data_structures",
+        "matrices"
+      ]
+    },
+    {
+      "slug": "rectangles",
+      "uuid": "f8c6786e-bf93-4f35-b649-03f4e39bb094",
+      "core": false,
+      "unlocked_by": "matrix",
+      "difficulty": 4,
+      "topics": [
+        "arrays",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "matrices",
+        "strings"
+      ]
+    },
+
     {
       "slug": "beer-song",
       "uuid": "6573f168-d8fc-4ccf-a864-1a61f432fae1",
@@ -495,293 +802,31 @@
       ]
     },
     {
-      "slug": "isogram",
-      "uuid": "3df577af-2854-40ee-b211-9b608dbbad58",
+      "slug": "diamond",
+      "uuid": "6a1eee0e-f8d4-446d-9c52-f31c3700af1b",
       "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 2,
-      "topics": [
-        "filtering",
-        "strings"
-      ]
-    },
-    {
-      "slug": "phone-number",
-      "uuid": "82775adb-eabe-4d44-91f5-4080b8834a4a",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 3,
-      "topics": [
-        "parsing",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "anagram",
-      "uuid": "309fa4f1-e03a-4ab2-b371-cdf742501cf7",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 1,
-      "topics": [
-        "filtering",
-        "strings"
-      ]
-    },
-    {
-      "slug": "word-count",
-      "uuid": "0073ff9a-cd6a-43cf-b8bf-4d5d8117b81b",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 1,
-      "topics": [
-        "control_flow_loops",
-        "lists",
-        "regular_expressions",
-        "strings",
-        "unicode"
-      ]
-    },
-    {
-      "slug": "acronym",
-      "uuid": "440d78d1-9dea-466f-9bd4-935eed067409",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 2,
-      "topics": [
-        "control_flow_loops",
-        "regular_expressions",
-        "strings",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "series",
-      "uuid": "5178ae53-5364-46c9-bee3-70e6e8a8c2e3",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 3,
-      "topics": [
-        "control_flow_loops",
-        "exception_handling",
-        "strings",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "largest-series-product",
-      "uuid": "1f84305d-ea76-4fe2-9858-3b53576d683d",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 7,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "exception_handling",
-        "integers",
-        "math",
-        "regular_expressions",
-        "strings"
-      ]
-    },
-    {
-      "slug": "bracket-push",
-      "uuid": "4d456646-3a9b-4393-9558-6b30e5c1039c",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 3,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "exception_handling",
-        "parsing",
-        "strings"
-      ]
-    },
-    {
-      "slug": "high-scores",
-      "uuid": "19b41c4a-1466-5c19-b547-40284189fd18",
-      "core": false,
-      "unlocked_by": "pangram",
-      "difficulty": 2,
-      "topics": [
-        "arrays"
-      ]
-    },
-    {
-      "slug": "grains",
-      "uuid": "d003975a-9045-4f03-9ad9-c15db584dc13",
-      "core": false,
-      "unlocked_by": "space-age",
+      "unlocked_by": "pascals-triangle",
       "difficulty": 5,
-      "topics": [
-        "control_flow_loops",
-        "integers"
-      ]
-    },
-    {
-      "slug": "perfect-numbers",
-      "uuid": "c6691fd2-e10d-47df-acbf-3adeac5a2f89",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 3,
       "topics": [
         "arrays",
         "control_flow_conditionals",
         "control_flow_loops",
-        "integers",
-        "math"
-      ]
-    },
-    {
-      "slug": "luhn",
-      "uuid": "28872cc9-f1ef-487f-9a79-6bf7983148bf",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 4,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "strings"
-      ]
-    },
-    {
-      "slug": "pythagorean-triplet",
-      "uuid": "394755a3-c743-4b85-b9b8-387907f4e32d",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 5,
-      "topics": [
-        "algorithms",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "math"
-      ]
-    },
-    {
-      "slug": "difference-of-squares",
-      "uuid": "7dfa878c-83a6-48ef-9170-b6633d51d601",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 3,
-      "topics": [
-        "algorithms",
-        "control_flow_loops",
-        "integers",
-        "math"
-      ]
-    },
-    {
-      "slug": "complex-numbers",
-      "uuid": "ea9a9a3e-ae6a-470d-8bb4-2afead507f24",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 4,
-      "topics": [
-        "math"
-      ]
-    },
-    {
-      "slug": "prime-factors",
-      "uuid": "f43cdddf-eea8-4c4a-8359-c69e20ff9661",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 4,
-      "topics": [
-        "algorithms",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "math"
-      ]
-    },
-    {
-      "slug": "forth",
-      "uuid": "e4035939-4375-4720-87ae-e613f925f013",
-      "core": false,
-      "unlocked_by": "matrix",
-      "difficulty": 8,
-      "topics": [
-        "domain_specific_languages",
-        "parsing",
-        "stacks"
-      ]
-    },
-    {
-      "slug": "saddle-points",
-      "uuid": "a01aa48c-65c4-4b1f-b3d9-3ec7da2ef754",
-      "core": false,
-      "unlocked_by": "matrix",
-      "difficulty": 6,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "equality",
         "exception_handling",
-        "integers",
-        "matrices",
-        "optional_values",
-        "parsing"
-      ]
-    },
-    {
-      "slug": "ocr-numbers",
-      "uuid": "24c197ee-d492-4083-8615-629cb4b836b2",
-      "core": false,
-      "unlocked_by": "matrix",
-      "difficulty": 5,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "equality",
-        "exception_handling",
-        "integers",
+        "games",
         "parsing",
         "text_formatting"
       ]
     },
     {
-      "slug": "transpose",
-      "uuid": "9c140fb7-cc8b-411b-b613-a0e0081a9c3f",
+      "slug": "rational-numbers",
+      "uuid": "d8da6cdd-3804-40b0-9821-0dd5765876ff",
       "core": false,
-      "unlocked_by": "matrix",
-      "difficulty": 1,
+      "unlocked_by": "pascals-triangle",
+      "difficulty": 5,
       "topics": [
-        "arrays",
-        "lists",
-        "loops",
-        "matrices",
-        "strings",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "spiral-matrix",
-      "uuid": "c1abafcc-0d44-4fb5-afae-bff3ce2e1b39",
-      "core": false,
-      "unlocked_by": "matrix",
-      "difficulty": 4,
-      "topics": [
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "data_structures",
-        "matrices"
-      ]
-    },
-    {
-      "slug": "rectangles",
-      "uuid": "f8c6786e-bf93-4f35-b649-03f4e39bb094",
-      "core": false,
-      "unlocked_by": "matrix",
-      "difficulty": 4,
-      "topics": [
-        "arrays",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "matrices",
-        "strings"
+        "algorithms",
+        "floating_point_numbers",
+        "math"
       ]
     },
     {
@@ -952,30 +997,71 @@
       ]
     },
     {
-      "slug": "diamond",
-      "uuid": "6a1eee0e-f8d4-446d-9c52-f31c3700af1b",
+      "slug": "strain",
+      "uuid": "8407f9d5-7a7e-40c8-aace-a6a8294ae5e9",
       "core": false,
-      "unlocked_by": "pascals-triangle",
-      "difficulty": 5,
+      "unlocked_by": "list-ops",
+      "difficulty": 4,
       "topics": [
+        "algorithms",
         "arrays",
+        "callbacks",
         "control_flow_conditionals",
         "control_flow_loops",
-        "exception_handling",
-        "games",
-        "parsing",
-        "text_formatting"
+        "filtering",
+        "lists"
       ]
     },
     {
-      "slug": "rational-numbers",
-      "uuid": "d8da6cdd-3804-40b0-9821-0dd5765876ff",
+      "slug": "accumulate",
+      "uuid": "6ebe247c-3d11-48b7-8e6f-39f98359d233",
       "core": false,
-      "unlocked_by": "pascals-triangle",
+      "unlocked_by": "list-ops",
       "difficulty": 5,
       "topics": [
         "algorithms",
-        "floating_point_numbers",
+        "callbacks",
+        "control_flow_loops",
+        "lists"
+      ]
+    },
+    {
+      "slug": "flatten-array",
+      "uuid": "1a6c4a3b-d5db-4a5a-b123-66cf085defe6",
+      "core": false,
+      "unlocked_by": "list-ops",
+      "difficulty": 5,
+      "topics": [
+        "arrays",
+        "recursion"
+      ]
+    },
+    {
+      "slug": "sieve",
+      "uuid": "127287d1-ba44-4400-884a-6fe5f72e210f",
+      "core": false,
+      "unlocked_by": "robot-name",
+      "difficulty": 5,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "math",
+        "recursion"
+      ]
+    },
+    {
+      "slug": "nth-prime",
+      "uuid": "7ce09989-f202-4c3c-8b7e-72cef18808c3",
+      "core": false,
+      "unlocked_by": "robot-name",
+      "difficulty": 5,
+      "topics": [
+        "algorithms",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "exception_handling",
+        "integers",
         "math"
       ]
     },
@@ -1069,43 +1155,29 @@
       ]
     },
     {
-      "slug": "strain",
-      "uuid": "8407f9d5-7a7e-40c8-aace-a6a8294ae5e9",
+      "slug": "sum-of-multiples",
+      "uuid": "f7452f71-795b-40b6-847c-67ef4bb9db45",
       "core": false,
-      "unlocked_by": "list-ops",
-      "difficulty": 4,
+      "unlocked_by": "secret-handshake",
+      "difficulty": 5,
       "topics": [
-        "algorithms",
-        "arrays",
-        "callbacks",
         "control_flow_conditionals",
         "control_flow_loops",
-        "filtering",
-        "lists"
+        "integers",
+        "lists",
+        "math"
       ]
     },
     {
-      "slug": "accumulate",
-      "uuid": "6ebe247c-3d11-48b7-8e6f-39f98359d233",
+      "slug": "change",
+      "uuid": "cfa5741c-9fe9-4cb5-a322-d77ba8145f4b",
       "core": false,
-      "unlocked_by": "list-ops",
-      "difficulty": 5,
+      "unlocked_by": "secret-handshake",
+      "difficulty": 8,
       "topics": [
         "algorithms",
-        "callbacks",
-        "control_flow_loops",
-        "lists"
-      ]
-    },
-    {
-      "slug": "flatten-array",
-      "uuid": "1a6c4a3b-d5db-4a5a-b123-66cf085defe6",
-      "core": false,
-      "unlocked_by": "list-ops",
-      "difficulty": 5,
-      "topics": [
-        "arrays",
-        "recursion"
+        "performance",
+        "searching"
       ]
     },
     {
@@ -1121,38 +1193,12 @@
       ]
     },
     {
-      "slug": "point-mutations",
-      "uuid": "6d43709b-3809-4a6a-ab41-2a5ab841b5fb",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 0,
-      "topics": null,
-      "deprecated": true
-    },
-    {
       "slug": "darts",
       "uuid": "6c64649b-ea81-4118-9e74-a0a55018ffbc",
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
       "topics": null
-    },
-    {
-      "slug": "binary",
-      "uuid": "0ba4d3b9-2519-49ac-bd93-f960aca6c11f",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "exception_handling",
-        "integers",
-        "mathematics",
-        "regular_expressions",
-        "strings"
-      ],
-      "deprecated": true
     },
     {
       "slug": "run-length-encoding",
@@ -1193,112 +1239,6 @@
         "algorithms",
         "events",
         "reactive_programming"
-      ]
-    },
-    {
-      "slug": "trinary",
-      "uuid": "1acf1d2d-a25e-4576-94de-0470abc872d9",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "mathematics",
-        "regular_expressions",
-        "strings"
-      ],
-      "deprecated": true
-    },
-    {
-      "slug": "sieve",
-      "uuid": "127287d1-ba44-4400-884a-6fe5f72e210f",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 5,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "math",
-        "recursion"
-      ]
-    },
-    {
-      "slug": "octal",
-      "uuid": "dec66f89-39d0-4857-9679-a035cf4259d7",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "mathematics",
-        "regular_expressions",
-        "strings"
-      ],
-      "deprecated": true
-    },
-    {
-      "slug": "hexadecimal",
-      "uuid": "8ed2c9fe-a13f-4313-abf9-125f351c85c9",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "mathematics",
-        "regular_expressions",
-        "strings"
-      ],
-      "deprecated": true
-    },
-    {
-      "slug": "nth-prime",
-      "uuid": "7ce09989-f202-4c3c-8b7e-72cef18808c3",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 5,
-      "topics": [
-        "algorithms",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "exception_handling",
-        "integers",
-        "math"
-      ]
-    },
-    {
-      "slug": "palindrome-products",
-      "uuid": "f6799d10-0210-4c73-ac08-d5cac1a00ff3",
-      "core": false,
-      "unlocked_by": "space-age",
-      "difficulty": 7,
-      "topics": [
-        "algorithms",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "exception_handling",
-        "integers",
-        "math"
-      ]
-    },
-    {
-      "slug": "sum-of-multiples",
-      "uuid": "f7452f71-795b-40b6-847c-67ef4bb9db45",
-      "core": false,
-      "unlocked_by": "secret-handshake",
-      "difficulty": 5,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "lists",
-        "math"
       ]
     },
     {
@@ -1345,18 +1285,6 @@
       ]
     },
     {
-      "slug": "change",
-      "uuid": "cfa5741c-9fe9-4cb5-a322-d77ba8145f4b",
-      "core": false,
-      "unlocked_by": "secret-handshake",
-      "difficulty": 8,
-      "topics": [
-        "algorithms",
-        "performance",
-        "searching"
-      ]
-    },
-    {
       "slug": "protein-translation",
       "uuid": "775ae0ec-8db7-4568-a188-963931cf5ee1",
       "core": false,
@@ -1379,6 +1307,81 @@
         "algorithms",
         "math"
       ]
+    },
+
+    {
+      "slug": "trinary",
+      "uuid": "1acf1d2d-a25e-4576-94de-0470abc872d9",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "mathematics",
+        "regular_expressions",
+        "strings"
+      ],
+      "deprecated": true
+    },
+    {
+      "slug": "octal",
+      "uuid": "dec66f89-39d0-4857-9679-a035cf4259d7",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "mathematics",
+        "regular_expressions",
+        "strings"
+      ],
+      "deprecated": true
+    },
+    {
+      "slug": "hexadecimal",
+      "uuid": "8ed2c9fe-a13f-4313-abf9-125f351c85c9",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "mathematics",
+        "regular_expressions",
+        "strings"
+      ],
+      "deprecated": true
+    },
+    {
+      "slug": "point-mutations",
+      "uuid": "6d43709b-3809-4a6a-ab41-2a5ab841b5fb",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 0,
+      "topics": null,
+      "deprecated": true
+    },
+    {
+      "slug": "binary",
+      "uuid": "0ba4d3b9-2519-49ac-bd93-f960aca6c11f",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "exception_handling",
+        "integers",
+        "mathematics",
+        "regular_expressions",
+        "strings"
+      ],
+      "deprecated": true
     }
   ]
 }

--- a/config.json
+++ b/config.json
@@ -683,6 +683,20 @@
       ]
     },
     {
+      "slug": "prime-factors",
+      "uuid": "f43cdddf-eea8-4c4a-8359-c69e20ff9661",
+      "core": false,
+      "unlocked_by": "space-age",
+      "difficulty": 4,
+      "topics": [
+        "algorithms",
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "math"
+      ]
+    },
+    {
       "slug": "forth",
       "uuid": "e4035939-4375-4720-87ae-e613f925f013",
       "core": false,
@@ -1139,20 +1153,6 @@
         "strings"
       ],
       "deprecated": true
-    },
-    {
-      "slug": "prime-factors",
-      "uuid": "f43cdddf-eea8-4c4a-8359-c69e20ff9661",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "algorithms",
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "math"
-      ]
     },
     {
       "slug": "run-length-encoding",


### PR DESCRIPTION
This PR is the result of work being done to structure the exercises in a track according to a predefined methodology (this work is not finished). This first step (of many rounds) attempts to remove *Math* and *DIY* exercises from the core track, and fix obvious problems with the sequence of the existing core exercises. The result is as follows:

(Taken the format from https://github.com/exercism/csharp/pull/740, thanks @ErikSchierboom!)

```` 
Core (matches config.json) of this track:
- hello-world (1)
- leap (1)
- gigasecond (1)
- rna-transcription (2)
- space-age (2)
- pangram (2)
- matrix (3)
- bob (4)
- pascals-triangle (4)
- linked-list (5)
- grade-school (5)
- list-ops (6)
- robot-name (6)
- simple-cipher (6)
- wordy (7)
- secret-handshake (6)


core
----
├─ hello-world
│  └─ two-fer (1)
│
├─ leap
│  ├─ reverse-string (2)
│  ├─ triangle (3)
│  └─ collatz-conjecture (3)
│
├─ gigasecond
│  ├─ clock (5)
│  └─ meetup (7)
│
├─ rna-transcription
│  ├─ hamming (2)
│  ├─ etl (2)
│  ├─ scrabble-score (5)
│  ├─ raindrops (2)
│  ├─ allergies (6)
│  └─ nucleotide-count (4)
│
├─ space-age
│  ├─ word-count (1)
│  ├─ grains (5)
│  ├─ perfect-numbers (3)
│  ├─ luhn (4)
│  ├─ pythagorean-triplet (5)
│  ├─ difference-of-squares (3)
│  ├─ complex-numbers (4)
│  ├─ prime-factors (4)
│  └─ palindrome-products (7)
│
├─ pangram
│  ├─ isogram (2)
│  ├─ phone-number (3)
│  ├─ anagram (1)
│  ├─ acronym (2)
│  ├─ series (3)
│  ├─ largest-series-product (7)
│  ├─ bracket-push (3)
│  └─ high-scores (2)
│
├─ matrix
│  ├─ forth (8)
│  ├─ saddle-points (6)
│  ├─ ocr-numbers (5)
│  ├─ transpose (1)
│  ├─ spiral-matrix (4)
│  └─ rectangles (4)
│
├─ bob
│  ├─ beer-song (5)
│  ├─ food-chain (4)
│  ├─ pig-latin (4)
│  ├─ proverb (4)
│  ├─ house (4)
│  ├─ twelve-days (4)
│  ├─ say (6)
│  └─ isbn-verifier (4)
│
├─ pascals-triangle
│  ├─ diamond (5)
│  └─ rational-numbers (5)
│
├─ linked-list
│  ├─ sublist (4)
│  ├─ word-search (8)
│  ├─ circular-buffer (8)
│  ├─ binary-search (7)
│  ├─ binary-search-tree (6)
│  ├─ custom-set (6)
│  └─ simple-linked-list (8)
│
├─ grade-school
│  ├─ two-bucket (6)
│  ├─ bowling (8)
│  ├─ alphametics (7)
│  ├─ connect (7)
│  └─ variable-length-quantity (5)
│
├─ list-ops
│  ├─ strain (4)
│  ├─ accumulate (5)
│  └─ flatten-array (5)
│
├─ robot-name
│  ├─ sieve (5)
│  └─ nth-prime (5)
│
├─ simple-cipher
│  ├─ atbash-cipher (7)
│  ├─ crypto-square (9)
│  ├─ diffie-hellman (3)
│  └─ rotational-cipher (2)
│
├─ wordy
│  ├─ kindergarten-garden (7)
│  └─ robot-simulator (5)
│
├─ secret-handshake
│  ├─ sum-of-multiples (5)
│  └─ change (8)

bonus
----
- zipper (8)
- darts (3)
- run-length-encoding (2)
- roman-numerals (3)
- react (8)
- queen-attack (8)
- all-your-base (5)
- minesweeper (7)
- protein-translation (1)
- armstrong-numbers (2)
- trinary (4)
- octal (4)
- hexadecimal (4)
- point-mutations (0)
- binary (4)
````

You can generate this output running `bin/print-config-tree` (and make your own changes to config.json to see the effect).

The most notable changes are:

- `space-age`: moved up to 5th place. The new tests / implementation requirements make it far simpler to work out.
- `gigasecond`: has move up from the 7th place to the 3rd place. It's quite simple to understand and implement and as its goal is to introduce the Date type early on as a very important core data type in javascript, it makes sense to move it up.
- `list-ops`: moved up from last to 12th place.
- `bob`: moved down to 8th place.
- `simple-cipher`: has moved down considerably from 4th to ~13th~ 14th place. This is a change inspired by https://github.com/exercism/exercism/issues/4577, mentoring and #564. It's a _great_ exercise, but not this early on in the track. The implementation differences and lack of knowledge of the standard library also makes it so that mentors don't like mentoring this. Both in JS and TS, the time to wait is between 1 week and 2 months (!). Moving this down should resolve this!
- `prime-factors`: no longer a core exercise. This is due to a recently added policy to exclude "mathy" exercises as core exercise.

My notes on the current core exercises are as follows and as you might be able to tell is that I'm trying to introduce a minimum number of subjects with each exercise. Bad or meh here refers to the test suite, the implementation or the exercise as a whole (in terms of teaching fluency of the language). 

| exercise | notes | post-discussion position |
|----------|-------|----|
| hello-world | | 1 |
| leap | bad exercise, introduction to modulo | 2 |
| gigasecond | introduction to date | 3 |
| rna-transcription | introduction to objects, enumeration | 4 |
|  bob | introduction to regex | 8 |
| pangram | introduction to charAt/charCodeAt, enumeration | 6 |
| space-age | date math, introduction to floating point math |  5 |
| matrix | implement "string reader" and "pivot" | 7 |
| linked-list | introduction to class, heavy use of "pointers" | 10 |
| grade-school |  introduction to sort, needs arrays, objects and class |  11 |
| robot-name | introduction to rand, meh exercise | 13 |
| pascals-triangle | interesting solutions with enumeration / recursive | 9 |
| simple-cipher | listed as easy, is actually hard to do right | 14 |
| wordy | interesting implementations (tokenizer) | 15 |
| secret-handshake | bad description (incomplete), interesting solutions with bit masks / modulo | 16 |
| list-ops | immutability, interesting implementations, classic exercise | 12 |

Not all of these have mentoring notes -- that will be next up.

The current ordering is _still_ not perfect and there is still lots to improve, but I feel it is definitely an improvement over the [current situation](https://github.com/exercism/exercism/issues/4577). I'm interested in hearing your thoughts!
