### PR TITLE
Fix bigint tests

### DIFF
--- a/exercises/grains/big-integer.spec.js
+++ b/exercises/grains/big-integer.spec.js
@@ -23,7 +23,7 @@ describe("The big-integer module's returned object", () => {
     expect(bigI.toString()).toBe('42');
     // NOTE:
     // The '==' operator calls '.toString()' here in order to compare.
-    expect(bigI === '42').toBe(true);
+    expect(bigI == '42').toBe(true);
     // While the line above is easier to write and read, we will use the
     // 'expect(bigI.toString()).toBe(expected)' way so that test failure
     // messages will be more informative. Eg,

--- a/exercises/grains/big-integer.spec.js
+++ b/exercises/grains/big-integer.spec.js
@@ -1,6 +1,6 @@
 import BigInt from './lib/big-integer';
 
-describe("The big-integer module's returned object", () => {
+describe('The big-integer module\'s returned object', () => {
   let bigI;
 
   beforeEach(() => {
@@ -17,7 +17,7 @@ describe("The big-integer module's returned object", () => {
     expect(typeof bigI).toBe('object');
   });
 
-  test("can be compared to a stringified number by calling '.toString()'", () => {
+  test('can be compared to a stringified number by calling \'.toString()\'', () => {
     expect(bigI).not.toBe(42);
     expect(bigI).not.toBe('42');
     expect(bigI.toString()).toBe('42');

--- a/exercises/grains/big-integer.spec.js
+++ b/exercises/grains/big-integer.spec.js
@@ -1,6 +1,6 @@
-import BigInt from './big-integer';
+import BigInt from './lib/big-integer';
 
-describe('The big-integer module\'s returned object', () => {
+describe("The big-integer module's returned object", () => {
   let bigI;
 
   beforeEach(() => {
@@ -17,7 +17,7 @@ describe('The big-integer module\'s returned object', () => {
     expect(typeof bigI).toBe('object');
   });
 
-  test('can be compared to a stringified number by calling \'.toString()\'', () => {
+  test("can be compared to a stringified number by calling '.toString()'", () => {
     expect(bigI).not.toBe(42);
     expect(bigI).not.toBe('42');
     expect(bigI.toString()).toBe('42');


### PR DESCRIPTION
For the "Grains" exercise, the BigInt function was not being imported correctly, so the tests wouldn't run.

Also, one of the tests was testing for the .toString() function on BigInt by using coercion, but the test had "===" instead of "==".