### PR TITLE
Wordy spec: Use class name as arg for `toThrow`

### DIFF
--- a/exercises/wordy/wordy.spec.js
+++ b/exercises/wordy/wordy.spec.js
@@ -75,13 +75,13 @@ describe('Word Problem', () => {
     const question = 'What is 53 cubed?';
     const problem = new WordProblem(question);
 
-    expect(problem.answer.bind(problem)).toThrow(new ArgumentError());
+    expect(problem.answer.bind(problem)).toThrow(ArgumentError);
   });
 
   xtest('irrelevant', () => {
     const question = 'Who is the president of the United States?';
     const problem = new WordProblem(question);
 
-    expect(problem.answer.bind(problem)).toThrow(new ArgumentError());
+    expect(problem.answer.bind(problem)).toThrow(ArgumentError);
   });
 });


### PR DESCRIPTION
Closes #674 

Per jest documentation, use class name as argument to test `ArgumentError` is thrown.
https://jest-bot.github.io/jest/docs/expect.html#tothrowerror