### PR TITLE
Test that callbacks with static values still fire

### DIFF
--- a/exercises/react/react.spec.js
+++ b/exercises/react/react.spec.js
@@ -98,6 +98,24 @@ describe('React module', () => {
     expect(callback.values).toEqual([222]);
   });
 
+  xtest('static callbacks fire even if their own value has not changed', () => {
+    const inputCell = new InputCell(1);
+    const output = new ComputeCell(
+      [inputCell],
+      inputs => (inputs[0].value < 3 ? 111 : 222),
+    );
+
+    const callback = new CallbackCell(() => "cell changed");
+    output.addCallback(callback);
+
+    inputCell.setValue(2);
+    expect(callback.values).toEqual([]);
+
+    inputCell.setValue(4);
+    inputCell.setValue(2);
+    inputCell.setValue(4);
+    expect(callback.values).toEqual(["cell changed","cell changed","cell changed"]);
+  });
 
   xtest('callbacks can be added and removed', () => {
     const inputCell = new InputCell(1);


### PR DESCRIPTION
I had a student misunderstand the callback system and **their callbacks would always run** but _only log values_ if the *callback* data had changed. The tests still pass since all the test callbacks mirror the cells data (ie, always changing when the cell changes).

A single test that had static data would have failed.

Can we fix this somehow?