### PR TITLE
simple-cipher: Update tests according to the spec

### DIFF
--- a/exercises/simple-cipher/package.json
+++ b/exercises/simple-cipher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/simple-cipher/simple-cipher.spec.js
+++ b/exercises/simple-cipher/simple-cipher.spec.js
@@ -14,7 +14,7 @@ describe('Random key generation', () => {
 describe('Random key cipher', () => {
   const cipher = new Cipher();
 
-  test('has a key made of letters', () => {
+  test('has a key made only of lowercase letters', () => {
     expect(cipher.key).toMatch(/^[a-z]+$/);
   });
 
@@ -103,7 +103,7 @@ describe('Substitution cipher', () => {
     expect(cipher.decode(cipher.encode('abcdefghij'))).toEqual('abcdefghij');
   });
 
-  xtest('double shift encode', () => {
+  xtest('can double shift encode', () => {
     expect(new Cipher('iamapandabear').encode('iamapandabear'))
       .toEqual('qayaeaagaciai');
   });

--- a/exercises/simple-cipher/simple-cipher.spec.js
+++ b/exercises/simple-cipher/simple-cipher.spec.js
@@ -1,26 +1,8 @@
 /* eslint-disable no-new */
 import { Cipher } from './simple-cipher';
 
-describe('Random key generation', () => {
-  xtest('generates keys at random', () => {
-    // Strictly speaking, this is difficult to test with 100% certainty.
-    // But, if you have a generator that generates 100-character-long
-    // strings of lowercase letters at random, the odds of two consecutively
-    // generated keys being identical are astronomically low.
-    expect(new Cipher().key).not.toEqual(new Cipher().key);
-  });
-});
-
 describe('Random key cipher', () => {
   const cipher = new Cipher();
-
-  test('has a key made only of lowercase letters', () => {
-    expect(cipher.key).toMatch(/^[a-z]+$/);
-  });
-
-  xtest('has a key that is at least 100 characters long', () => {
-    expect(cipher.key.length).toBeGreaterThanOrEqual(100);
-  });
 
   // Here we take advantage of the fact that plaintext of "aaa..."
   // outputs the key. This is a critical problem with shift ciphers, some
@@ -37,59 +19,15 @@ describe('Random key cipher', () => {
     const plaintext = 'abcdefghij';
     expect(cipher.decode(cipher.encode(plaintext))).toEqual(plaintext);
   });
-});
 
-describe('Incorrect key cipher', () => {
-  xtest('throws an error with an all caps key', () => {
-    expect(() => {
-      new Cipher('ABCDEF');
-    }).toThrow(new Error('Bad key'));
-  });
-
-  xtest('throws an error with a mixed-case key', () => {
-    expect(() => {
-      new Cipher('ABcdEF');
-    }).toThrow(new Error('Bad key'));
-  });
-
-  xtest('throws an error with a numeric key', () => {
-    expect(() => {
-      new Cipher('12345');
-    }).toThrow(new Error('Bad key'));
-  });
-
-  xtest('throws an error with an empty key', () => {
-    expect(() => {
-      new Cipher('');
-    }).toThrow(new Error('Bad key'));
-  });
-
-  xtest('throws an error with a leading space', () => {
-    expect(() => {
-      new Cipher(' leadingspace');
-    }).toThrow(new Error('Bad key'));
-  });
-
-  xtest('throws an error with a punctuation mark', () => {
-    expect(() => {
-      new Cipher('hyphened-word');
-    }).toThrow(new Error('Bad key'));
-  });
-
-  xtest('throws an error with a single capital letter', () => {
-    expect(() => {
-      new Cipher('leonardoDavinci');
-    }).toThrow(new Error('Bad key'));
+  test('key is made only of lowercase letters', () => {
+    expect(cipher.key).toMatch(/^[a-z]+$/);
   });
 });
 
 describe('Substitution cipher', () => {
   const key = 'abcdefghij';
   const cipher = new Cipher(key);
-
-  xtest('keeps the submitted key', () => {
-    expect(cipher.key).toEqual(key);
-  });
 
   xtest('can encode', () => {
     expect(cipher.encode('aaaaaaaaaa')).toEqual('abcdefghij');

--- a/exercises/simple-cipher/simple-cipher.spec.js
+++ b/exercises/simple-cipher/simple-cipher.spec.js
@@ -103,7 +103,7 @@ describe('Substitution cipher', () => {
     expect(cipher.decode(cipher.encode('abcdefghij'))).toEqual('abcdefghij');
   });
 
-  xtest(': double shift encode', () => {
+  xtest('double shift encode', () => {
     expect(new Cipher('iamapandabear').encode('iamapandabear'))
       .toEqual('qayaeaagaciai');
   });

--- a/exercises/simple-cipher/simple-cipher.spec.js
+++ b/exercises/simple-cipher/simple-cipher.spec.js
@@ -4,10 +4,10 @@ import { Cipher } from './simple-cipher';
 describe('Random key cipher', () => {
   const cipher = new Cipher();
 
-  // Here we take advantage of the fact that plaintext of "aaa..."
-  // outputs the key. This is a critical problem with shift ciphers, some
-  // characters will always output the key verbatim.
   xtest('can encode', () => {
+    // Here we take advantage of the fact that plaintext of "aaa..."
+    // outputs the key. This is a critical problem with shift ciphers, some
+    // characters will always output the key verbatim.
     expect(cipher.encode('aaaaaaaaaa')).toEqual(cipher.key.substr(0, 10));
   });
 
@@ -16,6 +16,8 @@ describe('Random key cipher', () => {
   });
 
   xtest('is reversible', () => {
+    // I.e., if you apply decode in a encoded result, you must see
+    // the same plaintext encode parameter as a result of the decode method
     const plaintext = 'abcdefghij';
     expect(cipher.decode(cipher.encode(plaintext))).toEqual(plaintext);
   });
@@ -38,6 +40,8 @@ describe('Substitution cipher', () => {
   });
 
   xtest('is reversible', () => {
+    // I.e., if you apply decode in a encoded result, you must see
+    // the same plaintext encode parameter as a result of the decode method
     expect(cipher.decode(cipher.encode('abcdefghij'))).toEqual('abcdefghij');
   });
 


### PR DESCRIPTION
EDIT: at first, this PR just fixed a typo. In the end we updated the test file to match the spec file mentioned in the next comment.