### PR TITLE
[WIP] Bootstrap generate exercise tool

### DIFF
--- a/bin/tools/format-track-config
+++ b/bin/tools/format-track-config
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+/**
+ * This orders the track config.json as follows:
+ *
+ * - core exercises, in current orders
+ * - side exercises, in order of their unlocked_by core exercise
+ * - bonus exercises
+ * - deprecated exercises
+ *
+ * Usage:
+ *
+ * ./bin/tools/format-track-config
+ * ./bin/tools/format-track-config --config=<path/to/config.json> # uses this config
+ */
+
+// @ts-check
+
+const fs = require('fs')
+const path = require('path')
+const pathToConfig = (process.argv.slice(2).find(arg => arg.startsWith('--config')) || path.join(__dirname, '..', '..', 'config.json'))
+  .replace('--config', '')
+  .replace('=', '')
+  .trim()
+
+const config = require(pathToConfig)
+
+const core        = []
+const side        = {}
+const bonus       = []
+const deprecated  = []
+
+for (const exercise of config.exercises) {
+  if (exercise.deprecated === true) {
+    deprecated.push(exercise)
+  } else if (exercise.core === true) {
+    side[core] = []
+    core.push(exercise)
+  } else if (exercise.unlocked_by !== null) {
+    side[exercise.unlocked_by] = side[exercise.unlocked_by] || []
+    side[exercise.unlocked_by].push(exercise)
+  } else {
+    bonus.push(exercise)
+  }
+}
+function orderByDifficulty(a, b) {
+  if (a.difficulty === b.difficulty) {
+
+    return a.slug.localeCompare(b.slug)
+  }
+
+  if (a.difficulty > b.difficulty) {
+    return 1
+  }
+
+  return -1
+}
+
+Object.keys(side).forEach(slug => {
+  side[slug] = side[slug].sort(orderByDifficulty)
+})
+
+bonus.sort(orderByDifficulty)
+
+const newExercises = []
+newExercises.push(...core)
+core.forEach(core_ => newExercises.push(...side[core_.slug]))
+newExercises.push(...bonus)
+newExercises.push(...deprecated)
+
+fs.writeFile(pathToConfig, JSON.stringify({ ...config, exercises: newExercises }, null, 2) + '\n', (err) => {
+  if (err) {
+    process.stderr.write(err.toString())
+    process.exit(-1)
+  }
+
+  process.exit(0)
+})

--- a/bin/tools/generate
+++ b/bin/tools/generate
@@ -5,8 +5,8 @@
  *
  * Usage:
  *
- * ./bin/tools/generate <exercise> <path/to/problem-spec> # no-http
- * ./bin/tools/generate <exercise>                        # will download it
+ * ./bin/tools/generate <exercise> <path/to/problem-spec/root> # no-http
+ * ./bin/tools/generate <exercise>                             # will download it
  */
 
 // @ts-check

