### PR TITLE
simple-cipher: Replace "List" by "Cipher" for the class name

### DIFF
--- a/exercises/simple-cipher/simple-cipher.js
+++ b/exercises/simple-cipher/simple-cipher.js
@@ -3,7 +3,7 @@
 // convenience to get you started writing code faster.
 //
 
-export class List {
+export class Cipher {
   constructor() {
     throw new Error("Remove this statement and implement this function");
   }


### PR DESCRIPTION
As imported by the spec.js file, the class name should be `Cipher`, not `List`.