### PR TITLE
Implement exercise versioning

### DIFF
--- a/exercises/hello-world/hello-world.spec.js
+++ b/exercises/hello-world/hello-world.spec.js
@@ -1,7 +1,7 @@
 import { hello } from './hello-world';
 
 describe('Hello World', () => {
-  test('says hello', () => {
+  test('Say Hi!', () => {
     expect(hello()).toEqual('Hello, World!');
   });
 });

--- a/exercises/hello-world/package.json
+++ b/exercises/hello-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "1.1.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/scripts/checksum
+++ b/scripts/checksum
@@ -15,10 +15,16 @@ const crypto = require('crypto');
 
 const sha = str => crypto.createHash('md5').update(str).digest("hex");
 
+// Helper function to check single assignment
 function checksum(filename, assignment, rootChecksum) {
   if(!assignment) { return; }
 
-  const assignmentConfig = shell.cat(['exercises', assignment, filename].join('/')).toString();
+  let assignmentConfig = shell.cat(['exercises', assignment, filename].join('/')).toString();
+  if(filename === 'package.json') {
+    const json = JSON.parse(assignmentConfig);
+    delete json['version'];
+    assignmentConfig = JSON.stringify(json, null, 2) + '\n';
+  }
   const assignmentChecksum = sha(assignmentConfig);
 
   if(assignmentChecksum !== rootChecksum) {
@@ -27,6 +33,8 @@ function checksum(filename, assignment, rootChecksum) {
   }
 }
 
+// Check all assignments by default
+// or single if ASSIGNMENT is given
 function checkSumAll(filename, rootFileName = filename) {
   shell.echo('\nChecking integrity of ' + filename + '...');
 

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -46,6 +46,7 @@ function createExercisePackageJson() {
   const packageFile = shell.cat('package.json').toString();
   const packageJson = JSON.parse(packageFile);
 
+  delete packageJson['version'];
   SKIP_PACKAGES_FOR_CHECKSUM.forEach(package => delete packageJson['devDependencies'][package]);
 
   const shellStr = new shell.ShellString(JSON.stringify(packageJson, null, 2) + '\n');


### PR DESCRIPTION
* Skip package.json version when comparing checksums. This will allow us to implement versioning policy in https://github.com/exercism/javascript/issues/628.
* As a proof that this works - Sync `hello-world` exercise with canonical data `v1.1.0`. 