### PR TITLE
Use LTS instead of latest Node on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-- 'node'
+- 'lts/*'
 sudo: false
 before_install:
 - npm i -g npm@latest


### PR DESCRIPTION
Latest travis breaks for node v11.11 with jest: https://github.com/facebook/create-react-app/issues/6591