### PR TITLE
Change exercise tests to be TDD orientated.

### DIFF
--- a/exercises/change/change.spec.js
+++ b/exercises/change/change.spec.js
@@ -1,7 +1,27 @@
 import { Change } from './change';
 
 describe('Change', () => {
-  test('test change for 1 cent', () => {
+  test('test no coins make 0 change', () => {
+    const change = new Change();
+    const result = change.calculate([1, 5, 10, 21, 25], 0);
+    expect(result).toEqual([]);
+  });
+
+  xtest('negative change is rejected', () => {
+    const change = new Change();
+    const message = 'Negative totals are not allowed.';
+    const test = () => { change.calculate([1, 2, 5], -5); };
+    expect(test).toThrowError(message);
+  });
+
+  xtest('error testing for change smaller than the smallest of coins', () => {
+    const change = new Change();
+    const message = 'The total 3 cannot be represented in the given currency.';
+    const test = () => { change.calculate([5, 10], 3); };
+    expect(test).toThrowError(message);
+  });
+
+  xtest('test change for 1 cent', () => {
     const change = new Change();
     const result = change.calculate([1, 5, 10, 25], 1);
     expect(result).toEqual([1]);
@@ -17,20 +37,6 @@ describe('Change', () => {
     const change = new Change();
     const result = change.calculate([1, 5, 10, 25, 100], 15);
     expect(result).toEqual([5, 10]);
-  });
-
-  xtest('test change with Lilliputian Coins where a greedy algorithm fails', () => {
-    // https://en.wikipedia.org/wiki/Change-making_problem#Greedy_method
-    const change = new Change();
-    const result = change.calculate([1, 4, 15, 20, 50], 23);
-    expect(result).toEqual([4, 4, 15]);
-  });
-
-  xtest('test change with Lower Elbonia Coins where a greedy algorithm fails', () => {
-    // https://en.wikipedia.org/wiki/Change-making_problem#Greedy_method
-    const change = new Change();
-    const result = change.calculate([1, 5, 10, 21, 25], 63);
-    expect(result).toEqual([21, 21, 21]);
   });
 
   xtest('test large amount of change', () => {
@@ -51,19 +57,6 @@ describe('Change', () => {
     expect(result).toEqual([4, 4, 4, 5, 5, 5]);
   });
 
-  xtest('test no coins make 0 change', () => {
-    const change = new Change();
-    const result = change.calculate([1, 5, 10, 21, 25], 0);
-    expect(result).toEqual([]);
-  });
-
-  xtest('error testing for change smaller than the smallest of coins', () => {
-    const change = new Change();
-    const message = 'The total 3 cannot be represented in the given currency.';
-    const test = () => { change.calculate([5, 10], 3); };
-    expect(test).toThrowError(message);
-  });
-
   xtest('error testing if no combination can add up to target', () => {
     const change = new Change();
     const message = 'The total 94 cannot be represented in the given currency.';
@@ -71,10 +64,17 @@ describe('Change', () => {
     expect(test).toThrowError(message);
   });
 
-  xtest('negative change is rejected', () => {
+  xtest('test change with Lilliputian Coins where a greedy algorithm fails', () => {
+    // https://en.wikipedia.org/wiki/Change-making_problem#Greedy_method
     const change = new Change();
-    const message = 'Negative totals are not allowed.';
-    const test = () => { change.calculate([1, 2, 5], -5); };
-    expect(test).toThrowError(message);
+    const result = change.calculate([1, 4, 15, 20, 50], 23);
+    expect(result).toEqual([4, 4, 15]);
+  });
+
+  xtest('test change with Lower Elbonia Coins where a greedy algorithm fails', () => {
+    // https://en.wikipedia.org/wiki/Change-making_problem#Greedy_method
+    const change = new Change();
+    const result = change.calculate([1, 5, 10, 21, 25], 63);
+    expect(result).toEqual([21, 21, 21]);
   });
 });


### PR DESCRIPTION
I have rearranged the tests for this exercise to be more test driven development orientated as we would potentially want the easier test cases to come first so the user doing the exercise can write code to fail fast (eg. negative coins, 0 coins, etc) then build up to the difficult scenarios of using Lilliputian and Lower Elbonia Coins.

This is just a suggestion as I found the exercises as a great way of doing TDD - albeit the tests having already been wrote!