### PR TITLE
Add CI check for stub files

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -12,6 +12,9 @@
 const shell = require('shelljs');
 const helpers = require('./helpers');
 
+const stubResult = shell.exec('scripts/stub-check').code;
+if(stubResult != 0) { shell.exit(stubResult); }
+
 const checkResult = shell.exec('scripts/checksum').code;
 if(checkResult != 0) { shell.exit(checkResult); }
 

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -4,10 +4,13 @@
  */
 
 const shell = require('shelljs');
+const fs = require('fs');
 
 const exerciseDirs = shell.ls('-d', 'exercises/*');
 
-const assignments = exerciseDirs.map(dir => dir.split('/')[1]);
+const config = JSON.parse(fs.readFileSync('config.json'))['exercises'];
+const assignments = exerciseDirs.map(dir => dir.split('/')[1])
+      .filter(exercise => !exercise.deprecated);
 
 // Preapre all exercises (see above) & run a given command
 function prepareAndRun(command, infoStr, failureStr) {

--- a/scripts/stub-check
+++ b/scripts/stub-check
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+/**
+ * Run this script (from root directory): npx @babel/node scripts/stub-check
+ *
+ * This script checks that all exercises have a stub file.
+ * Ref: https://github.com/exercism/javascript/issues/705
+ */
+
+const shell = require('shelljs');
+const helpers = require('./helpers');
+
+const noStubs = helpers.assignments.filter(
+  assignment => !shell.test('-f', `exercises/${assignment}/${assignment}.js`)
+);
+if(noStubs.length > 0) {
+  shell.echo('[Error]: No stub files found for following exercises:');
+  shell.echo(noStubs.join('\n'));
+  shell.exit(1);
+}
+else {
+  shell.echo('[Success]: Stub files present for all exercises!');
+}


### PR DESCRIPTION
To be merged after we get all stubs.

Here's the list of exercises missing stubs:

- [x] alphametics
- [x] atbash-cipher
- [x] binary-search
- [x] bowling
- [x] change
- [x] circular-buffer
- [x] connect
- [x] crypto-square
- [x] diffie-hellman
- [x] forth
- [x] kindergarten-garden
- [x] meetup
- [x] minesweeper
- [x] queen-attack
- [x] react
- [x] simple-linked-list
- [x] two-fer
- [x] word-search
- [x] wordy
- [x] zipper