### PR TITLE
Convert multiple exercises to named exports

### DIFF
--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,7 +1,5 @@
-class HelloWorld {
+export class HelloWorld {
   hello() {
     return 'Hello, World!';
   }
-}
-
-export default HelloWorld;
+};

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -28,10 +28,10 @@ $ npm run watch
 
 The skip method instructs the test suite to not run a test, this function could be used also under the aliases: `it.skip(name, fn) or xit(name, fn) or xtest(name, fn)`
 
-- Why they are skipped ? 
+- Why they are skipped ?
 So as to enable users to concentrate on one test at a time and enable one by one as they evolve the solution.
 
-- How to enable them ? 
+- How to enable them ?
 Change xtest to test.
 
 ```javascript
@@ -43,11 +43,11 @@ test('title cased phrases', () => {
 ## Making Your First JavaScript 2015 Module
 
 Usually, tests on this track will load your implementation by importing it as a
-JavaScript module: `import Bob from './bob.js';`. You just
+JavaScript module: `import { Bob } from './bob.js';`. You just
 need to export your implementation from the referenced file, `bob.js`:
 
 ```javascript
-export default class Bob {
+export class Bob {
   hey(message) {
 	//
 	// Your solution to the exercise goes here

--- a/exercises/allergies/allergies.spec.js
+++ b/exercises/allergies/allergies.spec.js
@@ -1,4 +1,4 @@
-import Allergies from './allergies';
+import { Allergies } from './allergies';
 
 describe('Allergies', () => {
   test('no allergies at all', () => {

--- a/exercises/allergies/example.js
+++ b/exercises/allergies/example.js
@@ -9,7 +9,7 @@ const possibleAllergies = [
   'cats',
 ];
 
-class Allergies {
+export class Allergies {
   constructor(allergenIndex) {
     this.allergenIndex = allergenIndex;
   }
@@ -23,5 +23,3 @@ class Allergies {
     return this.list().some(allergy => allergy === food);
   }
 }
-
-export default Allergies;

--- a/exercises/anagram/anagram.spec.js
+++ b/exercises/anagram/anagram.spec.js
@@ -1,4 +1,4 @@
-import Anagram from './anagram';
+import { Anagram } from './anagram';
 
 describe('Anagram', () => {
   test('no matches', () => {

--- a/exercises/anagram/example.js
+++ b/exercises/anagram/example.js
@@ -2,7 +2,7 @@ const normalize = str => str.toLowerCase().split('').sort().join();
 const sameWord = (word, candidate) => word.toLowerCase() === candidate.toLowerCase();
 const isAnagram = (word, candiate) => normalize(word) === normalize(candiate);
 
-export default class Anagram {
+export class Anagram {
   constructor(word) {
     this.word = word;
   }

--- a/exercises/beer-song/beer-song.spec.js
+++ b/exercises/beer-song/beer-song.spec.js
@@ -1,26 +1,26 @@
-import Beer from './beer-song';
+import { BeerSong } from './beer-song';
 
-describe('Beer', () => {
+describe('BeerSong', () => {
   test('prints an arbitrary verse', () => {
     const expected = `8 bottles of beer on the wall, 8 bottles of beer.
 Take one down and pass it around, 7 bottles of beer on the wall.
 `;
 
-    expect(Beer.verse(8)).toEqual(expected);
+    expect(BeerSong.verse(8)).toEqual(expected);
   });
 
   xtest('handles 1 bottle', () => {
     const expected = `1 bottle of beer on the wall, 1 bottle of beer.
 Take it down and pass it around, no more bottles of beer on the wall.
 `;
-    expect(Beer.verse(1)).toEqual(expected);
+    expect(BeerSong.verse(1)).toEqual(expected);
   });
 
   xtest('handles 0 bottles', () => {
     const expected = `No more bottles of beer on the wall, no more bottles of beer.
 Go to the store and buy some more, 99 bottles of beer on the wall.
 `;
-    expect(Beer.verse(0)).toEqual(expected);
+    expect(BeerSong.verse(0)).toEqual(expected);
   });
 
   xtest('sings several verses', () => {
@@ -33,7 +33,7 @@ Take one down and pass it around, 6 bottles of beer on the wall.
 6 bottles of beer on the wall, 6 bottles of beer.
 Take one down and pass it around, 5 bottles of beer on the wall.
 `;
-    expect(Beer.sing(8, 6)).toEqual(expected);
+    expect(BeerSong.sing(8, 6)).toEqual(expected);
   });
 
   xtest('sings the rest of the verses', () => {
@@ -49,11 +49,11 @@ Take it down and pass it around, no more bottles of beer on the wall.
 No more bottles of beer on the wall, no more bottles of beer.
 Go to the store and buy some more, 99 bottles of beer on the wall.
 `;
-    expect(Beer.sing(3)).toEqual(expected);
+    expect(BeerSong.sing(3)).toEqual(expected);
   });
 
   xtest('sings all the verses', () => {
-    const song = Beer.sing();
+    const song = BeerSong.sing();
     expect(song).toEqual(`99 bottles of beer on the wall, 99 bottles of beer.
 Take one down and pass it around, 98 bottles of beer on the wall.
 

--- a/exercises/beer-song/example.js
+++ b/exercises/beer-song/example.js
@@ -27,7 +27,7 @@ function nextBottle(currentVerse) {
   return `${bottles(nextVerse(currentVerse)).toLowerCase()} of beer on the wall.\n`;
 }
 
-class BeerSong {
+export class BeerSong {
   static verse(number) {
     const line1 = `${bottles(number)} of beer on the wall, `;
     const line2 = `${bottles(number).toLowerCase()} of beer.\n`;
@@ -46,5 +46,3 @@ class BeerSong {
     return verses.join('\n');
   }
 }
-
-export default BeerSong;

--- a/exercises/binary-search-tree/binary-search-tree.spec.js
+++ b/exercises/binary-search-tree/binary-search-tree.spec.js
@@ -1,4 +1,4 @@
-import BinarySearchTree from './binary-search-tree';
+import { BinarySearchTree } from './binary-search-tree';
 
 function recordAllData(bst) {
   const out = [];

--- a/exercises/binary-search-tree/example.js
+++ b/exercises/binary-search-tree/example.js
@@ -1,4 +1,4 @@
-class BinarySearchTree {
+export class BinarySearchTree {
   constructor(data) {
     this.data = data;
     this.left = undefined;
@@ -45,5 +45,3 @@ class BinarySearchTree {
     }
   }
 }
-
-export default BinarySearchTree;

--- a/exercises/binary-search/binary-search.spec.js
+++ b/exercises/binary-search/binary-search.spec.js
@@ -1,4 +1,4 @@
-import BinarySearch from './binary-search';
+import { BinarySearch } from './binary-search';
 
 describe('BinarySearch', () => {
   const sortedArray = [1, 2, 3, 4, 5, 6];

--- a/exercises/binary-search/example.js
+++ b/exercises/binary-search/example.js
@@ -25,7 +25,7 @@ function recursiveSearch(array, value, start, end) {
   return mid;
 }
 
-class BinarySearch {
+export class BinarySearch {
   constructor(array) {
     if (isSortedArray(array)) {
       this.array = array;
@@ -36,5 +36,3 @@ class BinarySearch {
     return recursiveSearch(this.array, value, 0, this.array.length);
   }
 }
-
-export default BinarySearch;

--- a/exercises/binary/binary.spec.js
+++ b/exercises/binary/binary.spec.js
@@ -1,4 +1,4 @@
-import Binary from './binary';
+import { Binary } from './binary';
 
 describe('binary', () => {
   test('0 is decimal 0', () => expect(new Binary('0').toDecimal()).toEqual(0));

--- a/exercises/binary/example.js
+++ b/exercises/binary/example.js
@@ -1,6 +1,6 @@
 // classy solution, eh?
 
-class Binary {
+export class Binary {
   constructor(binary) {
     this.binary = binary.match(/^[01]*$/) ? parseInt(binary, 2) : 0;
   }
@@ -10,5 +10,3 @@ class Binary {
     return Number.isNaN(out) ? 0 : out;
   }
 }
-
-export default Binary;

--- a/exercises/bowling/bowling.spec.js
+++ b/exercises/bowling/bowling.spec.js
@@ -1,4 +1,4 @@
-import Bowling from './bowling';
+import { Bowling } from './bowling';
 
 describe('Bowling', () => {
   describe('Check game can be scored correctly.', () => {

--- a/exercises/bowling/example.js
+++ b/exercises/bowling/example.js
@@ -1,4 +1,4 @@
-export default class Bowling {
+export class Bowling {
   constructor() {
     this.maxPins = 10;
     this.maxFrames = 10;

--- a/exercises/change/change.spec.js
+++ b/exercises/change/change.spec.js
@@ -1,4 +1,4 @@
-import Change from './change';
+import { Change } from './change';
 
 describe('Change', () => {
   test('test change for 1 cent', () => {

--- a/exercises/change/example.js
+++ b/exercises/change/example.js
@@ -34,7 +34,7 @@ class Candidate {
   }
 }
 
-export default class Change {
+export class Change {
   constructor() {
     this.candidates = [];
   }

--- a/exercises/clock/clock.spec.js
+++ b/exercises/clock/clock.spec.js
@@ -1,4 +1,4 @@
-import at from './clock';
+import { at } from './clock';
 
 describe('Clock', () => {
   describe('Creating a new clock with an initial time', () => {

--- a/exercises/clock/example.js
+++ b/exercises/clock/example.js
@@ -1,4 +1,4 @@
-export default function (hour, minute) {
+export const at = (hour, minute) => {
   const MINUTESPERDAY = 1440;
   const HOURSPERDAY = 24;
 
@@ -38,4 +38,4 @@ export default function (hour, minute) {
       && clock.minute === otherClock.clock.minute
     ),
   };
-}
+};

--- a/exercises/complex-numbers/complex-numbers.spec.js
+++ b/exercises/complex-numbers/complex-numbers.spec.js
@@ -1,4 +1,4 @@
-import ComplexNumber from './complex-numbers.js';
+import { ComplexNumber } from './complex-numbers.js';
 
 describe('Complex numbers', () => {
   test('Real part of a purely real number', () => {

--- a/exercises/complex-numbers/example.js
+++ b/exercises/complex-numbers/example.js
@@ -1,4 +1,4 @@
-export default class ComplexNumber {
+export class ComplexNumber {
   constructor(real, imag) {
     this.real = real;
     this.imag = imag;

--- a/exercises/connect/connect.spec.js
+++ b/exercises/connect/connect.spec.js
@@ -1,4 +1,4 @@
-import Board from './connect';
+import { Board } from './connect';
 
 describe('Judging a game of connect', () => {
   test('an empty board has no winner', () => {

--- a/exercises/connect/example.js
+++ b/exercises/connect/example.js
@@ -2,7 +2,7 @@
  * "Player O" plays from top to bottom, "Player X" plays from left to right.
  * @param board
  */
-export default class {
+export class Board {
   constructor(board) {
     this.board = board.map(b => [...b]);
   }

--- a/exercises/crypto-square/crypto-square.spec.js
+++ b/exercises/crypto-square/crypto-square.spec.js
@@ -1,4 +1,4 @@
-import Crypto from './crypto-square';
+import { Crypto } from './crypto-square';
 
 describe('Crypto', () => {
   test('normalize strange characters', () => {

--- a/exercises/crypto-square/example.js
+++ b/exercises/crypto-square/example.js
@@ -1,4 +1,4 @@
-export default class Square {
+export class Crypto {
   constructor(input) {
     this.input = input;
   }

--- a/exercises/custom-set/custom-set.spec.js
+++ b/exercises/custom-set/custom-set.spec.js
@@ -1,4 +1,4 @@
-import CustomSet from './custom-set';
+import { CustomSet } from './custom-set';
 
 describe('CustomSet', () => {
   describe('empty: returns true if the set contains no elements', () => {

--- a/exercises/custom-set/example.js
+++ b/exercises/custom-set/example.js
@@ -1,4 +1,4 @@
-export default class CustomSet {
+export class CustomSet {
   constructor(data = []) {
     this.data = {};
     data.forEach(el => this.add(el));

--- a/exercises/diamond/diamond.spec.js
+++ b/exercises/diamond/diamond.spec.js
@@ -1,4 +1,4 @@
-import Diamond from './diamond.js';
+import { Diamond } from './diamond.js';
 
 describe('Make diamond function', () => {
   const diamond = new Diamond();

--- a/exercises/diamond/example.js
+++ b/exercises/diamond/example.js
@@ -1,4 +1,4 @@
-export default class Diamond {
+export class Diamond {
   makeDiamond(input) {
     const inputIndex = input.charCodeAt() - 65;
     let output = '';

--- a/exercises/difference-of-squares/difference-of-squares.spec.js
+++ b/exercises/difference-of-squares/difference-of-squares.spec.js
@@ -1,4 +1,4 @@
-import Squares from './difference-of-squares';
+import { Squares } from './difference-of-squares';
 
 describe('difference-of-squares', () => {
   const squares1 = new Squares(1);

--- a/exercises/difference-of-squares/example.js
+++ b/exercises/difference-of-squares/example.js
@@ -1,4 +1,4 @@
-export default class Squares {
+export class Squares {
   constructor(max) {
     this.max = max;
   }

--- a/exercises/diffie-hellman/diffie-hellman.spec.js
+++ b/exercises/diffie-hellman/diffie-hellman.spec.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-new */
-import DiffieHellman from './diffie-hellman';
+import { DiffieHellman } from './diffie-hellman';
 
 describe('diffie-hellman', () => {
   const p = 23;

--- a/exercises/diffie-hellman/example.js
+++ b/exercises/diffie-hellman/example.js
@@ -5,7 +5,7 @@ const PRIMES = [
 ];
 /* eslint-enable max-len */
 
-export default class DiffieHellman {
+export class DiffieHellman {
   constructor(p, g) {
     if (!DiffieHellman.validateInitialArguments(p, g)) {
       throw Error('Constructor arguments are out of range or non-prime!');

--- a/exercises/etl/etl.spec.js
+++ b/exercises/etl/etl.spec.js
@@ -1,4 +1,4 @@
-import transform from './etl';
+import { transform } from './etl';
 
 describe('Transform', () => {
   test('transforms one value', () => {

--- a/exercises/etl/example.js
+++ b/exercises/etl/example.js
@@ -1,4 +1,4 @@
-function transform(input) {
+export const transform = (input) => {
   const output = {};
 
   Object.keys(input).forEach((key) => {
@@ -11,6 +11,4 @@ function transform(input) {
   });
 
   return output;
-}
-
-export default transform;
+};

--- a/exercises/flatten-array/example.js
+++ b/exercises/flatten-array/example.js
@@ -1,4 +1,4 @@
-export default class Flattener {
+export class Flattener {
   flatten(arr) {
     return arr
       .reduce((acc, el) => (Array.isArray(el)

--- a/exercises/flatten-array/flatten-array.spec.js
+++ b/exercises/flatten-array/flatten-array.spec.js
@@ -1,4 +1,4 @@
-import Flattener from './flatten-array.js';
+import { Flattener } from './flatten-array.js';
 
 describe('FlattenArray', () => {
   const flattener = new Flattener();

--- a/exercises/food-chain/example.js
+++ b/exercises/food-chain/example.js
@@ -1,4 +1,4 @@
-export default class Song {
+export class Song {
   /**
    * @param {Number} number
    * verse number

--- a/exercises/food-chain/food-chain.spec.js
+++ b/exercises/food-chain/food-chain.spec.js
@@ -1,4 +1,4 @@
-import Song from './food-chain';
+import { Song } from './food-chain';
 
 describe('Food Chain', () => {
   let song;

--- a/exercises/forth/example.js
+++ b/exercises/forth/example.js
@@ -1,4 +1,4 @@
-class Forth {
+export class Forth {
   constructor(){
     this.stack = [];
     this.commands = Forth.basicCommands();
@@ -59,5 +59,3 @@ class Forth {
     };
   }
 }
-
-export default Forth;

--- a/exercises/forth/forth.spec.js
+++ b/exercises/forth/forth.spec.js
@@ -1,4 +1,4 @@
-import Forth from './forth';
+import { Forth } from './forth';
 
 describe('Forth', () => {
   let forth;

--- a/exercises/grains/example.js
+++ b/exercises/grains/example.js
@@ -6,7 +6,7 @@ import BigInt from './big-integer';
  * chess board, starting with one grain on the first
  * square, and doubling with each successive square.
  */
-export default class Grains {
+export class Grains {
   /**
    * Gets the number of grains on the nth square
    *

--- a/exercises/grains/grains.spec.js
+++ b/exercises/grains/grains.spec.js
@@ -27,7 +27,7 @@
  * See its tests in this folder for a quick primer on how to use it! ( :
  */
 
-import Grains from './grains';
+import { Grains } from './grains';
 
 describe('Grains', () => {
   const grains = new Grains();

--- a/exercises/house/example.js
+++ b/exercises/house/example.js
@@ -28,7 +28,7 @@ const ACTIONS = [
   'belonged to',
 ];
 
-class House {
+export class House {
   static verse(verseNumber) {
     const lines = [];
     const totalLines = verseNumber;
@@ -58,5 +58,3 @@ class House {
     return lines;
   }
 }
-
-export default House;

--- a/exercises/house/house.spec.js
+++ b/exercises/house/house.spec.js
@@ -1,4 +1,4 @@
-import House from './house';
+import { House } from './house';
 
 describe('House', () => {
   test('verse one - the house that jack built', () => {

--- a/exercises/isbn-verifier/example.js
+++ b/exercises/isbn-verifier/example.js
@@ -1,4 +1,4 @@
-export default class ISBN {
+export class ISBN {
   constructor(isbn) {
     this.isbn = isbn.replace(/-/g, '');
   }

--- a/exercises/isbn-verifier/isbn-verifier.spec.js
+++ b/exercises/isbn-verifier/isbn-verifier.spec.js
@@ -1,4 +1,4 @@
-import ISBN from './isbn-verifier.js';
+import { ISBN } from './isbn-verifier.js';
 
 describe('ISBN Verifier Test Suite', () => {
   test('valid isbn number', () => {

--- a/exercises/kindergarten-garden/example.js
+++ b/exercises/kindergarten-garden/example.js
@@ -34,7 +34,7 @@ function parse(diagram) {
   return diagram.split('\n').map(row => [...row].map(sign => plantCodes[sign]));
 }
 
-class Garden {
+export class Garden {
   constructor(diagram, students) {
     this.students = students || defaultChildren;
     this.students.sort();
@@ -44,5 +44,3 @@ class Garden {
     });
   }
 }
-
-export default Garden;

--- a/exercises/kindergarten-garden/kindergarten-garden.spec.js
+++ b/exercises/kindergarten-garden/kindergarten-garden.spec.js
@@ -1,4 +1,4 @@
-import Garden from './kindergarten-garden';
+import { Garden } from './kindergarten-garden';
 
 describe('Garden', () => {
   test('for Alice', () => {

--- a/exercises/list-ops/example.js
+++ b/exercises/list-ops/example.js
@@ -1,4 +1,4 @@
-class List {
+export class List {
   constructor(arr) {
     this.values = arr || [];
   }
@@ -74,5 +74,3 @@ class List {
     return this;
   }
 }
-
-export default List;

--- a/exercises/list-ops/list-ops.spec.js
+++ b/exercises/list-ops/list-ops.spec.js
@@ -1,5 +1,4 @@
-import List from './list-ops';
-
+import { List } from './list-ops';
 
 describe('append entries to a list and return the new list', () => {
   test('empty lists', () => {

--- a/exercises/luhn/example.js
+++ b/exercises/luhn/example.js
@@ -25,7 +25,7 @@ function isValid(num) {
   return sum > 0 && sum % 10 === 0;
 }
 
-export default class Luhn {
+export class Luhn {
   constructor(number) {
     this.valid = isValid(number);
   }

--- a/exercises/luhn/luhn.spec.js
+++ b/exercises/luhn/luhn.spec.js
@@ -1,4 +1,4 @@
-import Luhn from './luhn';
+import { Luhn } from './luhn';
 
 describe('Luhn', () => {
   test('single digit strings can not be valid', () => {

--- a/exercises/nth-prime/example.js
+++ b/exercises/nth-prime/example.js
@@ -25,7 +25,7 @@ function generatePrimes(uptoNumber) {
     .map(p => p.number);
 }
 
-class Prime {
+export class Prime {
   nth(nthPrime) {
     if (nthPrime === 0) {
       throw new Error('Prime is not possible');
@@ -34,5 +34,3 @@ class Prime {
     return realPrimes[nthPrime - 1];
   }
 }
-
-export default Prime;

--- a/exercises/nth-prime/nth-prime.spec.js
+++ b/exercises/nth-prime/nth-prime.spec.js
@@ -1,4 +1,4 @@
-import Prime from './nth-prime';
+import { Prime } from './nth-prime';
 
 describe('Prime', () => {
   const prime = new Prime();

--- a/exercises/nucleotide-count/example.js
+++ b/exercises/nucleotide-count/example.js
@@ -1,6 +1,6 @@
 const count = (str, nuc) => [...str].filter(nucleotide => nucleotide === nuc).length;
 
-class NucleotideCounts {
+export class NucleotideCounts {
   static parse(strand) {
     if (strand.replace(/A|C|G|T/g, '').length) {
       throw new Error('Invalid nucleotide in strand');
@@ -9,5 +9,3 @@ class NucleotideCounts {
     }
   }
 }
-
-export default NucleotideCounts;

--- a/exercises/nucleotide-count/nucleotide-count.spec.js
+++ b/exercises/nucleotide-count/nucleotide-count.spec.js
@@ -1,4 +1,4 @@
-import NucleotideCounts from './nucleotide-count';
+import { NucleotideCounts } from './nucleotide-count';
 
 describe('count all nucleotides in a strand', () => {
   test('empty strand', () => {

--- a/exercises/octal/example.js
+++ b/exercises/octal/example.js
@@ -1,7 +1,6 @@
-
-export default function (octal) {
+export const Octal = (octal) => {
   const newOctal = octal.match(/[^0-7]/) ? '0' : octal;
   return {
     toDecimal: () => newOctal.split('').reduce((prev, curr) => prev * 8 + parseInt(curr, 8), 0),
   };
-}
+};

--- a/exercises/octal/octal.spec.js
+++ b/exercises/octal/octal.spec.js
@@ -1,4 +1,4 @@
-import Octal from './octal';
+import { Octal } from './octal';
 
 describe('octal', () => {
   test('1 is decimal 1', () => {

--- a/exercises/phone-number/example.js
+++ b/exercises/phone-number/example.js
@@ -1,4 +1,4 @@
-export default class PhoneNumber {
+export class PhoneNumber {
   constructor(number) {
     this.rawNumber = number;
   }

--- a/exercises/phone-number/phone-number.spec.js
+++ b/exercises/phone-number/phone-number.spec.js
@@ -1,4 +1,4 @@
-import PhoneNumber from './phone-number';
+import { PhoneNumber } from './phone-number';
 
 describe('PhoneNumber()', () => {
   test('cleans the number', () => {

--- a/exercises/pig-latin/example.js
+++ b/exercises/pig-latin/example.js
@@ -10,7 +10,7 @@ function translateWord(word) {
   return `${newWord}ay`;
 }
 
-const translator = {
+export const translator = {
   translate(english) {
     return english
       .split(' ')
@@ -18,5 +18,3 @@ const translator = {
       .join(' ');
   },
 };
-
-export default translator;

--- a/exercises/pig-latin/pig-latin.spec.js
+++ b/exercises/pig-latin/pig-latin.spec.js
@@ -1,4 +1,4 @@
-import translator from './pig-latin';
+import { translator } from './pig-latin';
 
 describe('Pig Latin', () => {
   describe('ay is added to words that start with vowels', () => {

--- a/exercises/point-mutations/example.js
+++ b/exercises/point-mutations/example.js
@@ -1,4 +1,4 @@
-class DNA {
+export class DNA {
   constructor(nucleotides) {
     this.nucleotides = nucleotides;
   }
@@ -17,5 +17,3 @@ class DNA {
     return distance;
   }
 }
-
-export default DNA;

--- a/exercises/point-mutations/point-mutations.spec.js
+++ b/exercises/point-mutations/point-mutations.spec.js
@@ -1,4 +1,4 @@
-import DNA from './point-mutations';
+import { DNA } from './point-mutations';
 
 describe('DNA', () => {
   test('no difference between empty strands', () => {

--- a/exercises/protein-translation/example.js
+++ b/exercises/protein-translation/example.js
@@ -20,7 +20,7 @@ const ACID_PROTEIN_MAP = {
 
 const getProtein = codon => ACID_PROTEIN_MAP[codon] || 'INVALID';
 
-export default function translate(rnaStrand) {
+export const translate = (rnaStrand) => {
   const proteins = [];
 
   if (rnaStrand) {
@@ -42,4 +42,4 @@ export default function translate(rnaStrand) {
   }
 
   return proteins;
-}
+};

--- a/exercises/protein-translation/protein-translation.spec.js
+++ b/exercises/protein-translation/protein-translation.spec.js
@@ -1,4 +1,4 @@
-import translate from './protein-translation';
+import { translate } from './protein-translation';
 
 describe('ProteinTranslation', () => {
   test('Empty RNA has no proteins', () => {

--- a/exercises/proverb/example.js
+++ b/exercises/proverb/example.js
@@ -5,7 +5,7 @@ const lastArgIsOptions = (args) => {
 
 const conclusion = (firstArg, qualifier = '') => `And all for the want of a ${qualifier}${firstArg}.`;
 
-const proverb = (...args) => {
+export const proverb = (...args) => {
   let options = {};
   if (lastArgIsOptions(args)) {
     options = args.pop();
@@ -19,5 +19,3 @@ const proverb = (...args) => {
 
   return chainOfEvents.join('\n');
 };
-
-export default proverb;

--- a/exercises/proverb/proverb.spec.js
+++ b/exercises/proverb/proverb.spec.js
@@ -1,4 +1,4 @@
-import proverb from './proverb';
+import { proverb } from './proverb';
 
 describe('Proverb Test Suite', () => {
   test('a single consequence', () => {

--- a/exercises/pythagorean-triplet/example.js
+++ b/exercises/pythagorean-triplet/example.js
@@ -1,4 +1,4 @@
-export default class Triplet {
+export class Triplet {
   constructor(a, b, c) {
     this.a = a;
     this.b = b;

--- a/exercises/pythagorean-triplet/pythagorean-triplet.spec.js
+++ b/exercises/pythagorean-triplet/pythagorean-triplet.spec.js
@@ -1,4 +1,4 @@
-import Triplet from './pythagorean-triplet';
+import { Triplet } from './pythagorean-triplet';
 
 describe('Triplet', () => {
   test('calculates the sum', () => {

--- a/exercises/rectangles/example.js
+++ b/exercises/rectangles/example.js
@@ -1,4 +1,4 @@
-class Rectangles {
+export class Rectangles {
   static count(diagram) {
     const rows = diagram.length;
     const cols = rows ? diagram[0].length : 0;
@@ -33,5 +33,3 @@ class Rectangles {
     return rectangles;
   }
 }
-
-export default Rectangles;

--- a/exercises/rectangles/rectangles.spec.js
+++ b/exercises/rectangles/rectangles.spec.js
@@ -1,4 +1,4 @@
-import Rectangles from './rectangles.js';
+import { Rectangles } from './rectangles.js';
 
 describe('Rectangles', () => {
   test('no rows', () => {

--- a/exercises/robot-simulator/example.js
+++ b/exercises/robot-simulator/example.js
@@ -5,7 +5,7 @@ export class InvalidInputError extends Error {
   }
 }
 
-class Robot {
+export class Robot {
   constructor() {
     this.coordinates = [0, 0];
     this.bearing = 'north';
@@ -87,6 +87,3 @@ class Robot {
     });
   }
 }
-
-
-export default Robot;

--- a/exercises/robot-simulator/robot-simulator.spec.js
+++ b/exercises/robot-simulator/robot-simulator.spec.js
@@ -1,4 +1,4 @@
-import Robot, { InvalidInputError } from './robot-simulator';
+import { Robot, InvalidInputError } from './robot-simulator';
 
 describe('Robot', () => {
   const robot = new Robot();

--- a/exercises/rotational-cipher/example.js
+++ b/exercises/rotational-cipher/example.js
@@ -1,4 +1,4 @@
-class RotationalCipher {
+export class RotationalCipher {
   static rotate(text, shift) {
     return [...text].map((c) => {
       const isUpper = c.match(/[A-Z]/);
@@ -12,5 +12,3 @@ class RotationalCipher {
     }).join('');
   }
 }
-
-export default RotationalCipher;

--- a/exercises/rotational-cipher/rotational-cipher.spec.js
+++ b/exercises/rotational-cipher/rotational-cipher.spec.js
@@ -1,4 +1,4 @@
-import RotationalCipher from './rotational-cipher';
+import { RotationalCipher } from './rotational-cipher';
 
 describe('Rotational cipher', () => {
   test('rotate a by 0, same output as input', () => {

--- a/exercises/saddle-points/example.js
+++ b/exercises/saddle-points/example.js
@@ -9,7 +9,7 @@ function findSaddlePoints(rows, rowMaxs, colMins) {
   }, []);
 }
 
-export default class Matrix {
+export class Matrix {
   constructor(data) {
     this.rows = [];
     this.columns = [];

--- a/exercises/saddle-points/saddle-points.spec.js
+++ b/exercises/saddle-points/saddle-points.spec.js
@@ -1,4 +1,4 @@
-import Matrix from './saddle-points';
+import { Matrix } from './saddle-points';
 
 describe('Matrix', () => {
   test('extracts a row', () => {

--- a/exercises/say/example.js
+++ b/exercises/say/example.js
@@ -1,5 +1,4 @@
-
-export default class Say {
+export class Say {
   constructor() {
     this.smallNumbers = {
       0: 'zero',

--- a/exercises/say/say.spec.js
+++ b/exercises/say/say.spec.js
@@ -1,4 +1,4 @@
-import Say from './say';
+import { Say } from './say';
 
 describe('say', () => {
   const say = new Say();

--- a/exercises/series/example.js
+++ b/exercises/series/example.js
@@ -1,4 +1,4 @@
-export default class Series {
+export class Series {
   constructor(numberString) {
     this.numberString = numberString;
     this.digits = this.getDigits();

--- a/exercises/series/series.spec.js
+++ b/exercises/series/series.spec.js
@@ -1,4 +1,4 @@
-import Series from './series';
+import { Series } from './series';
 
 describe('Series', () => {
   test('has digits (short)', () => {

--- a/exercises/spiral-matrix/example.js
+++ b/exercises/spiral-matrix/example.js
@@ -1,4 +1,4 @@
-class SpiralMatrix {
+export class SpiralMatrix {
   static ofSize(size) {
     const spiral = Array(size).fill().map(() => Array(0));
 
@@ -19,6 +19,4 @@ class SpiralMatrix {
 
     return spiral;
   }
-}
-
-export default SpiralMatrix;
+};

--- a/exercises/spiral-matrix/spiral-matrix.spec.js
+++ b/exercises/spiral-matrix/spiral-matrix.spec.js
@@ -1,4 +1,4 @@
-import SpiralMatrix from './spiral-matrix';
+import { SpiralMatrix } from './spiral-matrix';
 
 describe('Spiral Matrix', () => {
   test('empty spiral', () => {

--- a/exercises/sublist/example.js
+++ b/exercises/sublist/example.js
@@ -1,4 +1,4 @@
-class List {
+export class List {
   constructor(list = []) {
     this.list = list;
   }
@@ -25,5 +25,3 @@ function lengthDiff(one, two){
 function isSublist(one, two){
   return one.join().match(two.join());
 }
-
-export default List;

--- a/exercises/sublist/sublist.spec.js
+++ b/exercises/sublist/sublist.spec.js
@@ -1,5 +1,4 @@
-import List from './sublist';
-
+import { List } from './sublist';
 
 describe('sublist', () => {
   test('two empty lists are equal', () => {

--- a/exercises/transpose/example.js
+++ b/exercises/transpose/example.js
@@ -3,7 +3,7 @@ function trimTrailingUndefined(array) {
   return array.slice(0, array.length - trailingUndefinedCount);
 }
 
-export default function transpose(input) {
+export function transpose(input) {
   const maxCol = Math.max(0, ...(input.map(row => row.length)));
   return [...Array(maxCol).keys()].map(col => trimTrailingUndefined(
     input.map((_v, row) => input[row][col]),

--- a/exercises/transpose/transpose.spec.js
+++ b/exercises/transpose/transpose.spec.js
@@ -1,4 +1,4 @@
-import transpose from './transpose';
+import { transpose } from './transpose';
 
 describe('Transpose', () => {
   test('empty string', () => {

--- a/exercises/triangle/example.js
+++ b/exercises/triangle/example.js
@@ -1,4 +1,4 @@
-class Triangle {
+export class Triangle {
   constructor(...sides) {
     this.sides = sides;
   }
@@ -45,5 +45,3 @@ class Triangle {
     return new Set(this.sides).size;
   }
 }
-
-export default Triangle;

--- a/exercises/triangle/triangle.spec.js
+++ b/exercises/triangle/triangle.spec.js
@@ -1,4 +1,4 @@
-import Triangle from './triangle';
+import { Triangle } from './triangle';
 
 describe('Triangle', () => {
   test('equilateral triangles have equal sides', () => {

--- a/exercises/trinary/example.js
+++ b/exercises/trinary/example.js
@@ -1,6 +1,6 @@
 const BASE = 3;
 
-export default class Trinary {
+export class Trinary {
   constructor(decimal) {
     this.digits = [...decimal].reverse().map(Number);
   }

--- a/exercises/trinary/trinary.spec.js
+++ b/exercises/trinary/trinary.spec.js
@@ -1,4 +1,4 @@
-import Trinary from './trinary';
+import { Trinary } from './trinary';
 
 describe('Trinary', () => {
   test('1 is decimal 1', () => {

--- a/exercises/twelve-days/example.js
+++ b/exercises/twelve-days/example.js
@@ -1,4 +1,4 @@
-class TwelveDays {
+export class TwelveDays {
   constructor() {
     this.verseList = [
       'On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree.',
@@ -49,5 +49,3 @@ class TwelveDays {
     return song;
   }
 }
-
-export default TwelveDays;

--- a/exercises/twelve-days/twelve-days.spec.js
+++ b/exercises/twelve-days/twelve-days.spec.js
@@ -1,4 +1,4 @@
-import TwelveDays from './twelve-days.js';
+import { TwelveDays } from './twelve-days.js';
 
 describe('TwelveDays', () => {
   let twelveDaysObject;

--- a/exercises/two-bucket/example.js
+++ b/exercises/two-bucket/example.js
@@ -1,4 +1,4 @@
-class TwoBucket {
+export class TwoBucket {
   constructor(x, y, z, starter) {
     this.starter = starter;
     this.x = x;
@@ -121,5 +121,3 @@ class TwoBucket {
     return moveCount + 1;
   }
 }
-
-export default TwoBucket;

--- a/exercises/two-bucket/two-bucket.spec.js
+++ b/exercises/two-bucket/two-bucket.spec.js
@@ -1,4 +1,4 @@
-import TwoBucket from './two-bucket';
+import { TwoBucket } from './two-bucket';
 
 describe('TwoBucket', () => {
   describe('works for input of 3, 5, 1', () => {

--- a/exercises/word-count/example.js
+++ b/exercises/word-count/example.js
@@ -1,4 +1,4 @@
-class Words {
+export class Words {
   count(input) {
     this.counts = {};
     this.words = input.match(/\S+/g);
@@ -11,5 +11,3 @@ class Words {
     return this.counts;
   }
 }
-
-export default Words;

--- a/exercises/word-count/word-count.spec.js
+++ b/exercises/word-count/word-count.spec.js
@@ -1,4 +1,4 @@
-import Words from './word-count';
+import { Words } from './word-count';
 
 describe('words()', () => {
   const words = new Words();

--- a/exercises/zipper/example.js
+++ b/exercises/zipper/example.js
@@ -20,7 +20,7 @@ function rebuildTree(tree, trail) {
   return rebuildTree(fromTrail(tree, last), trail.slice(1));
 }
 
-class Zipper {
+export class Zipper {
   constructor(tree, trail) {
     this.tree = tree;
     this.trail = trail;
@@ -69,6 +69,3 @@ class Zipper {
     return new Zipper({ value: this.tree.value, left: this.tree.left, right }, this.trail);
   }
 }
-
-
-export default Zipper;

--- a/exercises/zipper/zipper.spec.js
+++ b/exercises/zipper/zipper.spec.js
@@ -1,4 +1,4 @@
-import Zipper from './zipper';
+import { Zipper } from './zipper';
 
 // Tests adapted from `problem-specifications/zipper/canonical-data.json` @ v1.0.0
 


### PR DESCRIPTION
Instead of default exports

Issue: https://github.com/exercism/javascript/issues/436

These are all the trivial changes - hence all at once. After this we have only `7` left which are not so trivial - they will be separate PRs - that would be easier to review.

```sh
➜  ag "export default"
exercises/variable-length-quantity/example.js
27:export default {

exercises/strain/example.js
18:export default Strain;

exercises/palindrome-products/example.js
38:export default Palindromes;

exercises/queen-attack/example.js
52:export default QueenAttack;

exercises/sum-of-multiples/example.js
19:export default Sum;

exercises/sieve/example.js
30:export default function (n) {

exercises/hexadecimal/example.js
1:export default function (hex) {
```