### PR TITLE
robot-name: change optional test to enforce better implementation

### DIFF
--- a/exercises/robot-name/example.js
+++ b/exercises/robot-name/example.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-underscore-dangle */
-
 // This generates ALL the possible names in order to be able to satisfy the
 // final test. This also _ensures_ it _never_ has a duplicate.
 const LETTERS = [...'QWERTYUIOPASDFGHJKLZXCVBNM'];
@@ -61,5 +60,4 @@ export default class Robot {
   }
 }
 
-Robot.release_names = () => { shuffledPointer = -1; };
-Robot.reshuffle_names = shuffleNames;
+Robot.releaseNames = () => { shuffledPointer = -1; };

--- a/exercises/robot-name/example.js
+++ b/exercises/robot-name/example.js
@@ -2,64 +2,64 @@
 
 // This generates ALL the possible names in order to be able to satisfy the
 // final test. This also _ensures_ it _never_ has a duplicate.
-const LETTERS = [...'QWERTYUIOPASDFGHJKLZXCVBNM']
-const NUMBERS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
+const LETTERS = [...'QWERTYUIOPASDFGHJKLZXCVBNM'];
+const NUMBERS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
 
-const ALL_NAMES = []
+const ALL_NAMES = [];
 
 LETTERS.forEach((a) => {
   LETTERS.forEach((b) => {
     NUMBERS.forEach((c) => {
       NUMBERS.forEach((d) => {
         NUMBERS.forEach((e) => {
-          ALL_NAMES.push([a, b, c, d, e].join(''))
-        })
-      })
-    })
-  })
-})
+          ALL_NAMES.push([a, b, c, d, e].join(''));
+        });
+      });
+    });
+  });
+});
 
-const shuffled = ALL_NAMES
-let shuffledPointer = -1
+const shuffled = ALL_NAMES;
+let shuffledPointer = -1;
 
 // Fisher-Yates shuffle in order to randomly sort the current names. Normally
 // you would return a new array, but this function is going to be attached to
 // the Robot class so it may be re-shuffled at will.
 function shuffleNames() {
-  let j
-  let x
-  let i
+  let j;
+  let x;
+  let i;
 
   for (i = shuffled.length - 1; i > 0; i -= 1) {
-    j = Math.floor(Math.random() * (i + 1))
-    x = shuffled[i]
-    shuffled[i] = shuffled[j]
+    j = Math.floor(Math.random() * (i + 1));
+    x = shuffled[i];
+    shuffled[i] = shuffled[j];
     shuffled[j] = x;
   }
 }
 
 function generateName() {
-  shuffledPointer += 1
+  shuffledPointer += 1;
   if (shuffledPointer > shuffled.length) {
-    throw new Error('Can not generate another name because all the names have been used.')
+    throw new Error('Can not generate another name because all the names have been used.');
   }
-  return shuffled[shuffledPointer]
+  return shuffled[shuffledPointer];
 }
 
 // Initial shuffle
-shuffleNames()
+shuffleNames();
 
 export default class Robot {
   constructor() {
-    this._name = generateName()
+    this._name = generateName();
   }
 
-  get name() { return this._name }
+  get name() { return this._name; }
 
   reset() {
-    this._name = generateName()
+    this._name = generateName();
   }
 }
 
-Robot.release_names = () => { shuffledPointer = -1 }
-Robot.reshuffle_names = shuffleNames
+Robot.release_names = () => { shuffledPointer = -1; };
+Robot.reshuffle_names = shuffleNames;

--- a/exercises/robot-name/example.js
+++ b/exercises/robot-name/example.js
@@ -1,28 +1,65 @@
-const ALPHA = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-const BASE = 10;
-const usedNames = {};
+/* eslint-disable no-underscore-dangle */
 
-const random = max => Math.floor(Math.random() * max);
+// This generates ALL the possible names in order to be able to satisfy the
+// final test. This also _ensures_ it _never_ has a duplicate.
+const LETTERS = [...'QWERTYUIOPASDFGHJKLZXCVBNM']
+const NUMBERS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
 
-const generateName = () => {
-  let name = ALPHA.charAt(random(ALPHA.length))
-    + ALPHA.charAt(random(ALPHA.length))
-    + random(BASE) + random(BASE) + random(BASE);
-  if (usedNames[name]) name = generateName();
-  else usedNames[name] = true;
-  return name;
-};
+const ALL_NAMES = []
+
+LETTERS.forEach((a) => {
+  LETTERS.forEach((b) => {
+    NUMBERS.forEach((c) => {
+      NUMBERS.forEach((d) => {
+        NUMBERS.forEach((e) => {
+          ALL_NAMES.push([a, b, c, d, e].join(''))
+        })
+      })
+    })
+  })
+})
+
+const shuffled = ALL_NAMES
+let shuffledPointer = -1
+
+// Fisher-Yates shuffle in order to randomly sort the current names. Normally
+// you would return a new array, but this function is going to be attached to
+// the Robot class so it may be re-shuffled at will.
+function shuffleNames() {
+  let j
+  let x
+  let i
+
+  for (i = shuffled.length - 1; i > 0; i -= 1) {
+    j = Math.floor(Math.random() * (i + 1))
+    x = shuffled[i]
+    shuffled[i] = shuffled[j]
+    shuffled[j] = x;
+  }
+}
+
+function generateName() {
+  shuffledPointer += 1
+  if (shuffledPointer > shuffled.length) {
+    throw new Error('Can not generate another name because all the names have been used.')
+  }
+  return shuffled[shuffledPointer]
+}
+
+// Initial shuffle
+shuffleNames()
 
 export default class Robot {
   constructor() {
-    this.robotName = generateName();
+    this._name = generateName()
   }
 
-  get name() {
-    return this.robotName;
-  }
+  get name() { return this._name }
 
   reset() {
-    this.robotName = generateName();
+    this._name = generateName()
   }
 }
