### PR TITLE
Sync Leap exercise with v1.6.0

### DIFF
--- a/exercises/leap/leap.spec.js
+++ b/exercises/leap/leap.spec.js
@@ -1,23 +1,39 @@
 import { isLeap } from './leap';
 
 describe('A leap year', () => {
-  test('year not divisible by 4: common year', () => {
+  test('year not divisible by 4 in common year', () => {
     expect(isLeap(2015)).toBe(false);
   });
 
-  xtest('year divisible by 4, not divisible by 100: leap year', () => {
-    expect(isLeap(2016)).toBe(true);
+  xtest('year divisible by 2, not divisible by 4 in common year', () => {
+    expect(isLeap(1970)).toBe(false);
   });
 
-  xtest('year divisible by 100, not divisible by 400: common year', () => {
+  xtest('year divisible by 4, not divisible by 100 in leap year', () => {
+    expect(isLeap(1996)).toBe(true);
+  });
+
+  xtest('year divisible by 4 and 5 is still a leap year', () => {
+    expect(isLeap(1960)).toBe(true);
+  });
+
+  xtest('year divisible by 100, not divisible by 400 in common year', () => {
     expect(isLeap(2100)).toBe(false);
   });
 
-  xtest('year divisible by 400: leap year', () => {
+  xtest('year divisible by 100 but not by 3 is still not a leap year', () => {
+    expect(isLeap(1900)).toBe(false);
+  });
+
+  xtest('year divisible by 400 in leap year', () => {
     expect(isLeap(2000)).toBe(true);
   });
 
-  xtest('year divisible by 200, not divisible by 400: common year', () => {
+  xtest('year divisible by 400 but not by 125 is still a leap year', () => {
+    expect(isLeap(2400)).toBe(true);
+  });
+
+  xtest('year divisible by 200, not divisible by 400 in common year', () => {
     expect(isLeap(1800)).toBe(false);
   });
 });

--- a/exercises/leap/package.json
+++ b/exercises/leap/package.json
@@ -1,5 +1,6 @@
 {
   "name": "exercism-javascript",
+  "version": "1.6.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,


### PR DESCRIPTION
## Context
See [Leap exercise's canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/leap/canonical-data.json)

## Changes
For Leap exercise:
- Sync test descriptions with canonical data
- Add missing tests
- Add version