### PR TITLE
Fix rational-numbers spec failing on some platforms

### DIFF
--- a/exercises/rational-numbers/rational-numbers.spec.js
+++ b/exercises/rational-numbers/rational-numbers.spec.js
@@ -155,8 +155,7 @@ describe('Exponentiation of a real number to a rational number', () => {
   });
 
   xtest('Raise a real number to a negative rational number', () => {
-    const expected = 0.3333333333333333;
-    expect(new Rational(-1, 2).expreal(9)).toEqual(expected);
+    expect(new Rational(-1, 2).expreal(9)).toBeCloseTo(0.33, 2);
   });
 
   xtest('Raise a real number to a zero rational number', () => {


### PR DESCRIPTION
Due to float precision error. Use `toBeCloseTo` for comparing floats.
https://jestjs.io/docs/en/expect#tobeclosetonumber-numdigits

Failure on master:

```
FAIL tmp_exercises/rational-numbers.spec.js
  ● Exponentiation of a real number to a rational number › Raise a real number to a negative rational number

    expect(received).toEqual(expected)

    Expected: 0.3333333333333333
    Received: 0.33333333333333337

      157 |   test('Raise a real number to a negative rational number', () => {
      158 |     const expected = 0.3333333333333333;
    > 159 |     expect(new Rational(-1, 2).expreal(9)).toEqual(expected);
          |                                            ^
      160 |   });
      161 |
      162 |   test('Raise a real number to a zero rational number', () => {

      at Object.toEqual (tmp_exercises/rational-numbers.spec.js:159:44)
```