### PR TITLE
Documentation: cleanup, links to green pages and snippet update

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,16 +1,31 @@
-ECMAScript is the standard that defines JavaScript, the language that allows web pages to be dynamic.
-It is an interpreted language, which means that it doesn't need to be compiled by the programmer: instead the client (such as a web browser) will parse the code and turn it into code that their machine can run - suitable for creating dynamic websites that can run on any browser on any computer!
+ECMAScript is the standard that defines JavaScript, the language that allows web
+pages to be dynamic. It is an interpreted language, which means that it doesn't
+need to be compiled by the programmer: instead the client (such as a web
+browser) will parse the code and turn it into code that their machine can run -
+suitable for creating dynamic websites that can run on any browser on any
+computer!
 
-In addition to use in web pages with modern web browsers, and it can also be executed on servers where the NodeJS platform is installed where it can be used for creating a web server too.
+In addition to use in web pages with modern web browsers, and it can also be
+executed on servers where the NodeJS platform is installed where it can be used
+for creating a web server too.
 
-"ECMAScript has grown to be one of the world’s most widely used general purpose programming languages.
-It is best known as the language embedded in web browsers but has also been widely adopted for server and embedded applications."
-—[ECMA International Language Specification](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-ecmascript-overview)
+"ECMAScript has grown to be one of the world’s most widely used general purpose
+programming languages.
+It is best known as the language embedded in web browsers but has also been
+widely adopted for server and embedded applications."
+— [ECMA International Language Specification](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-ecmascript-overview)
 
-Starting with the 6th edition (commonly known as ES2015 or ES6) in 2015, a new edition of the standard will be released each year.
-The 6th edition was a major update which brought many enhancements over ES5, including notably template strings, expressive arrow function syntax, and cleaner syntax for defining classes.
+Starting with the 6th edition (commonly known as ES2015 or ES6) in 2015, a new
+edition of the standard will be released each year. The 6th edition was a major
+update which brought many enhancements over ES5, including notably template
+strings, expressive arrow function syntax, and cleaner syntax for defining
+classes.
 
