### PR TITLE
Sync rna-transcription to 1.3.0

### DIFF
--- a/exercises/rna-transcription/example.js
+++ b/exercises/rna-transcription/example.js
@@ -5,13 +5,4 @@ const DNA_TO_RNA = {
   A: 'U',
 };
 
-export const toRna = (dna) => {
-  const rna = dna.replace(/./g, nucleotide => DNA_TO_RNA[nucleotide]);
-
-  if (rna.length !== dna.length) {
-    // invalid characters in the strand
-    throw new Error('Invalid input DNA.');
-  } else {
-    return rna;
-  }
-};
+export const toRna = (dna) => dna.replace(/./g, nucleotide => DNA_TO_RNA[nucleotide]);

--- a/exercises/rna-transcription/rna-transcription.spec.js
+++ b/exercises/rna-transcription/rna-transcription.spec.js
@@ -1,6 +1,6 @@
-import { toRna } from './rna-transcription';
+import { toRna } from './rna-transcription'
 
-describe('Transcriptor', () => {
+describe('Transcription', () => {
   test('empty rna sequence', () => {
     expect(toRna('')).toEqual('');
   });
@@ -13,28 +13,15 @@ describe('Transcriptor', () => {
     expect(toRna('G')).toEqual('C');
   });
 
-  xtest('transcribes adenine to uracil', () => {
-    expect(toRna('A')).toEqual('U');
-  });
-
   xtest('transcribes thymine to adenine', () => {
     expect(toRna('T')).toEqual('A');
   });
 
+  xtest('transcribes adenine to uracil', () => {
+    expect(toRna('A')).toEqual('U');
+  });
+
   xtest('transcribes all dna nucleotides to their rna complements', () => {
-    expect(toRna('ACGTGGTCTTAA'))
-      .toEqual('UGCACCAGAAUU');
+    expect(toRna('ACGTGGTCTTAA')).toEqual('UGCACCAGAAUU');
   });
-
-  xtest('correctly handles invalid input', () => {
-    expect(() => toRna('U')).toThrow(new Error('Invalid input DNA.'));
-  });
-
-  xtest('correctly handles completely invalid input', () => {
-    expect(() => toRna('XXX')).toThrow(new Error('Invalid input DNA.'));
-  });
-
-  xtest('correctly handles partially invalid input', () => {
-    expect(() => toRna('ACGTXXXCTTAA')).toThrow(new Error('Invalid input DNA.'));
-  });
-});
+})


### PR DESCRIPTION
Matching the data on [28 July 2018](https://github.com/exercism/problem-specifications/blob/294c831e290670d2932365754317e92f09baacbc/exercises/rna-transcription/canonical-data.json).