### PR TITLE
Use JS scripts instead of Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
 script:
 - bin/fetch-configlet
 - bin/configlet lint .
-- make test-travis
+- scripts/ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -4725,7 +4725,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4746,12 +4747,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4766,17 +4769,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4893,7 +4899,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4905,6 +4912,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4919,6 +4927,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4926,12 +4935,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4950,6 +4961,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5030,7 +5042,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5042,6 +5055,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5127,7 +5141,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5163,6 +5178,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5182,6 +5198,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5225,12 +5242,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5602,6 +5621,12 @@
         }
       }
     },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "dev": true
+    },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
@@ -5716,7 +5741,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -7470,6 +7496,15 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -7805,6 +7840,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "shellwords": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "babel-jest": "^24.5.0",
     "eslint": "^5.15.3",
     "eslint-plugin-import": "^2.16.0",
-    "jest": "^24.5.0"
+    "jest": "^24.5.0",
+    "shelljs": "^0.8.3"
   },
   "jest": {
     "modulePathIgnorePatterns": [

--- a/scripts/checksum
+++ b/scripts/checksum
@@ -4,14 +4,18 @@ var shell = require('shelljs');
 var helpers = require('./helpers');
 var crypto = require('crypto');
 
+function sha(str) {
+  return crypto.createHash('md5').update(str).digest("hex");
+}
+
 function checksum(filename, assignment, rootChecksum) {
-  if(assignment) {
-    var assignmentConfig = shell.cat('exercises/' + assignment + '/' + filename).toString();
-    var assignmentChecksum = crypto.createHash('md5').update(assignmentConfig).digest("hex");
-    if(assignmentChecksum !== rootChecksum) {
-      shell.echo(filename + ' did not match for ' + assignment);
-      shell.exit(1);
-    }
+  if(!assignment) { return; }
+
+  var assignmentConfig = shell.cat(['exercises', assignment, filename].join('/')).toString();
+  var assignmentChecksum = sha(assignmentConfig);
+  if(assignmentChecksum !== rootChecksum) {
+    shell.echo(filename + ' did not match for ' + assignment);
+    shell.exit(1);
   }
 }
 
@@ -19,7 +23,7 @@ function checkSumAll(filename, rootFileName = filename) {
   shell.echo('\nChecking integrity of ' + filename + '...');
 
   var config = shell.cat(rootFileName).toString();
-  var rootChecksum = crypto.createHash('md5').update(config).digest("hex");
+  var rootChecksum = sha(config);
   var assignment = shell.env['ASSIGNMENT'];
   var assignments = helpers.assignments;
 

--- a/scripts/checksum
+++ b/scripts/checksum
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+var shell = require('shelljs');
+var helpers = require('./helpers');
+var crypto = require('crypto');
+
+function checksum(filename, assignment, rootChecksum) {
+  if(assignment) {
+    var assignmentConfig = shell.cat('exercises/' + assignment + '/' + filename).toString();
+    var assignmentChecksum = crypto.createHash('md5').update(assignmentConfig).digest("hex");
+    if(assignmentChecksum !== rootChecksum) {
+      shell.echo(filename + ' did not match for ' + assignment);
+      shell.exit(1);
+    }
+  }
+}
+
+function checkSumAll(filename, rootFileName = filename) {
+  shell.echo('\nChecking integrity of ' + filename + '...');
+
+  var config = shell.cat(rootFileName).toString();
+  var rootChecksum = crypto.createHash('md5').update(config).digest("hex");
+  var assignment = shell.env['ASSIGNMENT'];
+  var assignments = helpers.assignments;
+
+  if(assignment) {
+    checksum(filename, assignment, rootChecksum);
+  }
+  else {
+    for(i = 0; i < assignments.length; i++) {
+      checksum(filename, assignments[i], rootChecksum);
+    }
+  }
+}
+
+helpers.createExercisePackageJson();
+checkSumAll('package.json', 'exercise-package.json');
+shell.rm('exercise-package.json');
+
+checkSumAll('.eslintrc');
+checkSumAll('babel.config.js');

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,16 +1,33 @@
 #!/usr/bin/env node
 
+/**
+ * Run this script (from root directory): node scripts/ci
+ *
+ * This will run following checks:
+ * 1. Check config in all exercises matches
+ * 2. Run eslint to check code-style
+ * 3. Run tests against sample solutions
+ */
+
 var shell = require('shelljs');
 var helpers = require('./helpers');
 
 var checkResult = shell.exec('scripts/checksum').code;
-if(checkResult != 0) shell.exit(checkResult);
+if(checkResult != 0) { shell.exit(checkResult); }
 
 // Cleanup tmp directory if any exists
 helpers.cleanUp();
 
+/**
+ * PREPARE=true moves all example and test files to single directory - tmp_exercises
+ * This allows running the test command together for all files
+ * which is way faster than running once for each exercise
+ */
 var lintResult = shell.exec('PREPARE=true scripts/lint').code;
-if(lintResult != 0) shell.exit(lintResult);
+if(lintResult != 0) { shell.exit(lintResult); }
 
+/**
+ * CLEANUP=true removes tmp_exercises folder
+ */
 var testResult = shell.exec('CLEANUP=true scripts/test').code;
-if(testResult != 0) shell.exit(testResult);
+if(testResult != 0) { shell.exit(testResult); }

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+var shell = require('shelljs');
+var helpers = require('./helpers');
+
+var checkResult = shell.exec('scripts/checksum').code;
+if(checkResult != 0) shell.exit(checkResult);
+
+// Cleanup tmp directory if any exists
+helpers.cleanUp();
+
+var lintResult = shell.exec('PREPARE=true scripts/lint').code;
+if(lintResult != 0) shell.exit(lintResult);
+
+var testResult = shell.exec('CLEANUP=true scripts/test').code;
+if(testResult != 0) shell.exit(testResult);

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1,0 +1,75 @@
+// Not intended to be run as a script
+
+var shell = require('shelljs');
+
+var assignments = [];
+var exerciseDirs = shell.ls('-d', 'exercises/*');
+for(i = 0; i < exerciseDirs.length; i++) {
+  assignments.push(exerciseDirs[i].split('/')[1]);
+}
+
+function prepare(assignment) {
+  if(!assignment) {
+    shell.echo('assignment not provided');
+    shell.exit(1);
+  }
+  var exampleFile = 'exercises/' + assignment + '/example.js';
+  var specFile = 'exercises/' + assignment + '/' + assignment + '.spec.js'
+
+  var inDir = 'exercises/' + assignment;
+  var outDir = 'tmp_exercises/' + assignment;
+
+  shell.mkdir('-p', 'tmp_exercises/lib');
+  shell.cp(exampleFile, 'tmp_exercises/' + assignment + '.js')
+  shell.sed('xtest', 'test', specFile)
+    .to('tmp_exercises/' + assignment + '.spec.js');
+
+  var libDir = 'exercises/' + assignment + '/lib/';
+  if(shell.test('-d', libDir)) {
+    shell.cp(libDir + '*.js', 'tmp_exercises/lib');
+  }
+}
+
+function prepareAndRun(command, infoStr, failureStr) {
+  if(shell.env['PREPARE']) {
+    var assignment = shell.env['ASSIGNMENT'];
+
+    if(assignment) {
+      prepare(assignment);
+    }
+    else {
+      for(i = 0; i < assignments.length; i++) {
+        prepare(assignments[i]);
+      }
+    }
+  }
+
+  if(infoStr) shell.echo(infoStr);
+  var result = shell.exec(command);
+
+  if(shell.env['CLEANUP']) cleanUp();
+
+  if(result.code !== 0) {
+    if(failureStr) shell.echo(failureStr);
+    shell.exit(1);
+  }
+}
+
+function cleanUp() {
+  shell.rm('-rf', 'tmp_exercises');
+}
+
+function createExercisePackageJson() {
+  var packageFile = shell.cat('package.json').toString();
+  var packageJson = JSON.parse(packageFile);
+  delete packageJson['devDependencies']['shelljs'];
+  var shellStr = new shell.ShellString(JSON.stringify(packageJson, null, 2) + '\n');
+  shellStr.to('exercise-package.json');
+}
+
+module.exports = {
+  assignments: assignments,
+  cleanUp: cleanUp,
+  prepareAndRun: prepareAndRun,
+  createExercisePackageJson: createExercisePackageJson
+};

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -8,28 +8,33 @@ for(i = 0; i < exerciseDirs.length; i++) {
   assignments.push(exerciseDirs[i].split('/')[1]);
 }
 
+
+/**
+ * Copy sample solution and specs for given assignment to tmp_exercises
+ */
 function prepare(assignment) {
   if(!assignment) {
     shell.echo('assignment not provided');
     shell.exit(1);
   }
-  var exampleFile = 'exercises/' + assignment + '/example.js';
-  var specFile = 'exercises/' + assignment + '/' + assignment + '.spec.js'
+  var exampleFile = ['exercises', assignment, 'example.js'].join('/');
+  var specFile = ['exercises', assignment, assignment + '.spec.js'].join('/');
 
-  var inDir = 'exercises/' + assignment;
-  var outDir = 'tmp_exercises/' + assignment;
+  var inDir = ['exercises', assignment].join('/');
+  var outDir = ['tmp_exercises', assignment].join('/');
 
   shell.mkdir('-p', 'tmp_exercises/lib');
-  shell.cp(exampleFile, 'tmp_exercises/' + assignment + '.js')
+  shell.cp(exampleFile, ['tmp_exercises', assignment + '.js'].join('/'));
   shell.sed('xtest', 'test', specFile)
-    .to('tmp_exercises/' + assignment + '.spec.js');
+    .to(['tmp_exercises', assignment + '.spec.js'].join('/'));
 
-  var libDir = 'exercises/' + assignment + '/lib/';
+  var libDir = ['exercises', assignment, 'lib'].join('/');
   if(shell.test('-d', libDir)) {
-    shell.cp(libDir + '*.js', 'tmp_exercises/lib');
+    shell.cp(libDir + '/*.js', 'tmp_exercises/lib');
   }
 }
 
+// Preapre all exercises (see above) & run a given command
 function prepareAndRun(command, infoStr, failureStr) {
   if(shell.env['PREPARE']) {
     var assignment = shell.env['ASSIGNMENT'];
@@ -44,21 +49,23 @@ function prepareAndRun(command, infoStr, failureStr) {
     }
   }
 
-  if(infoStr) shell.echo(infoStr);
+  if(infoStr) { shell.echo(infoStr); }
   var result = shell.exec(command);
 
-  if(shell.env['CLEANUP']) cleanUp();
+  if(shell.env['CLEANUP']) { cleanUp(); }
 
   if(result.code !== 0) {
-    if(failureStr) shell.echo(failureStr);
+    if(failureStr) { shell.echo(failureStr); }
     shell.exit(1);
   }
 }
 
+// Delete tmp directory
 function cleanUp() {
   shell.rm('-rf', 'tmp_exercises');
 }
 
+// Filter out some unwanted packages and create package.json for exercises
 function createExercisePackageJson() {
   var packageFile = shell.cat('package.json').toString();
   var packageJson = JSON.parse(packageFile);

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+var shell = require('shelljs');
+var helpers = require('./helpers');
+var assignment = shell.env['ASSIGNMENT'];
+
+var infoStr =
+    assignment ? '\nRunning lint for ' + assignment + '...':
+    '\nRunning lint for all exercises...';
+var failureStr = 'Lint check failed!';
+helpers.prepareAndRun('npx eslint tmp_exercises', infoStr, failureStr);

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 
+/**
+ * Run this script (from root directory): node scripts/lint
+ *
+ * This runs tests for all sample solutions
+ */
+
 var shell = require('shelljs');
 var helpers = require('./helpers');
 var assignment = shell.env['ASSIGNMENT'];

--- a/scripts/sync
+++ b/scripts/sync
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+var shell = require('shelljs');
+var assignment = shell.env['ASSIGNMENT'];
+var helpers = require('./helpers');
+
+function copyConfig(destination) {
+  helpers.createExercisePackageJson();
+  shell.cat('exercise-package.json').to(destination + '/package.json');
+  shell.rm('exercise-package.json');
+
+  shell.cp('babel.config.js', destination);
+  shell.cp('.eslintrc', destination);
+}
+
+if(assignment) {
+  shell.echo('Syncing ' + assignment + '...');
+  copyConfig('exercises/' + assignment);
+}
+else {
+  shell.echo('Syncing all assignments...');
+  var assignments = helpers.assignments;
+
+  for(i = 0; i < assignments.length; i++) {
+    copyConfig('exercises/' + assignments[i]);
+  }
+}

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+var shell = require('shelljs');
+var helpers = require('./helpers');
+var assignment = shell.env['ASSIGNMENT'];
+
+var infoStr =
+    assignment ? '\nRunning tests for ' + assignment + '...':
+    '\nRunning tests for all exercises...';
+var failureStr = 'Tests failed!';
+helpers.prepareAndRun('npx jest --bail tmp_exercises', infoStr, failureStr);

--- a/scripts/test
+++ b/scripts/test
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 
+/**
+ * Run this script (from root directory): node scripts/test
+ *
+ * This runs eslint on all sample solutions (and test) files
+ */
+
 var shell = require('shelljs');
 var helpers = require('./helpers');
 var assignment = shell.env['ASSIGNMENT'];


### PR DESCRIPTION
Issue: https://github.com/exercism/javascript/issues/646

* No `make` dependency anymore!

* Uses [shelljs](https://github.com/shelljs/shelljs) for all shell commands. So everything is unix-like without depending on OS commands! `shelljs` gets removed while syncing to exercise dirs and while performing checksum.

* Travis job now uses these JS scripts instead.

* Next step is to streamline process, change all the docs, add contributing doc and delete Makefile.