### PR TITLE
simple-cipher: add test to check that messages longer than the key can be decoded.

### DIFF
--- a/exercises/simple-cipher/simple-cipher.spec.js
+++ b/exercises/simple-cipher/simple-cipher.spec.js
@@ -116,8 +116,13 @@ describe('Substitution cipher', () => {
     expect(cipher.decode('zabcdefghi')).toEqual('zzzzzzzzzz');
   });
 
-  xtest('can handle messages longer than the key', () => {
+  xtest('can encode messages longer than the key', () => {
     expect(new Cipher('abc').encode('iamapandabear'))
       .toEqual('iboaqcnecbfcr');
+  });
+
+  xtest('can decode messages longer than the key', () => {
+    expect(new Cipher('abc').decode('iboaqcnecbfcr'))
+      .toEqual('iamapandabear');
   });
 });


### PR DESCRIPTION
I just come across a solution for the "Simple Cipher" exercise from a student, which could encode messages longer than the key but failed to _decode_ messages longer than the key, and yet, because we haven't a test to cover this, all tests would pass giving an illusion of correctness.

This pull request adds a test to also check that a message longer than the key can be decoded.

Correspondent problem specifications PR: exercism/problem-specifications#1460.