### PR TITLE
Add two-fer version

### DIFF
--- a/exercises/two-fer/package.json
+++ b/exercises/two-fer/package.json
@@ -1,5 +1,6 @@
 {
   "name": "exercism-javascript",
+  "version": "1.2.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,


### PR DESCRIPTION
This exercise is already synced with the latest canonical-data, but a version (#688) is missing.