-However, support in current browsers is incomplete, and often requires transpilation with a tool like [Babel](https://babeljs.io/).
+However, support for the newest syntax is incomplete in [current browsers]https://kangax.github.io/compat-table/es6/)
+and [the latest node](https://node.green/), and often requires transpilation
+with a tool like [Babel](https://babeljs.io/).
 
-_Note: This track supports the latest ECMAScript syntax via Babel and the [babel-preset-env](https://babeljs.io/docs/plugins/preset-env/) plugin, and new experimental features will be enabled with each release of the specification. 
-Here, you will find code that not all browsers are able to run. 
+_Note_: This track supports the latest ECMAScript syntax via Babel and the
+[@babel/preset-env](https://babeljs.io/docs/plugins/preset-env/) plugin, and new
+experimental features will be enabled with each release of the specification.
+Here, you will find code that not all runtimes are able to run.

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -21,7 +21,7 @@ update which brought many enhancements over ES5, including notably template
 strings, expressive arrow function syntax, and cleaner syntax for defining
 classes.
 
-However, support for the newest syntax is incomplete in [current browsers]https://kangax.github.io/compat-table/es6/)
+However, support for the newest syntax is incomplete in [current browsers](https://kangax.github.io/compat-table/es6/)
 and [the latest node](https://node.green/), and often requires transpilation
 with a tool like [Babel](https://babeljs.io/).
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,15 +1,15 @@
 There are a couple of ways to install [NodeJS](http://nodejs.org):
 
-* via an [Installer or Binaries](https://nodejs.org/en/download/) 
+* via an [Installer or Binaries](https://nodejs.org/en/download/)
 * via [package managers](https://nodejs.org/en/download/package-manager/)
 
-Both options have selections for Windows, MacOS, and Linux. 
+Both options have selections for Windows, MacOS, and Linux.
 
-If you've used the official installer, your `PATH` should have been automatically
-configured, but if your shell has trouble locating your globally installed
-modules&mdash;or if you build Node.js from source&mdash;update your `PATH` to
-include the `npm` binaries by adding the following to either `~/.bash_profile` or
-`~/.zshrc`:
+If you've used the official installer, your `PATH` should have been
+automatically configured, but if your shell has trouble locating your globally
+installed modules&mdash;or if you build Node.js from source&mdash;update your
+`PATH` to include the `npm` binaries by adding the following to either
+`~/.bash_profile` or `~/.zshrc`:
 
 ```bash
 $ export PATH=/usr/local/share/npm/bin:$PATH
@@ -20,8 +20,8 @@ Each assignment needs some tools to run the tests:
 * [Jest](https://facebook.github.io/jest/): a test runner based on Jasmine
 * [Babel](https://github.com/babel/babel): to transpile ECMAScript
 2015 code to ECMAScript 5
-* [ESLint](http://eslint.org/) (optional): to perform several static analysis and
-coding style checks to your JavaScript code.
+* [ESLint](http://eslint.org/) (optional): to perform several static analysis
+and coding style checks to your JavaScript code.
 
 They can be installed running this command within each assignment directory:
 

--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,5 +1,3 @@
-export class HelloWorld {
-  hello() {
-    return 'Hello, World!';
-  }
+export function hello() {
+  return 'Hello, World!';
 };

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -4,9 +4,10 @@ Execute the tests with:
 $ npm run test
 ```
 
-Be sure your code follows best practices and coding styles, as other users do, with
-ESLint, a tool to perform static analysis to your code. Sometimes, tools like this
-save you some time detecting typos or silly mistakes in your JavaScript code:
+Be sure your code follows best practices and coding styles, as other users do,
+with ESLint, a tool to perform static analysis to your code. Sometimes, tools
+like this save you some time detecting typos or silly mistakes in your
+JavaScript code:
 
 ```bash
 $ npm run lint
@@ -18,7 +19,8 @@ Or do both at the same time:
 $ npm run lint-test
 ```
 
-You can also run Jest in "watch" mode, which will re-run your tests automatically when you save changes to the code or test module:
+You can also run Jest in "watch" mode, which will re-run your tests
+automatically when you save changes to the code or test module:
 
 ```bash
 $ npm run watch
@@ -26,13 +28,18 @@ $ npm run watch
 
 ## Understanding Skip Tests
 
-The skip method instructs the test suite to not run a test, this function could be used also under the aliases: `it.skip(name, fn) or xit(name, fn) or xtest(name, fn)`
+The skip method instructs the test suite to not run a test, this function could
+be used also under the aliases: `it.skip(name, fn)` or `xit(name, fn)` or
+`xtest(name, fn)`
 
 - Why they are skipped ?
-So as to enable users to concentrate on one test at a time and enable one by one as they evolve the solution.
+
+So as to enable users to concentrate on one test at a time and enable one by one
+as they evolve the solution.
 
 - How to enable them ?
-Change xtest to test.
+
+Change `xtest` to `test`.
 
 ```javascript
 test('title cased phrases', () => {
@@ -43,15 +50,15 @@ test('title cased phrases', () => {
 ## Making Your First JavaScript 2015 Module
 
 Usually, tests on this track will load your implementation by importing it as a
-JavaScript module: `import { Bob } from './bob.js';`. You just
-need to export your implementation from the referenced file, `bob.js`:
+JavaScript module: `import { Bob } from './bob.js';`. You just need to export
+your implementation from the referenced file, `bob.js`:
 
 ```javascript
 export class Bob {
   hey(message) {
-	//
-	// Your solution to the exercise goes here
-	//
+    //
+    // Your solution to the exercise goes here
+    //
   }
 }
 ```


### PR DESCRIPTION
- Add links to the green page of node and browsers
- Update babel text to use babel 7's preset env (#636)
- Limit to 80 character width: Normalize these line endings which were sometimes capped at 85, sometimes at 80 and somtimes not at all.
- Update snippet to work with hello-world test: The old class implementation no longer is relevant.