--- a/bin/tools/generate
+++ b/bin/tools/generate
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+/**
+ * This generates an exercise from a problem specification.
+ *
+ * Usage:
+ *
+ * ./bin/tools/generate <exercise> <path/to/problem-spec> # no-http
+ * ./bin/tools/generate <exercise>                        # will download it
+ */
+
+// @ts-check
+
+const [exercise, canonicalDataPath] = process.argv.slice(2).filter(arg => !arg.startsWith('-'));
+
+if (!exercise) {
+  process.stderr.write("=> no exercise given\n=> call this with <exercise>\n")
+  process.exit(-1)
+}
+
+function log(message) {
+  process.stdout.write(message + '\n')
+}
+
+(async () => {
+  const canonicalData = await require('../../lib/generate/fetch-canonical-data').fetch({
+    localPath: canonicalDataPath,
+    exercise,
+    log
+  })
+
+  log(`=> generating ${canonicalData.exercise} (${canonicalData.version})\n`);
+
+  const { cases, exports } = require('../../lib/generate/generate-canonical-tests').generate({
+    exportAs: 'functions',
+    canonicalData,
+    log
+  })
+
+  // TODO: check if tests already exist, and diff / only generate new? Or maybe
+  // ask the user if it wants to replace something
+
+  log(`=> writing spec file`)
+  const contents = await require('../../lib/generate/write-canonical-tests').write({ exercise, cases, exports, log })
+  log(`=> contents output`)
+  log(contents)
+
+  const path = require('path')
+  const { execSync } = require('child_process')
+  execSync(`node ${path.join(__dirname, `copy-package-json ${exercise}`)}`, { stdio: 'inherit' })
+  execSync(`node ${path.join(__dirname, `copy-eslint-config ${exercise}`)}`, { stdio: 'inherit' })
+  execSync(`node ${path.join(__dirname, `copy-babel-config ${exercise}`)}`, { stdio: 'inherit' })
+
+  // TODO: automatically generate README.md -- check if problem specs folder exist
+  // execSync(path.join('.', 'bin', `configlet generate ${exercise}`))
+  execSync(path.join('.', 'bin', `configlet uuid`), { stdio: 'inherit' })
+  execSync(path.join('.', 'bin', `configlet lint .`), { stdio: 'inherit' })
+})().catch(() => process.exit(-2))

