### PR TITLE
[Space-Age] - Change API to take planet as input

### DIFF
--- a/exercises/space-age/example.js
+++ b/exercises/space-age/example.js
@@ -9,49 +9,9 @@ const EARTH_TO_OTHER_PLANETS = {
   neptune: 164.79132,
 };
 
-export class SpaceAge {
-  constructor(seconds) {
-    this.seconds = seconds;
-  }
+export const age = (planet, seconds) => {
+  const earthYears = seconds / 31557600;
+  const years = earthYears / EARTH_TO_OTHER_PLANETS[planet];
 
-  get earthYears() {
-    return this.seconds / 31557600;
-  }
-
-  yearsOnPlanet(planet) {
-    const years = this.earthYears / EARTH_TO_OTHER_PLANETS[planet];
-    return parseFloat(years.toFixed(2));
-  }
-
-  onMercury() {
-    return this.yearsOnPlanet('mercury');
-  }
-
-  onVenus() {
-    return this.yearsOnPlanet('venus');
-  }
-
-  onEarth() {
-    return this.yearsOnPlanet('earth');
-  }
-
-  onMars() {
-    return this.yearsOnPlanet('mars');
-  }
-
-  onJupiter() {
-    return this.yearsOnPlanet('jupiter');
-  }
-
-  onSaturn() {
-    return this.yearsOnPlanet('saturn');
-  }
-
-  onUranus() {
-    return this.yearsOnPlanet('uranus');
-  }
-
-  onNeptune() {
-    return this.yearsOnPlanet('neptune');
-  }
-}
+  return parseFloat(years.toFixed(2));
+};

--- a/exercises/space-age/space-age.spec.js
+++ b/exercises/space-age/space-age.spec.js
@@ -1,61 +1,35 @@
-import { SpaceAge } from './space-age';
+import { age } from './space-age';
 
 describe('Space Age', () => {
-  test('age in seconds', () => {
-    const age = new SpaceAge(1000000);
-    expect(age.seconds).toEqual(1000000);
+  xtest('age on Earth', () => {
+    expect(age('earth', 1000000000)).toEqual(31.69);
   });
 
-  xtest('age in earth years', () => {
-    const age = new SpaceAge(1000000000);
-    expect(age.onEarth()).toEqual(31.69);
+  xtest('age on Mercury', () => {
+    expect(age('mercury', 2134835688)).toEqual(280.88);
   });
 
-  xtest('age in mercury years', () => {
-    const age = new SpaceAge(2134835688);
-    expect(age.onEarth()).toEqual(67.65);
-    expect(age.onMercury()).toEqual(280.88);
+  xtest('age on Venus', () => {
+    expect(age('venus', 189839836)).toEqual(9.78);
   });
 
-  xtest('age in venus years', () => {
-    const age = new SpaceAge(189839836);
-    expect(age.onEarth()).toEqual(6.02);
-    expect(age.onVenus()).toEqual(9.78);
+  xtest('age on Mars', () => {
+    expect(age('mars', 2129871239)).toEqual(35.88);
   });
 
-  xtest('age in mars years', () => {
-    const age = new SpaceAge(2329871239);
-    expect(age.onEarth()).toEqual(73.83);
-    expect(age.onMars()).toEqual(39.25);
+  xtest('age on Jupiter', () => {
+    expect(age('jupiter', 901876382)).toEqual(2.41);
   });
 
-  xtest('age in jupiter years', () => {
-    const age = new SpaceAge(901876382);
-    expect(age.onEarth()).toEqual(28.58);
-    expect(age.onJupiter()).toEqual(2.41);
+  xtest('age on Saturn', () => {
+    expect(age('saturn', 2000000000)).toEqual(2.15);
   });
 
-  xtest('age in saturn years', () => {
-    const age = new SpaceAge(3000000000);
-    expect(age.onEarth()).toEqual(95.06);
-    expect(age.onSaturn()).toEqual(3.23);
+  xtest('age on Uranus', () => {
+    expect(age('uranus', 1210123456)).toEqual(0.46);
   });
 
-  xtest('age in uranus years', () => {
-    const age = new SpaceAge(3210123456);
-    expect(age.onEarth()).toEqual(101.72);
-    expect(age.onUranus()).toEqual(1.21);
-  });
-
-  xtest('age in neptune year', () => {
-    const age = new SpaceAge(8210123456);
-    expect(age.onEarth()).toEqual(260.16);
-    expect(age.onNeptune()).toEqual(1.58);
-  });
-
-  test('reassigning seconds', () => {
-    const age = new SpaceAge(1000000);
-    age.seconds = 3210123456;
-    expect(age.onEarth()).toEqual(101.72);
+  xtest('age on Neptune', () => {
+    expect(age('neptune', 1821023456)).toEqual(0.35);
   });
 });


### PR DESCRIPTION
* Rather than having multiple methods for each planet, just take it as input - makes the solution a lot simpler.

* Also properly adheres to the [canonical tests](https://github.com/exercism/problem-specifications/blob/master/exercises/space-age/canonical-data.json).

* Removes the last extra test to check for reassigning of seconds - which is not in canonical data.