### PR TITLE
linked-list: improve test for deleting first occurence only

### DIFF
--- a/exercises/linked-list/linked-list.spec.js
+++ b/exercises/linked-list/linked-list.spec.js
@@ -106,10 +106,14 @@ describe('LinkedList', () => {
   });
   xtest('deletes only the first occurence', () => {
     const list = new LinkedList();
+    list.push(5);
     list.push(10);
     list.push(10);
+    list.push(2);
     list.delete(10);
-    expect(list.count()).toBe(1);
+    expect(list.count()).toBe(3);
+    expect(list.pop()).toBe(2);
     expect(list.pop()).toBe(10);
+    expect(list.pop()).toBe(5);
   });
 });


### PR DESCRIPTION
The following implementation of `delete` passes the existing test, but does not pass with the suggested changes:
```Javascript
  delete(value) {
    switch(value) {
      case this.head.value: return this.shift();
      case this.tail.value: return this.pop();
      default: {
        for (let current = this.head; current; current = current.next) {
          if (value === current.value) {
            this.remove(current);
            // If this break statement were not commented out,
            // this solution would pass the suggested AND
            // the current forms of the test
            // break;
          }
        }
      }
    }

  remove(node) {
    if (!node.prev) {
      this.head = node.next;
    } else {
      node.prev.setNext(node.next);
    }
    if (!node.next) {
      this.tail = node.prev;
    } else {
      node.next.setPrev(node.prev);
    }
    return node;
  }
```