### PR TITLE
Promote two-fer to core and sync to 1.2.0

### DIFF
--- a/config.json
+++ b/config.json
@@ -19,6 +19,18 @@
       ]
     },
     {
+      "slug": "two-fer",
+      "uuid": "7f49e997-4435-4f34-a020-bddc92c838ed",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "optional_values",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
       "slug": "leap",
       "uuid": "7c8294ee-5924-4bf8-a72f-31d0e2d7d9a0",
       "core": true,
@@ -225,24 +237,10 @@
       ]
     },
     {
-      "slug": "two-fer",
-      "uuid": "7f49e997-4435-4f34-a020-bddc92c838ed",
-      "core": false,
-      "unlocked_by": "hello-world",
-      "difficulty": 1,
-      "topics": [
-        "booleans",
-        "logic",
-        "optional_values",
-        "strings",
-        "text_formatting"
-      ]
-    },
-    {
       "slug": "reverse-string",
       "uuid": "e84c97eb-dbec-487c-b99f-ae9924e16293",
       "core": false,
-      "unlocked_by": "leap",
+      "unlocked_by": "two-fer",
       "difficulty": 2,
       "topics": [
         "for",

--- a/config.json
+++ b/config.json
@@ -236,20 +236,6 @@
       ]
     },
     {
-      "slug": "two-fer",
-      "uuid": "7f49e997-4435-4f34-a020-bddc92c838ed",
-      "core": false,
-      "unlocked_by": "hello-world",
-      "difficulty": 1,
-      "topics": [
-        "booleans",
-        "logic",
-        "optional_values",
-        "strings",
-        "text_formatting"
-      ]
-    },
-    {
       "slug": "leap",
       "uuid": "7c8294ee-5924-4bf8-a72f-31d0e2d7d9a0",
       "core": false,

--- a/exercises/two-fer/example.js
+++ b/exercises/two-fer/example.js
@@ -1,4 +1,3 @@
-export const twoFer = (name) => {
-  const nameText = name || 'you';
-  return `One for ${nameText}, one for me.`;
+export const twoFer = (name = 'you') => {
+  return `One for ${name}, one for me.`;
 };

--- a/exercises/two-fer/two-fer.spec.js
+++ b/exercises/two-fer/two-fer.spec.js
@@ -1,4 +1,4 @@
-import { twoFer } from './two-fer.js'
+import { twoFer } from './two-fer'
 
 describe('twoFer()', () => {
   test('no name given', () => {

--- a/exercises/two-fer/two-fer.spec.js
+++ b/exercises/two-fer/two-fer.spec.js
@@ -1,18 +1,14 @@
 import { twoFer } from './two-fer.js'
 
-describe('no name given', () => {
+describe('twoFer()', () => {
   test('no name given', () => {
     expect(twoFer()).toEqual("One for you, one for me.")
   })
-})
 
-describe('a name given', () => {
   xtest('a name given', () => {
     expect(twoFer("Alice")).toEqual("One for Alice, one for me.")
   })
-})
 
-describe('another name given', () => {
   xtest('another name given', () => {
     expect(twoFer("Bob")).toEqual("One for Bob, one for me.")
   })

--- a/exercises/two-fer/two-fer.spec.js
+++ b/exercises/two-fer/two-fer.spec.js
@@ -1,18 +1,19 @@
-import { twoFer } from './two-fer';
+import { twoFer } from './two-fer.js'
 
-describe('twoFer()', () => {
+describe('no name given', () => {
   test('no name given', () => {
-    const name = '';
-    expect(twoFer(name)).toEqual('One for you, one for me.');
-  });
+    expect(twoFer()).toEqual("One for you, one for me.")
+  })
+})
 
+describe('a name given', () => {
   xtest('a name given', () => {
-    const name = 'Alice';
-    expect(twoFer(name)).toEqual('One for Alice, one for me.');
-  });
+    expect(twoFer("Alice")).toEqual("One for Alice, one for me.")
+  })
+})
 
+describe('another name given', () => {
   xtest('another name given', () => {
-    const name = 'Bob';
-    expect(twoFer(name)).toEqual('One for Bob, one for me.');
-  });
-});
+    expect(twoFer("Bob")).toEqual("One for Bob, one for me.")
+  })
+})


### PR DESCRIPTION
And make sure we expect an optional argument, instead of passing in null, requiring boolean logic.

Fixes #639 