### PR TITLE
Refactor makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,44 +25,68 @@ BABEL_CONFIG_FILES= $(shell find ./exercises/*/* -maxdepth 1 -name babel.config.
 SOURCE_ESLINT_MD5 ?= "`./bin/md5-hash ./.eslintrc`"
 ESLINTRC_FILES= $(shell find ./exercises/*/* -maxdepth 1 -name .eslintrc)
 
-copy-assignment:
+sync:
 	@cp package.json exercises/$(ASSIGNMENT)
 	@cp babel.config.js exercises/$(ASSIGNMENT)
 	@cp .eslintrc exercises/$(ASSIGNMENT)
+
+test-prepare:
 	@mkdir -p $(OUTDIR)
-	@cp exercises/grains/lib/big-integer.$(FILEEXT) $(OUTDIR)
-	@cp exercises/$(ASSIGNMENT)/$(TSTFILE) $(OUTDIR)
 	@cp exercises/$(ASSIGNMENT)/$(EXAMPLE) $(OUTDIR)/$(subst _,-,$(ASSIGNMENT)).$(FILEEXT)
 	@sed 's/xtest/test/g' exercises/$(ASSIGNMENT)/$(TSTFILE) > tmp_exercises/$(ASSIGNMENT)/$(TSTFILE)
+	@cp package.json $(OUTDIR)
+	@cp babel.config.js $(OUTDIR)
+	@cp .eslintrc $(OUTDIR)
+ifeq ($(ASSIGNMENT),grains)
+	@mkdir -p tmp_exercises/grains/lib
+	@cp exercises/grains/lib/big-integer.js tmp_exercises/grains/lib/
+endif
 
-# To be run as: make test-assignment ASSIGNMENT=hello-world
-test-assignment:
-	$(MAKE) -s copy-assignment
-	@node_modules/.bin/jest $(OUTDIR)
-	@rm -rf $(OUTDIR)
+test-eslint:
+	@echo "Checking eslint..."
+	@node_modules/.bin/eslint $(OUTDIR);
+
+test-specs:
+	@echo "Running exercise tests..."
+	@node_modules/.bin/jest --bail $(OUTDIR);
+
+test-cleanup:
+	rm -rf $(OUTDIR);
 
 test-travis:
 	@echo "Checking that exercise package.json files match main package.json ..."
 	@for pkg in $(PKG_FILES); do \
-  		! ./bin/md5-hash $$pkg | grep -qv $(SOURCE_PKG_MD5) || { echo "$$pkg does not match main package.json.  Please run 'make test' locally and commit the results."; exit 1; }; \
-  	done
+		! ./bin/md5-hash $$pkg | grep -qv $(SOURCE_PKG_MD5) || { echo "$$pkg does not match main package.json.  Please run 'make test' locally and commit the changes."; exit 1; }; \
+	done
+
 	@echo "Checking that exercise babel.config.js files match main babel.config.json ..."
 	@for bconfig in $(BABEL_CONFIG_FILES); do \
-  		! ./bin/md5-hash $$bconfig | grep -qv $(SOURCE_BABEL_MD5) || { echo "$$bconfig does not match main babel.config.js.  Please run 'make test' locally and commit the results."; exit 1; }; \
-  	done
+		! ./bin/md5-hash $$bconfig | grep -qv $(SOURCE_BABEL_MD5) || { echo "$$bconfig does not match main babel.config.js.  Please run 'make test' locally and commit the changes."; exit 1; }; \
+	done
+
 	@echo "Checking that exercise .eslintrc files match main .eslintrc ..."
 	@for eslintrc in $(ESLINTRC_FILES); do \
-  		! ./bin/md5-hash eslintrc | grep -qv $(SOURCE_ESLINT_MD5) || { echo "$$eslintrc does not match main .eslintrc.  Please run 'make test' locally and commit the results."; exit 1; }; \
-  	done
-	$(MAKE) -s test
+		! ./bin/md5-hash eslintrc | grep -qv $(SOURCE_ESLINT_MD5) || { echo "$$eslintrc does not match main .eslintrc.  Please run 'make test' locally and commit the changes."; exit 1; }; \
+	done
+	@for assignment in $(ASSIGNMENTS); do \
+		ASSIGNMENT=$$assignment $(MAKE) -s test-prepare || exit 1; \
+	done
+	$(MAKE) -s test-eslint
+	$(MAKE) -s test-specs
+	$(MAKE) -s test-cleanup
 
 test:
-	@echo "Preparing tests..."
 	@for assignment in $(ASSIGNMENTS); do \
-		ASSIGNMENT=$$assignment $(MAKE) -s copy-assignment || exit 1; \
+		ASSIGNMENT=$$assignment $(MAKE) -s sync || exit 1; \
+		ASSIGNMENT=$$assignment $(MAKE) -s test-prepare || exit 1; \
 	done
-	@echo "Checking eslint..."
-	@node_modules/.bin/eslint $(OUTDIR);
-	@echo "Running tests..."
-	@node_modules/.bin/jest --bail $(OUTDIR);
-	rm -rf $(OUTDIR);
+	$(MAKE) -s test-eslint
+	$(MAKE) -s test-specs
+	$(MAKE) -s test-cleanup
+
+# To be run as: make test-assignment ASSIGNMENT=hello-world
+test-assignment:
+	$(MAKE) -s test-prepare
+	$(MAKE) -s test-eslint
+	$(MAKE) -s test-specs
+	$(MAKE) -s test-cleanup

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,9 @@ test-prepare:
 	@cp package.json $(OUTDIR)
 	@cp babel.config.js $(OUTDIR)
 	@cp .eslintrc $(OUTDIR)
-ifeq ($(ASSIGNMENT),grains)
-	@mkdir -p tmp_exercises/grains/lib
-	@cp exercises/grains/lib/big-integer.js tmp_exercises/grains/lib/
-endif
+	if test -d exercises/$(ASSIGNMENT)/lib; \
+	then cp -R exercises/$(ASSIGNMENT)/lib $(OUTDIR); \
+	fi
 
 test-eslint:
 	@echo "Checking eslint..."

--- a/exercises/grains/example.js
+++ b/exercises/grains/example.js
@@ -1,4 +1,4 @@
-import BigInt from './big-integer';
+import BigInt from './lib/big-integer';
 
 /**
  * Computes the number of grains on the squares of a


### PR DESCRIPTION
* Break Makefile tasks into smaller chunks for future modification (exercise versioning, etc).

* Fix import of `big-integer` in `grains` example solution file. Not same as #643 