### PR TITLE
#629 Linked List fix head/tail semantics

### DIFF
--- a/exercises/linked-list/example.js
+++ b/exercises/linked-list/example.js
@@ -10,68 +10,68 @@ export class LinkedList {
   }
 
   pop() {
-    if (!this.head) {
+    if (!this.tail) {
       return undefined;
     }
 
-    const { value } = this.head;
-    if (this.head.next) {
-      this.head = this.head.next;
-      this.head.prev = null;
+    const { value } = this.tail;
+    if (this.tail.next) {
+      this.tail = this.tail.next;
+      this.tail.prev = null;
     } else {
-      this.tail = null;
-      this.head = this.tail;
+      this.head = null;
+      this.tail = this.head;
     }
 
     return value;
   }
 
   push(value) {
-    if (this.head) {
-      const newHead = new Element(value);
-      newHead.next = this.head;
-      this.head.prev = newHead;
-      this.head = newHead;
-    } else {
-      this.head = new Element(value);
-      this.tail = this.head;
-    }
-  }
-
-  shift() {
-    if (!this.tail) {
-      return undefined;
-    }
-
-    const { value } = this.tail;
-    if (this.tail.prev) {
-      this.tail = this.tail.prev;
-      this.tail.next = null;
-    } else {
-      this.tail = null;
-      this.head = this.tail;
-    }
-
-    return value;
-  }
-
-  unshift(value) {
     if (this.tail) {
-      const newTail = new Element(value);
-      newTail.prev = this.tail;
-      this.tail.next = newTail;
-      this.tail = newTail;
+      const newtail = new Element(value);
+      newtail.next = this.tail;
+      this.tail.prev = newtail;
+      this.tail = newtail;
     } else {
       this.tail = new Element(value);
       this.head = this.tail;
     }
   }
 
+  shift() {
+    if (!this.head) {
+      return undefined;
+    }
+
+    const { value } = this.head;
+    if (this.head.prev) {
+      this.head = this.head.prev;
+      this.head.next = null;
+    } else {
+      this.head = null;
+      this.tail = this.head;
+    }
+
+    return value;
+  }
+
+  unshift(value) {
+    if (this.head) {
+      const newhead = new Element(value);
+      newhead.prev = this.head;
+      this.head.next = newhead;
+      this.head = newhead;
+    } else {
+      this.head = new Element(value);
+      this.tail = this.head;
+    }
+  }
+
   count() {
     let count = 0;
-    let element = this.head;
+    let element = this.tail;
 
-    while (this.head && element) {
+    while (this.tail && element) {
       count += 1;
       element = element.next;
     }
@@ -79,18 +79,18 @@ export class LinkedList {
   }
 
   delete(value) {
-    let element = this.head;
+    let element = this.tail;
     while (element) {
       if (element.value === value) {
         if (element.next) {
           element.next.prev = element.prev;
         } else {
-          this.tail = this.tail.prev;
+          this.head = this.head.prev;
         }
         if (element.prev) {
           element.prev.next = element.next;
         } else {
-          this.head = this.head.next;
+          this.tail = this.tail.next;
         }
         element = null;
       } else {


### PR DESCRIPTION
This PR updates the `example.js` code to be more reasonable. The `head` of the 
list is now also the front, and the `tail` of the list is now also the back. 

This matches the explanation in [this article](https://hackernoon.com/the-little-guide-of-linked-list-in-javascript-9daf89b63b54) and the readme.md of this exercise.

Fixes #629 