+
+Robot.release_names = () => { shuffledPointer = -1 }
+Robot.reshuffle_names = shuffleNames

--- a/exercises/robot-name/robot-name.js
+++ b/exercises/robot-name/robot-name.js
@@ -1,0 +1,6 @@
+// This is only a SKELETON file for the 'Robot Name' exercise. It's been
+// provided as a convenience to get your started writing code faster.
+
+export class Robot { }
+
+Robot.releaseNames = () => { };

--- a/exercises/robot-name/robot-name.spec.js
+++ b/exercises/robot-name/robot-name.spec.js
@@ -15,13 +15,6 @@ const areSequential = (name1, name2) => {
   return Math.abs(totalDiff) <= 1;
 };
 
-// Change these when adding / changing / removing tests in order to keep the
-// final test not exhausting all the names that can be generated.
-
-const NAMES_USED_IN_TESTS = 9 // beforeEach
-  + 3 // new Robot()
-  + 10003; // reset()
-
 const TOTAL_NUMBER_OF_NAMES = 26 // A-Z
   * 26 // A-Z
   * 10 // 0-9
@@ -33,6 +26,9 @@ describe('Robot', () => {
 
   beforeEach(() => {
     robot = new Robot();
+  });
+  afterEach(() => {
+    Robot.releaseNames();
   });
 
   test('has a name', () => {
@@ -99,14 +95,13 @@ describe('Robot', () => {
 
   // This test is optional.
   xtest('all the names can be generated', () => {
-    const NUMBER_OF_ROBOTS = TOTAL_NUMBER_OF_NAMES - NAMES_USED_IN_TESTS;
     const usedNames = new Set();
 
-    for (let i = 0; i < NUMBER_OF_ROBOTS; i += 1) {
+    for (let i = 0; i < TOTAL_NUMBER_OF_NAMES; i += 1) {
       const newRobot = new Robot();
       usedNames.add(newRobot.name);
     }
 
-    expect(usedNames.size).toEqual(NUMBER_OF_ROBOTS);
+    expect(usedNames.size).toEqual(TOTAL_NUMBER_OF_NAMES);
   });
 });

--- a/exercises/robot-name/robot-name.spec.js
+++ b/exercises/robot-name/robot-name.spec.js
@@ -18,17 +18,15 @@ const areSequential = (name1, name2) => {
 // Change these when adding / changing / removing tests in order to keep the
 // final test not exhausting all the names that can be generated.
 
-const NAMES_USED_IN_TESTS =
-    9     // beforeEach
-  + 3     // new Robot()
-  + 10003 // reset()
+const NAMES_USED_IN_TESTS = 9 // beforeEach
+  + 3 // new Robot()
+  + 10003; // reset()
 
-const TOTAL_NUMBER_OF_NAMES =
-    26    // A-Z
-  * 26    // A-Z
-  * 10    // 0-9
-  * 10    // 0-9
-  * 10    // 0-9
+const TOTAL_NUMBER_OF_NAMES = 26 // A-Z
+  * 26 // A-Z
+  * 10 // 0-9
+  * 10 // 0-9
+  * 10; // 0-9
 
 describe('Robot', () => {
   let robot;
@@ -112,4 +110,3 @@ describe('Robot', () => {
     expect(usedNames.size).toEqual(NUMBER_OF_ROBOTS);
   });
 });
-

--- a/exercises/robot-name/robot-name.spec.js
+++ b/exercises/robot-name/robot-name.spec.js
@@ -15,6 +15,21 @@ const areSequential = (name1, name2) => {
   return Math.abs(totalDiff) <= 1;
 };
 
+// Change these when adding / changing / removing tests in order to keep the
+// final test not exhausting all the names that can be generated.
+
+const NAMES_USED_IN_TESTS =
+    9     // beforeEach
+  + 3     // new Robot()
+  + 10003 // reset()
+
+const TOTAL_NUMBER_OF_NAMES =
+    26    // A-Z
+  * 26    // A-Z
+  * 10    // 0-9
+  * 10    // 0-9
+  * 10    // 0-9
+
 describe('Robot', () => {
   let robot;
 
@@ -85,8 +100,8 @@ describe('Robot', () => {
   });
 
   // This test is optional.
-  xtest('there can be lots of robots with different names each', () => {
-    const NUMBER_OF_ROBOTS = 10000;
+  xtest('all the names can be generated', () => {
+    const NUMBER_OF_ROBOTS = TOTAL_NUMBER_OF_NAMES - NAMES_USED_IN_TESTS;
     const usedNames = new Set();
 
     for (let i = 0; i < NUMBER_OF_ROBOTS; i += 1) {
@@ -97,3 +112,4 @@ describe('Robot', () => {
     expect(usedNames.size).toEqual(NUMBER_OF_ROBOTS);
   });
 });
+


### PR DESCRIPTION
According to the instructions, you may never generate a name that has already been used. Using random makes this improbable, but not impossible. This changes the final test so that a different approach is required to satisfy the entire exercise.

This is in line with the ruby tests (even though those have issues).