### PR TITLE
Sync gigasecond with 2.0.0

### DIFF
--- a/exercises/gigasecond/gigasecond.spec.js
+++ b/exercises/gigasecond/gigasecond.spec.js
@@ -27,7 +27,7 @@ describe('Gigasecond', () => {
     const gs = gigasecond(new Date(Date.UTC(2015, 0, 24, 22, 0, 0)));
     const expectedDate = new Date(Date.parse('2046-10-02T23:46:40Z'));
     expect(gs).toEqual(expectedDate);
-  })
+  });
   
   // full time with day roll-over
   xtest('tells the anniversary is next day when you are born at night', () => {

--- a/exercises/gigasecond/gigasecond.spec.js
+++ b/exercises/gigasecond/gigasecond.spec.js
@@ -1,21 +1,38 @@
 import { gigasecond } from './gigasecond';
 
-describe('Gigasecond', () => {
+describe('Gigasecond', () => {  
+  // date only specification of time
   test('tells a gigasecond anniversary since midnight', () => {
-    const gs = gigasecond(new Date(Date.UTC(2015, 8, 14)));
-    const expectedDate = new Date(Date.UTC(2047, 4, 23, 1, 46, 40));
+    const gs = gigasecond(new Date(Date.UTC(2011, 3, 25)));
+    const expectedDate = new Date(Date.parse('2043-01-01T01:46:40Z'));
     expect(gs).toEqual(expectedDate);
   });
-
+  
+  // second test for date only specification of time
+  xtest('tells another gigasecond anniversary since midnight', () => {
+    const gs = gigasecond(new Date(Date.UTC(1977, 5, 13)));
+    const expectedDate = new Date(Date.parse('2009-02-19T01:46:40Z'));
+    expect(gs).toEqual(expectedDate);
+  });
+  
+  // third test for date only specification of time
+  xtest('tells gigasecond anniversary since midnight, from before UNIX epoch', () => {
+    const gs = gigasecond(new Date(Date.UTC(1959, 6, 19)));
+    const expectedDate = new Date(Date.parse('1991-03-27T01:46:40Z'));
+    expect(gs).toEqual(expectedDate);
+  });
+  
+  // full time specified
+  xtest('tells the anniversary, including a time', () => {
+    const gs = gigasecond(new Date(Date.UTC(2015, 0, 24, 22, 0, 0)));
+    const expectedDate = new Date(Date.parse('2046-10-02T23:46:40Z'));
+    expect(gs).toEqual(expectedDate);
+  })
+  
+  // full time with day roll-over
   xtest('tells the anniversary is next day when you are born at night', () => {
-    const gs = gigasecond(new Date(Date.UTC(2015, 8, 14, 23, 59, 59)));
-    const expectedDate = new Date(Date.UTC(2047, 4, 24, 1, 46, 39));
-    expect(gs).toEqual(expectedDate);
-  });
-
-  xtest('even works before 1970 (beginning of Unix epoch)', () => {
-    const gs = gigasecond(new Date(Date.UTC(1959, 6, 19, 5, 13, 45)));
-    const expectedDate = new Date(Date.UTC(1991, 2, 27, 7, 0, 25));
+    const gs = gigasecond(new Date(Date.UTC(2015, 0, 24, 23, 59, 59)));
+    const expectedDate = new Date(Date.parse('2046-10-03T01:46:39Z'));
     expect(gs).toEqual(expectedDate);
   });
 });

--- a/exercises/gigasecond/package.json
+++ b/exercises/gigasecond/package.json
@@ -1,5 +1,6 @@
 {
   "name": "exercism-javascript",
+  "version": "2.0.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,


### PR DESCRIPTION
Adds the missing test cases. Locks timezone at UTC (like before), but uses Date.parse for expected output to match problem-specifications. The comments above the test match the name of the test cases in the problem-specifications canonical data.