### PR TITLE
Fix fetch-configlet bash script for windows

### DIFF
--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -10,8 +10,18 @@ case $(uname) in
         echo "linux";;
     (Windows*)
         echo "windows";;
+    (MINGW*)
+        echo "windows";;
     (*)
         echo "linux";;
+esac)
+
+EXT=$(
+case $OS in
+    (windows*)
+        echo "zip";;
+    (*)
+        echo "tgz";;
 esac)
 
 ARCH=$(
@@ -26,7 +36,15 @@ case $(uname -m) in
         echo 64bit;;
 esac)
 
-VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
-URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
 
-curl -s --location $URL | tar xz -C bin/
+VERSION="$(curl --silent --head $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
+URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.$EXT
+
+case $EXT in
+    (*zip)
+        curl -s --location $URL -o bin/latest-configlet.zip
+        unzip bin/latest-configlet.zip -d bin/
+        rm bin/latest-configlet.zip;;
+    (*)
+        curl -s --location $URL | tar xz -C bin/;;
+esac


### PR DESCRIPTION
Sync with upstream https://github.com/exercism/configlet/pull/156

* This correctly sets the OS and EXTension when on windows, even when in bash
(or a different bourne-shell).

* Additionally this uses unzip if the extension is zip, as tar will correctly say the
zip is not a tar. `unzip` does not allow for piping, so a temporary file is created.