--- a/bin/tools/generate
+++ b/bin/tools/generate
@@ -23,7 +23,7 @@ function log(message) {
 }
 
 (async () => {
-  const canonicalData = await require('../../lib/generate/fetch-canonical-data').fetch({
+  const canonicalData = await require('../../lib/fetch/canonical-data').fetch({
     localPath: canonicalDataPath,
     exercise,
     log

--- a/bin/tools/lint-topics
+++ b/bin/tools/lint-topics
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+/**
+ * This lints the topics in config.json against the canonical topics
+ *
+ * Usage:
+ *
+ * ./bin/tools/lint-topics                                # will download it
+ * ./bin/tools/lint-topics <path/to/problem-spec/root>    # no-http
+ * ./bin/tools/lint-topics --config=<path/to/config.json> # uses this config
+ */
+
+// @ts-check
+
+const [canonicalDataPath] = process.argv.slice(2).filter(arg => !arg.startsWith('-'));
+
+let knownDistances = {}
+
+/**
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+function levenshtein(a, b) {
+  if (knownDistances[a] && knownDistances[a][b]) {
+    return knownDistances[a][b]
+  }
+
+  knownDistances[a] = knownDistances[a] || {}
+
+  var t = [], u, i, j, m = a.length, n = b.length;
+  if (!m) { return knownDistances[a][b] = n; }
+  if (!n) { return knownDistances[a][b] = m; }
+  for (j = 0; j <= n; j++) { t[j] = j; }
+  for (i = 1; i <= m; i++) {
+    for (u = [i], j = 1; j <= n; j++) {
+      u[j] = a[i - 1] === b[j - 1] ? t[j - 1] : Math.min(t[j - 1], t[j], u[j - 1]) + 1;
+    } t = u;
+  }
+  return knownDistances[a][b] = u[n];
+}
+
+/**
+ *
+ * @param {{ validTopics: string[], invalidTopic: string }} params
+ * @returns {string}
+ */
+function suggest({ validTopics, invalidTopic }) {
+  const inclusions = validTopics.filter((topic) => invalidTopic.indexOf(topic) !== -1)
+
+  if (inclusions.length > 0) {
+    return ` (perhaps: ${inclusions.map(inclusion => `\`${inclusion}\``).join(', ')})`
+  }
+
+  const suggestions = validTopics
+    .map((topic) => ({ topic, distance: levenshtein(topic, invalidTopic)}))
+    .filter(l => l.distance < 6)
+    .sort((a, b) => a.distance === b.distance ? 0 : (a.distance > b.distance ? 1 : -1))
+
+  return suggestions.length > 0 ? ` (perhaps: ${suggestions.map(suggestion => `\`${suggestion.topic}\``).join(', ')})` : ''
+}
+
+const path = require('path')
+const pathToConfig = (process.argv.slice(2).find(arg => arg.startsWith('--config')) || path.join(__dirname, '..', '..', 'config.json'))
+  .replace('--config', '')
+  .replace('=', '')
+  .trim()
+
+
+/** @type {import('../../lib/fetch/topics')} */
+const { fetch } = require(path.join(__dirname, '..', '..', 'lib', 'fetch', 'topics'))
+
+/**
+ * @param {string} message
+ */
+function log(message) {
+  process.stdout.write(message + '\n')
+}
+
+(async function() {
+  log(`=> fetching config from ${pathToConfig}`)
+  /** @type {{ exercises: Array<{ slug: string, topics: string[] }>, language: string }} */
+  const { exercises, language } = require(path.isAbsolute(pathToConfig) ? pathToConfig : path.join(process.cwd(), pathToConfig))
+  const track = language.toLowerCase().replace('#', 'sharp')
+  const validTopics = await fetch({ log, localPath: canonicalDataPath })
+
+  const faultyExercises = exercises.filter(({ topics }) => (topics || []).some(topic => validTopics.indexOf(topic) === -1))
+  const emptyExercises = exercises.filter(({ topics }) => !topics || topics.length === 0)
+
+  if (faultyExercises.length === 0 && emptyExercises.length === 0) {
+    process.stdout.write(
+      'No issues detected'
+    )
+    process.exit(0)
+    return
+  }
+
+  process.stdout.write('<details>\n  <summary>List of valid topics</summary>\n\n')
+  process.stdout.write(validTopics.map(topic => `  - \`${topic}\``).join('\n'))
+  process.stdout.write('\n</details>')
+
+  if (faultyExercises.length > 0) {
+    process.stdout.write('\n\n## Exercises with non-standard topics\n\n')
+    process.stdout.write(
+      faultyExercises.map(({ slug, topics }) => {
+        return `- [ ] [\`${slug}\`](https://github.com/exercism/${track}/tree/master/exercises/${slug})\n`
+          + `  Incorrect topics:\n`
+          + topics
+            .filter(topic => validTopics.indexOf(topic) === -1)
+            .map(topic => `  - [ ] \`${topic}\`${suggest({ validTopics, invalidTopic: topic})}`)
+            .join('\n')
+      }).join('\n')
+    )
+  }
+
+  if (emptyExercises.length > 0) {
+    process.stdout.write('\n\n## Exercises without topics\n\n')
+    process.stdout.write(
+      emptyExercises.map(({ slug }) => {
+        return `- [ ] [\`${slug}\`](https://github.com/exercism/${track}/tree/master/exercises/${slug})`
+      }).join('\n')
+    )
+  }
+
+  process.exit(
+      ( emptyExercises.length === 0 ? 0 : (1 << 1))
+    + (faultyExercises.length === 0 ? 0 : (1 << 2))
+  )
+})()

--- a/bin/tools/list-new-exercises
+++ b/bin/tools/list-new-exercises
@@ -5,7 +5,8 @@
  *
  * Usage:
  *
- * ./bin/tools/list-new-exercises
+ * ./bin/tools/list-new-exercises                             # will download it
+ * ./bin/tools/list-new-exercises <path/to/problem-spec/root> # no-http
  */
 
 // @ts-check

--- a/bin/tools/list-new-exercises
+++ b/bin/tools/list-new-exercises
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+/**
+ * This generates a markdown list of exercises that have not been implemented.
+ *
+ * Usage:
+ *
+ * ./bin/tools/list-new-exercises
+ */
+
+// @ts-check
+
+const fs = require('fs')
+const path = require('path')
+
+/** @type {import('../../lib/fetch/exercises')} */
+const { fetch } = require(path.join(__dirname, '..', '..', 'lib', 'fetch', 'exercises'))
+
+/**
+ * @param {string} message
+ */
+function log(message) {
+  process.stdout.write(message + '\n')
+}
+
+(async function() {
+  const remoteExercises = await fetch({ log })
+  const localExercises = fs.readdirSync(path.join(__dirname, '..', '..', 'exercises'))
+
+  const newExercises = remoteExercises.filter(exercise => !localExercises.includes(exercise))
+
+  process.stdout.write(
+    newExercises.map(i => `- [ ] [${i}](https://github.com/exercism/problem-specifications/tree/master/exercises/${i})`).join("\n")
+  )
+})()

--- a/lib/fetch/canonical-data.js
+++ b/lib/fetch/canonical-data.js
@@ -1,0 +1,36 @@
+// @ts-check
+
+const { get, noop } = require('./get')
+const fs = require('fs')
+
+// TODO: consider using the API
+// TODO: consider using a local copy (via git pull)
+
+const REPOSITORY_BASE_URL = 'https://github.com/exercism/problem-specifications/raw/master/exercises'
+
+/**
+ *
+ * @param {{ exercise: string, localPath: string, log: typeof noop }} options
+ * @returns {Promise<object>}
+ */
+async function fetch({ exercise, localPath, log = noop }) {
+  if (localPath) {
+    log(`=> reading spec from ${localPath}`)
+
+    return new Promise((resolve, reject) => {
+      fs.readFile(localPath, (err, data) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(JSON.parse(data.toString()))
+        }
+      })
+    })
+  }
+
+  const url = [REPOSITORY_BASE_URL, exercise, 'canonical-data.json'].join('/')
+  return get(url, { log, accept: 'application/json' }).then(result => JSON.parse(result.trim()))
+}
+
+
+module.exports = { fetch }

