### PR TITLE
Remove spec duplicate from minesweeper task specs

### DIFF
--- a/exercises/minesweeper/minesweeper.spec.js
+++ b/exercises/minesweeper/minesweeper.spec.js
@@ -65,20 +65,6 @@ describe(')', () => {
     expect(annotate(input)).toEqual(expected);
   });
 
-  xtest('handles space surrounded by mines', () => {
-    const input = [
-      '***',
-      '* *',
-      '***',
-    ];
-    const expected = [
-      '***',
-      '*8*',
-      '***',
-    ];
-    expect(annotate(input)).toEqual(expected);
-  });
-
   xtest('handles horizontal line', () => {
     const input = [' * * '];
     const expected = ['1*2*1'];


### PR DESCRIPTION
During solving this task, I found that there is a duplicated spec in the spec file. See in the diff just one above deleted – they are the identical.

To reduce possible confusion we need to delete its copy.