### PR TITLE
linked-list: add test 'deletes only the first occurence'

### DIFF
--- a/exercises/linked-list/.meta/hints.md
+++ b/exercises/linked-list/.meta/hints.md
@@ -1,0 +1,2 @@
+Your list must also implement the following interface:
+- `delete` (delete the first occurence of a specified value)

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -27,6 +27,10 @@ empty list.
 
 If you want to know more about linked lists, check [Wikipedia](https://en.wikipedia.org/wiki/Linked_list).
 
+Your list must also implement the following interface:
+- `delete` (delete the first occurence of a specified value)
+
+
 ## Setup
 
 Go through the setup instructions for Javascript to install the necessary

--- a/exercises/linked-list/linked-list.spec.js
+++ b/exercises/linked-list/linked-list.spec.js
@@ -104,4 +104,12 @@ describe('LinkedList', () => {
     list.delete(20);
     expect(list.count()).toBe(1);
   });
+  xtest('deletes only the first occurence', () => {
+    const list = new LinkedList();
+    list.push(10);
+    list.push(10);
+    list.delete(10);
+    expect(list.count()).toBe(1);
+    expect(list.pop()).toBe(10);
+  });
 });


### PR DESCRIPTION
The following implementation of `LinkedList.delete(value)` would pass existing tests, but is incorrect:
```Javascript
  delete(value) {
    let current = this.head;
    while (current !== null) {
      if (value === current.value) {
        if (current.prev === null) {
          this.head = current.next;
        } else {
          current.prev.setNext(current.next);
        }
        if (current.next === null) {
          this.tail = current.prev;
        } else {
          current.next.setPrev(current.prev);
        }
      }
      current = current.next;
    }
  }
```