### PR TITLE
Add resistor-color version

### DIFF
--- a/exercises/resistor-color/package.json
+++ b/exercises/resistor-color/package.json
@@ -1,5 +1,6 @@
 {
   "name": "exercism-javascript",
+  "version": "1.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,


### PR DESCRIPTION
This exercise is already synced with the latest canonical-data, but a version (#688) is missing.