### PR TITLE
Fix ESLint errors in Pythagorean Triplet, Spiral Matrix and Sum Of Multiples exercises  

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,13 +8,10 @@ grains
 list-ops
 nth-prime
 palindrome-products
-pythagorean-triplet
 queen-attack
 rational-numbers
 saddle-points
 secret-handshake
-spiral-matrix
 sublist
-sum-of-multiples
 twelve-days
 variable-length-quantity

--- a/exercises/pythagorean-triplet/example.js
+++ b/exercises/pythagorean-triplet/example.js
@@ -18,6 +18,7 @@ export class Triplet {
   }
 
   static where(conditions) {
+    // eslint-disable-next-line no-use-before-define
     return new Triplets(conditions).toArray();
   }
 }
@@ -32,9 +33,9 @@ class Triplets {
   toArray() {
     let triplet;
     const triplets = [];
-    for (let a = this.min; a < this.max - 1; a++) {
-      for (let b = a + 1; b < this.max; b++) {
-        for (let c = b + 1; c <= this.max; c++) {
+    for (let a = this.min; a < this.max - 1; a += 1) {
+      for (let b = a + 1; b < this.max; b += 1) {
+        for (let c = b + 1; c <= this.max; c += 1) {
           triplet = new Triplet(a, b, c);
           if (this.isDesired(triplet)) {
             triplets.push(triplet);

--- a/exercises/spiral-matrix/example.js
+++ b/exercises/spiral-matrix/example.js
@@ -2,21 +2,36 @@ export class SpiralMatrix {
   static ofSize(size) {
     const spiral = Array(size).fill().map(() => Array(0));
 
-    const totalNumbers = size**2;
+    const totalNumbers = size ** 2;
     let currentNumber = 1;
     let topLeft = 0;
     let bottomRight = size - 1;
 
     while (currentNumber <= totalNumbers) {
-      for (let x = topLeft; x <= bottomRight; x++) spiral[topLeft][x] = currentNumber++;
-      for (let y = topLeft + 1; y <= bottomRight; y++) spiral[y][bottomRight] = currentNumber++;
-      for (let x = bottomRight - 1; x >= topLeft; x--) spiral[bottomRight][x] = currentNumber++;
-      for (let y = bottomRight - 1; y >= topLeft + 1; y--) spiral[y][topLeft] = currentNumber++;
+      for (let x = topLeft; x <= bottomRight; x += 1) {
+        spiral[topLeft][x] = currentNumber;
+        currentNumber += 1;
+      }
 
-      topLeft++;
-      bottomRight--;
+      for (let y = topLeft + 1; y <= bottomRight; y += 1) {
+        spiral[y][bottomRight] = currentNumber;
+        currentNumber += 1;
+      }
+
+      for (let x = bottomRight - 1; x >= topLeft; x -= 1) {
+        spiral[bottomRight][x] = currentNumber;
+        currentNumber += 1;
+      }
+
+      for (let y = bottomRight - 1; y >= topLeft + 1; y -= 1) {
+        spiral[y][topLeft] = currentNumber;
+        currentNumber += 1;
+      }
+
+      topLeft += 1;
+      bottomRight -= 1;
     }
 
     return spiral;
   }
-};
+}

--- a/exercises/sum-of-multiples/example.js
+++ b/exercises/sum-of-multiples/example.js
@@ -10,7 +10,7 @@ const Sum = (factors) => {
       }
     });
 
-    return Object.keys(multiples).reduce((prev, curr) => prev += multiples[curr], 0);
+    return Object.keys(multiples).reduce((prev, curr) => prev + multiples[curr], 0);
   };
 
   return self;


### PR DESCRIPTION
Fix various minor issues with some example.js file in accordance with issue #480.

Please note that I've cheated here slightly by adding a `eslint-disable-next-line no-use-before-define` comment to the Pythagorean Triplet file.  The solution given has circular references which can't be easily fixed so the alternative was to completely re-write the solution.