### PR TITLE
add exercise version to package.json based on canonical-data.json

### DIFF
--- a/exercises/acronym/package.json
+++ b/exercises/acronym/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.7.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/all-your-base/package.json
+++ b/exercises/all-your-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "2.3.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/allergies/package.json
+++ b/exercises/allergies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/alphametics/package.json
+++ b/exercises/alphametics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.3.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/anagram/package.json
+++ b/exercises/anagram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.4.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/armstrong-numbers/package.json
+++ b/exercises/armstrong-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.0.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/atbash-cipher/package.json
+++ b/exercises/atbash-cipher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/beer-song/package.json
+++ b/exercises/beer-song/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "2.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/binary-search-tree/package.json
+++ b/exercises/binary-search-tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.0.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/binary-search/package.json
+++ b/exercises/binary-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.3.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/binary/package.json
+++ b/exercises/binary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/bob/package.json
+++ b/exercises/bob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.4.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/bowling/package.json
+++ b/exercises/bowling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/bracket-push/package.json
+++ b/exercises/bracket-push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.5.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/change/package.json
+++ b/exercises/change/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.3.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/circular-buffer/package.json
+++ b/exercises/circular-buffer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/clock/package.json
+++ b/exercises/clock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "2.4.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/collatz-conjecture/package.json
+++ b/exercises/collatz-conjecture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.1.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/complex-numbers/package.json
+++ b/exercises/complex-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.3.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/connect/package.json
+++ b/exercises/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/crypto-square/package.json
+++ b/exercises/crypto-square/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "3.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/custom-set/package.json
+++ b/exercises/custom-set/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.3.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/darts/package.json
+++ b/exercises/darts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/diamond/package.json
+++ b/exercises/diamond/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/difference-of-squares/package.json
+++ b/exercises/difference-of-squares/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/diffie-hellman/package.json
+++ b/exercises/diffie-hellman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.0.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/etl/package.json
+++ b/exercises/etl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.0.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/flatten-array/package.json
+++ b/exercises/flatten-array/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/food-chain/package.json
+++ b/exercises/food-chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "2.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/forth/package.json
+++ b/exercises/forth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.7.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/gigasecond/package.json
+++ b/exercises/gigasecond/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "2.0.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/grade-school/package.json
+++ b/exercises/grade-school/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.0.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/grains/package.json
+++ b/exercises/grains/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/hamming/package.json
+++ b/exercises/hamming/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "2.3.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/hello-world/package.json
+++ b/exercises/hello-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/high-scores/package.json
+++ b/exercises/high-scores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "4.0.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/house/package.json
+++ b/exercises/house/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "2.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/isbn-verifier/package.json
+++ b/exercises/isbn-verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "2.7.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/isogram/package.json
+++ b/exercises/isogram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.7.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/kindergarten-garden/package.json
+++ b/exercises/kindergarten-garden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.1.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/largest-series-product/package.json
+++ b/exercises/largest-series-product/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/leap/package.json
+++ b/exercises/leap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.5.1.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/list-ops/package.json
+++ b/exercises/list-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "2.4.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/luhn/package.json
+++ b/exercises/luhn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.4.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/matrix/package.json
+++ b/exercises/matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/meetup/package.json
+++ b/exercises/meetup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/minesweeper/package.json
+++ b/exercises/minesweeper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/nth-prime/package.json
+++ b/exercises/nth-prime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "2.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/nucleotide-count/package.json
+++ b/exercises/nucleotide-count/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.3.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/ocr-numbers/package.json
+++ b/exercises/ocr-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/palindrome-products/package.json
+++ b/exercises/palindrome-products/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/pangram/package.json
+++ b/exercises/pangram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.4.1.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/pascals-triangle/package.json
+++ b/exercises/pascals-triangle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.5.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/perfect-numbers/package.json
+++ b/exercises/perfect-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/phone-number/package.json
+++ b/exercises/phone-number/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.7.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/pig-latin/package.json
+++ b/exercises/pig-latin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/prime-factors/package.json
+++ b/exercises/prime-factors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/protein-translation/package.json
+++ b/exercises/protein-translation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.1.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/proverb/package.json
+++ b/exercises/proverb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/pythagorean-triplet/package.json
+++ b/exercises/pythagorean-triplet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.0.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/queen-attack/package.json
+++ b/exercises/queen-attack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "2.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/raindrops/package.json
+++ b/exercises/raindrops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/rational-numbers/package.json
+++ b/exercises/rational-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.0.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/react/package.json
+++ b/exercises/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "2.0.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/rectangles/package.json
+++ b/exercises/rectangles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/reverse-string/package.json
+++ b/exercises/reverse-string/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/rna-transcription/package.json
+++ b/exercises/rna-transcription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.3.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/robot-simulator/package.json
+++ b/exercises/robot-simulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "3.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/roman-numerals/package.json
+++ b/exercises/roman-numerals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/rotational-cipher/package.json
+++ b/exercises/rotational-cipher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/run-length-encoding/package.json
+++ b/exercises/run-length-encoding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/saddle-points/package.json
+++ b/exercises/saddle-points/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.5.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/say/package.json
+++ b/exercises/say/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/scrabble-score/package.json
+++ b/exercises/scrabble-score/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/secret-handshake/package.json
+++ b/exercises/secret-handshake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/series/package.json
+++ b/exercises/series/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.0.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/sieve/package.json
+++ b/exercises/sieve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/simple-cipher/package.json
+++ b/exercises/simple-cipher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "2.0.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/space-age/package.json
+++ b/exercises/space-age/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/spiral-matrix/package.json
+++ b/exercises/spiral-matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/sublist/package.json
+++ b/exercises/sublist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/sum-of-multiples/package.json
+++ b/exercises/sum-of-multiples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.5.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/transpose/package.json
+++ b/exercises/transpose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/triangle/package.json
+++ b/exercises/triangle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/trinary/package.json
+++ b/exercises/trinary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/twelve-days/package.json
+++ b/exercises/twelve-days/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/two-bucket/package.json
+++ b/exercises/two-bucket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.4.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/two-fer/package.json
+++ b/exercises/two-fer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/variable-length-quantity/package.json
+++ b/exercises/variable-length-quantity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/word-count/package.json
+++ b/exercises/word-count/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.3.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/word-search/package.json
+++ b/exercises/word-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.2.1.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/wordy/package.json
+++ b/exercises/wordy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.5.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/zipper/package.json
+++ b/exercises/zipper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,


### PR DESCRIPTION
closes #628 

I have updated all exercises package.json to have its version field matching canonical-data.json version (when available)

I am a lazy developer, so I used the following bash script:
```
#!/bin/bash

version=`curl -s https://raw.githubusercontent.com/exercism/problem-specifications/master/exercises/$1/$
version="${version:0:6}.0\""

if [[ ${#version} == 3 ]]; then
    echo "error while getting version from canonical-data.json"
    exit 1
fi

echo "setting $1 to version $version"
file="../src/javascript/exercises/$1/package.json"
jq ".version = $version" "$file" | sponge "$file"
```

Usage:
```
sudo apt-get install jq moreutils
bash script.sh <exercise-name>
```

Notes:
1) I can remove the last version number .q if necessary (from 1.0.0.0 to 1.0.0)
2) We need to update others fields of package.json, like name, description, author, repository etc