### PR TITLE
Use exact boolean values in leap tests rather than truthy and falsy

### DIFF
--- a/exercises/leap/leap.spec.js
+++ b/exercises/leap/leap.spec.js
@@ -2,22 +2,22 @@ import { isLeap } from './leap';
 
 describe('A leap year', () => {
   test('year not divisible by 4: common year', () => {
-    expect(isLeap(2015)).toBeFalsy();
+    expect(isLeap(2015)).toBe(false);
   });
 
   xtest('year divisible by 4, not divisible by 100: leap year', () => {
-    expect(isLeap(2016)).toBeTruthy();
+    expect(isLeap(2016)).toBe(true);
   });
 
   xtest('year divisible by 100, not divisible by 400: common year', () => {
-    expect(isLeap(2100)).toBeFalsy();
+    expect(isLeap(2100)).toBe(false);
   });
 
   xtest('year divisible by 400: leap year', () => {
-    expect(isLeap(2000)).toBeTruthy();
+    expect(isLeap(2000)).toBe(true);
   });
 
   xtest('year divisible by 200, not divisible by 400: common year', () => {
-    expect(isLeap(1800)).toBeFalsy();
+    expect(isLeap(1800)).toBe(false);
   });
 });


### PR DESCRIPTION
I came across a leap solution which returned `"Leap Year"` string in place of true. This works with existing tests which check `truthy`/`falsy`. I think it is better to check for actual values rather than relying on weird coercion.