### PR TITLE
Update isbn-verifier.spec.js

### DIFF
--- a/exercises/isbn-verifier/isbn-verifier.spec.js
+++ b/exercises/isbn-verifier/isbn-verifier.spec.js
@@ -32,7 +32,7 @@ describe('ISBN Verifier Test Suite', () => {
   });
 
   xtest('X is only valid as a check digit', () => {
-    const isbn = new ISBN('3-598-2X507-0');
+    const isbn = new ISBN('3-598-2X507-9');
 
     expect(isbn.isValid()).toEqual(false);
   });


### PR DESCRIPTION
Updating **X is only valid as a check digit** test so if `X` in the middle of ISBN is treated as `10` the test will fail.

Changing check digit to `9` means `checksum('3-598-2X507-9') mod 11 == 0`, so solutions which simply replace `X` with `10` (without checking location) will treat `3-598-2X507-9` as a valid ISBN.