--- a/lib/fetch/canonical-data.js
+++ b/lib/fetch/canonical-data.js
@@ -2,23 +2,23 @@
 
 const { get, noop } = require('./get')
 const fs = require('fs')
+const path = require('path')
 
 // TODO: consider using the API
-// TODO: consider using a local copy (via git pull)
-
 const REPOSITORY_BASE_URL = 'https://github.com/exercism/problem-specifications/raw/master/exercises'
 
 /**
  *
- * @param {{ exercise: string, localPath: string, log: typeof noop }} options
+ * @param {{ exercise: string, localPath?: string, log: typeof noop }} options
  * @returns {Promise<object>}
  */
 async function fetch({ exercise, localPath, log = noop }) {
   if (localPath) {
-    log(`=> reading spec from ${localPath}`)
+    const localExcercisePath = path.join(localPath, exercise, 'canonical-data.json')
+    log(`=> reading spec from ${localExcercisePath}`)
 
     return new Promise((resolve, reject) => {
-      fs.readFile(localPath, (err, data) => {
+      fs.readFile(localExcercisePath, (err, data) => {
         if (err) {
           reject(err)
         } else {

--- a/lib/fetch/exercises.js
+++ b/lib/fetch/exercises.js
@@ -1,0 +1,29 @@
+// @ts-check
+
+const { get, noop } = require('./get')
+
+const jsdom = require("jsdom");
+const { JSDOM } = jsdom
+
+// TODO: consider using the API
+// TODO: consider using a local copy (via git pull)
+
+const REPOSITORY_BASE_URL = 'https://github.com/exercism/problem-specifications/tree/master/exercises'
+
+/**
+ *
+ * @param {{ log: typeof noop }} options
+ * @returns {Promise<string[]>}
+ */
+async function fetch({ log = noop }) {
+  const document = await get(REPOSITORY_BASE_URL, { accept: 'text/html', log }).then(result => new JSDOM(result.trim()).window.document)
+
+  /** @type {NodeListOf<HTMLElement>} */
+  const [...icons] = document.querySelectorAll('table.files [aria-label="directory"]')
+
+  /** @type {string[]} */
+  return icons.map((icon) => icon.closest('tr').querySelector('a').textContent)
+}
+
+
+module.exports = { fetch }

--- a/lib/fetch/exercises.js
+++ b/lib/fetch/exercises.js
@@ -2,21 +2,50 @@
 
 const { get, noop } = require('./get')
 
-const jsdom = require("jsdom");
-const { JSDOM } = jsdom
+const fs = require('fs')
+const path = require('path')
+
+let jsdom = undefined
+
+/**
+ *
+ * @param {string} dom
+ * @returns {import('jsdom').JSDOM}
+ */
+function createDom(dom) {
+  if (!jsdom) {
+    jsdom = require('jsdom')
+  }
+
+  const { JSDOM } = jsdom
+  return new JSDOM(dom)
+}
 
 // TODO: consider using the API
-// TODO: consider using a local copy (via git pull)
-
 const REPOSITORY_BASE_URL = 'https://github.com/exercism/problem-specifications/tree/master/exercises'
 
 /**
  *
- * @param {{ log: typeof noop }} options
+ * @param {{ localPath?: string, log: typeof noop }} options
  * @returns {Promise<string[]>}
  */
-async function fetch({ log = noop }) {
-  const document = await get(REPOSITORY_BASE_URL, { accept: 'text/html', log }).then(result => new JSDOM(result.trim()).window.document)
+async function fetch({ localPath, log = noop }) {
+  if (localPath) {
+    const localExercisesPath = path.join(localPath, 'exercises')
+    log(`=> reading exercises from ${localExercisesPath}`)
+
+    return new Promise((resolve, reject) => {
+      fs.readdir(localExercisesPath, (err, data) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(data.map(dir => dir.trim()))
+        }
+      })
+    })
+  }
+
+  const document = await get(REPOSITORY_BASE_URL, { accept: 'text/html', log }).then(result => createDom(result.trim()).window.document)
 
   /** @type {NodeListOf<HTMLElement>} */
   const [...icons] = document.querySelectorAll('table.files [aria-label="directory"]')

--- a/lib/fetch/get.js
+++ b/lib/fetch/get.js
@@ -1,0 +1,55 @@
+
+const https = require('https')
+
+/**
+ *
+ * @param {any} _
+ */
+// eslint-disable-next-line no-unused-vars
+function noop(_) {}
+
+/**
+ *
+ * @param {string} url
+ * @param {{ log?: (message: string) => void, redirections?: number, accept?: string }} options
+ * @returns {Promise<string>}
+ */
+function get(url, { accept = 'text/html', log = noop, redirections = 10 }) {
+  log(`=> fetch ${url} as ${accept} (${redirections} redirections left)`)
+
+  return new Promise((resolve, reject) => {
+    const request = https.request(url)
+    request.setHeader('Accept', accept)
+    request.setHeader('User-Agent', 'exercism/javascript 0.1.0')
+
+    request.on('error', (err) => reject(err))
+    request.on('response', (response) => {
+      if (response.statusCode >= 300 && response.statusCode < 400 && response.headers['location']) {
+        return get(response.headers['location'], { accept, log, redirections: redirections - 1 })
+          .then(resolve)
+          .catch(reject)
+      }
+
+      if (response.statusCode === 200) {
+        let chunks = ''
+
+        response.on("data", function (chunk) {
+          chunks += chunk || ''
+        })
+
+        response.on("end", function (chunk) {
+          chunks += chunk || ''
+          resolve(chunks)
+        })
+
+        return
+      }
+
+      return reject(new Error(`HTTPError ${response.statusCode}: ${response.statusMessage}`))
+    })
+
+    request.end(() => {})
+  })
+}
+
+module.exports = { noop, get }

--- a/lib/fetch/topics.js
+++ b/lib/fetch/topics.js
@@ -1,0 +1,48 @@
+// @ts-check
+
+const { get, noop } = require('./get')
+const fs = require('fs')
+const path = require('path')
+
+// TODO: consider using the API
+// TODO: consider using a local copy (via git pull)
+
+const REPOSITORY_BASE_URL = 'https://github.com/exercism/problem-specifications/raw/master'
+
+/**
+ *
+ * @param {{ localPath?: string, log: typeof noop }} options
+ * @returns {Promise<string[]>}
+ */
+async function fetch({ localPath, log = noop }) {
+  if (localPath) {
+    const localTopicsPath = path.join(localPath, 'TOPICS.txt')
+    log(`=> reading topics from ${localTopicsPath}`)
+
+    return new Promise((resolve, reject) => {
+      fs.readFile(localTopicsPath, (err, data) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(parse(data.toString()))
+        }
+      })
+    })
+  }
+
+  const url = [REPOSITORY_BASE_URL, 'TOPICS.txt'].join('/')
+  return get(url, { log, accept: 'text/plain' })
+    .then(result => parse(result.trim()))
+}
+
+/**
+ *
+ * @param {string} data
+ * @returns {string[]}
+ */
+function parse(data) {
+  // Remove headers (Capital Name), separators (-----) and blanks ()
+  return data.split("\n").filter((line) => /^[a-z]/.test(line)).map((line) => line.trim())
+}
+
+module.exports = { fetch }

--- a/lib/generate/fetch-canonical-data.js
+++ b/lib/generate/fetch-canonical-data.js
@@ -1,0 +1,68 @@
+// @ts-check
+
+const fs = require('fs')
+const https = require('https')
+
+const REPOSITORY_BASE_URL = 'https://github.com/exercism/problem-specifications/raw/master/exercises'
+
+// eslint-disable-next-line no-unused-vars
+function noop(_) {}
+
+function fetch({ exercise, localPath, log = noop }) {
+  if (localPath) {
+    log(`=> reading spec from ${localPath}`)
+
+    return new Promise((resolve, reject) => {
+      fs.readFile(localPath, (err, data) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(JSON.parse(data.toString()))
+        }
+      })
+    })
+  }
+
+  const url = [REPOSITORY_BASE_URL, exercise, 'canonical-data.json'].join('/')
+  return get(url, log)
+}
+
+function get(url, log = noop, redirections = 10) {
+  log(`=> fetch spec from ${url} (${redirections} redirections left)`)
+
+  return new Promise((resolve, reject) => {
+    const request = https.request(url)
+    request.setHeader('Accept', 'application/json')
+    request.setHeader('User-Agent', 'exercism/javascript 0.1.0')
+
+    request.on('error', (err) => reject(err))
+    request.on('response', (response) => {
+      if (response.statusCode >= 300 && response.statusCode < 400 && response.headers['location']) {
+        return get(response.headers['location'], log, redirections - 1)
+          .then(resolve)
+          .catch(reject)
+      }
+
+      if (response.statusCode === 200) {
+        let chunks = ''
+
+        response.on("data", function (chunk) {
+          chunks += chunk || ''
+        })
+
+        response.on("end", function (chunk) {
+          chunks += chunk || ''
+          resolve(JSON.parse(chunks.trim()))
+        })
+
+        return
+      }
+
+      return reject(new Error(`HTTPError ${response.statusCode}: ${response.statusMessage}`))
+    })
+
+    request.end(() => {})
+  })
+}
+
+module.exports = { fetch }

--- a/lib/generate/generate-canonical-tests.js
+++ b/lib/generate/generate-canonical-tests.js
@@ -1,0 +1,165 @@
+// @ts-check
+
+// eslint-disable-next-line no-unused-vars
+function noop(_) {}
+
+/**
+ * @typedef {{ exercise: string, version: string, cases: (CanonicalCase | CanonicalCases)[] }} canonicalData
+ * @typedef {{ description: string, cases: (CanonicalCase | CanonicalCases)[] }} CanonicalCases
+ * @typedef {{ description: string, property: string, input: { [k: string]: PropertyValue }, expected: PropertyValue }} CanonicalCase
+ * @typedef {(message: string) => void} log
+ * @typedef {ExportOptions & { exports: { [K:string]: true } }} Exported
+ * @typedef {{ as: 'functions' | 'class', class: string }} ExportOptions
+ * @typedef {string | number | (string | number)[] | object} PropertyValue
+ * @typedef {{ [k: string]: string | GeneratedTestCases }} GeneratedTestCases
+ */
+
+/**
+ *
+ * @param {{ canonicalData: any, log: log, exportAs: 'functions' | 'class' }} options
+ * @returns {{ cases: GeneratedTestCases, exports: Exported['exports'] }}
+ */
+function generate({ canonicalData, log = noop, exportAs = 'functions' }) {
+  const exported = {
+    as: exportAs,
+    class: exportAsClassName(canonicalData.exercise),
+    exports: {}
+  }
+
+  const cases = generateCases({
+    canonicalData,
+    exported,
+    log: (message) => log(message.replace(/\{path\}/, canonicalData.exercise)),
+    output: {} })
+
+  return { cases: { [exported.class]: cases }, exports: exported.exports }
+}
+
+/**
+ *
+ * @param {string} exercise
+ * @return {string}
+ */
+function exportAsClassName(exercise) {
+  return exercise
+    .split('-')
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join('')
+}
+
+/**
+ *
+ * @param {string} className
+ * @return {string}
+ */
+function instanceName(className) {
+  return className[0].toLowerCase() + className.slice(1)
+}
+
+/**
+ *
+ * @param {{ canonicalData: CanonicalCases, log: log, exported: Exported, output: GeneratedTestCases }} options
+ */
+function generateCases({ canonicalData, exported, output, log = noop }) {
+  const { cases } = canonicalData
+  const length = cases.length
+  log(`=> generating ${length} cases for {path}`)
+
+  for (let i = 0; i < length; i++) {
+    const current = cases[i]
+
+    /** @type {log} */
+    const nextLog = (message) => log(message.replace(/\{path\}/, `{path} -> ${current.description}`))
+
+    if (/** @type {CanonicalCases} */(current).cases) {
+      output[current.description] = generateCases({
+        exported,
+        log: nextLog,
+        canonicalData: (/** @type {CanonicalCases} */(current)),
+        output: {}
+      })
+    } else {
+      output[current.description] = generateJestTest({
+        ...(/** @type {CanonicalCase} */(current)),
+        log,
+        exported
+      })
+    }
+  }
+
+  return output
+}
+
+/**
+ * Creates a function that, when called, returns the correct way to access the
+ * property with the called argument (input).
+ *
+ * @example when exporting as functions
+ *
+ *   propertyToAccessor({ as: 'functions', exports: {} }, 'foo')
+ *   // => (input) => `foo(${input})`
+ *
+ * @example when exporting as class
+ *
+ *   propertyToAccessor({ as: 'class', exports: {}, class: 'BarKlazz' }, 'foo')
+ *   // => (input) => `barKlazz.foo(${input})`
+ *
+ * @param {Exported} exported
+ * @param {string} property
+ * @returns {(input: string) => string}
+ */
+function propertyToAccessor(exported, property) {
+  switch(exported.as) {
+    case 'functions':
+      exported.exports[property] = true
+      return (input) => `${property}(${input})`
+
+    case 'class':
+      exported.exports[instanceName(exported['class'])] = true
+      return (input) => `${instanceName(exported['class'])}.${property}(${input})`
+
+    default:
+      throw new Error(`Unexpected exported.as: ${exported.as}`)
+  }
+}
+
+/**
+ * Turns an input map to input parameters to be used with the result of
+ * propertyToAccessor.
+ *
+ * @see propertyToAccessor
+ * @param {{ [k: string]: PropertyValue }} input
+ * @returns {string}
+ */
+function inputToAccessorParameter(input) {
+  return Object.keys(input).reduce((result, key) => {
+    const values = input[key]
+    result.push(JSON.stringify(values))
+    return result
+  }, []).join(', ')
+}
+
+/**
+ * Turns an expected value into a jest chaining call
+ * @param {PropertyValue} expected
+ */
+function expectedToJestAssertion(expected) {
+  return `toEqual(${JSON.stringify(expected)})`
+}
+
+/**
+ * Generate a jest test (without describe)
+ * @param {{ description: string, property: string, input: PropertyValue, expected: PropertyValue, exported: Exported, log: log }} options
+ */
+function generateJestTest({ description, property, input, expected, exported, log }) {
+  const access = propertyToAccessor(exported, property)
+  log(`=> test {path} -> ${description}`)
+
+  return `
+xtest('${description}', () => {
+  expect(${access(inputToAccessorParameter(input))}).${expectedToJestAssertion(expected)}
+})
+`.trim()
+}
+
+module.exports = { generate }

--- a/lib/generate/write-canonical-tests.js
+++ b/lib/generate/write-canonical-tests.js
@@ -38,7 +38,7 @@ async function write({ cases, exports, exercise }) {
 
 function generateFile({ cases, exports, exercise }) {
   return [
-    `import { ${Object.keys(exports).filter(key => exports[key]).sort().join(', ') } } from './${exercise}.js'`,
+    `import { ${Object.keys(exports).filter(key => exports[key]).sort().join(', ') } } from './${exercise}'`,
     '',
     generateDescribes(cases).replace(/xtest/, 'test')
   ].join('\n')

--- a/lib/generate/write-canonical-tests.js
+++ b/lib/generate/write-canonical-tests.js
@@ -1,0 +1,72 @@
+// @ts-check
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT_PATH = path.join(__dirname, '..', '..');
+const EXERCISES_PATH = path.join(ROOT_PATH, 'exercises');
+
+// eslint-disable-next-line no-unused-vars
+function noop(_) {}
+
+/**
+ * @typedef {{ [K:string]: true }} Exports
+ * @typedef {{ [k: string]: string | GeneratedTestCases }} GeneratedTestCases
+ * @typedef {(message: string) => void} log
+ */
+
+/**
+ *
+ * @param {{ cases: GeneratedTestCases, exports: Exports, exercise: string, log: log }} options
+ */
+async function write({ cases, exports, exercise }) {
+  return new Promise((resolve, reject) => fs.mkdir(path.join(EXERCISES_PATH, exercise), (err) => {
+    if (err && err.code !== 'EEXIST') {
+      return reject(err)
+    }
+
+    const fileContents = generateFile({ cases, exports, exercise })
+    fs.writeFile(path.join(EXERCISES_PATH, exercise, `${exercise}.spec.js`), fileContents, (err) => {
+      if (err) {
+        return reject(err)
+      }
+
+      return resolve(fileContents)
+    })
+  }))
+}
+
+function generateFile({ cases, exports, exercise }) {
+  return [
+    `import { ${Object.keys(exports).filter(key => exports[key]).sort().join(', ') } } from './${exercise}.js'`,
+    '',
+    generateDescribes(cases).replace(/xtest/, 'test')
+  ].join('\n')
+}
+
+function indent(count, string) {
+  while (count > 0) {
+    return indent(count - 1, "  " + string)
+  }
+  return string
+}
+
+function generateDescribes(cases, indentation = 0) {
+  // TODO: instead of logic to indent, probably want to run prettier and be done
+  return Object.keys(cases).reduce((result, key) => {
+    const value = cases[key]
+    if (typeof value === 'string') {
+      result.push(value.split("\n").map(line => indent(indentation, line)).join("\n"))
+    } else {
+      result.push(indent(indentation, `describe('${key}', () => {`))
+      result.push(
+        generateDescribes(value, indentation + 1).trimRight()
+      )
+      result.push(indent(indentation, '})'))
+    }
+    result.push('')
+    return result
+  }, []).join("\n")
+}
+
+module.exports = { write }


### PR DESCRIPTION
This is a simple tool I just wrote to bootstrap a new exercise. This is no called in travis, or make, or package.json but just makes it easier to quickly add a new exercise.

- downloads the most recent problem specification
- generates test cases based on it (and a few settings, currentlý it's always generating tests expecting a "function")
- writes it to the file
- copies the configuration/package.json

If you have the `problem-specifications` repo locally (as per `configlet`), you can run with a local path. Additionally you can run `configlet generate exercise` in order to generate the README.md.

Similar to other tools, this is just to aid maintaining and contributing.

📌 **do not merge** this is a WIP