### PR TITLE
Add new exercise grep

### DIFF
--- a/config.json
+++ b/config.json
@@ -1435,7 +1435,7 @@
       "slug": "grep",
       "uuid": "78bcbae1-a0f2-460c-ba89-e51844fe9397",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "matrix",
       "difficulty": 4,
       "topics": [
         "files",

--- a/config.json
+++ b/config.json
@@ -1430,6 +1430,18 @@
         "strings"
       ],
       "deprecated": true
+    },
+    {
+      "slug": "grep",
+      "uuid": "78bcbae1-a0f2-460c-ba89-e51844fe9397",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "files",
+        "searching",
+        "text_formatting"
+      ]
     }
   ]
 }

--- a/exercises/grep/.eslintrc
+++ b/exercises/grep/.eslintrc
@@ -1,0 +1,26 @@
+{
+  "root": true,
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaVersion": 7,
+    "sourceType": "module"
+  },
+  "env": {
+    "es6": true,
+    "node": true,
+    "jest": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:import/errors",
+    "plugin:import/warnings"
+  ],
+  "rules": {
+    "linebreak-style": "off",
+
+    "import/extensions": "off",
+    "import/no-default-export": "off",
+    "import/no-unresolved": "off",
+    "import/prefer-default-export": "off"
+  }
+}

--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -1,0 +1,102 @@
+# Grep
+
+Search a file for lines matching a regular expression pattern. Return the line
+number and contents of each matching line.
+
+The Unix [`grep`](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html) command can be used to search for lines in one or more files
+that match a user-provided search query (known as the *pattern*).
+
+The `grep` command takes three arguments:
+
+1. The pattern used to match lines in a file.
+2. Zero or more flags to customize the matching behavior.
+3. One or more files in which to search for matching lines.
+
+Your task is to implement the `grep` function, which should read the contents
+of the specified files, find the lines that match the specified pattern
+and then output those lines as a single string. Note that the lines should
+be output in the order in which they were found, with the first matching line
+in the first file being output first.
+
+As an example, suppose there is a file named "input.txt" with the following contents:
+
+```text
+hello
+world
+hello again
+```
+
+If we were to call `grep "hello" input.txt`, the returned string should be:
+
+```text
+hello
+hello again
+```
+
+### Flags
+
+As said earlier, the `grep` command should also support the following flags:
+
+- `-n` Print the line numbers of each matching line.
+- `-l` Print only the names of files that contain at least one matching line.
+- `-i` Match line using a case-insensitive comparison.
+- `-v` Invert the program -- collect all lines that fail to match the pattern.
+- `-x` Only match entire lines, instead of lines that contain a match.
+
+If we run `grep -n "hello" input.txt`, the `-n` flag will require the matching
+lines to be prefixed with its line number:
+
+```text
+1:hello
+3:hello again
+```
+
+And if we run `grep -i "HELLO" input.txt`, we'll do a case-insensitive match,
+and the output will be:
+
+```text
+hello
+hello again
+```
+
+The `grep` command should support multiple flags at once.
+
+For example, running `grep -l -v "hello" file1.txt file2.txt` should
+print the names of files that do not contain the string "hello".
+
+## Setup
+
+Go through the setup instructions for Javascript to install the necessary
+dependencies:
+
+[https://exercism.io/tracks/javascript/installation](https://exercism.io/tracks/javascript/installation)
+
+## Requirements
+
+Install assignment dependencies:
+
+```bash
+$ npm install
+```
+
+## Making the test suite pass
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+In the test suites all tests but the first have been skipped.
+
+Once you get a test passing, you can enable the next one by changing `xtest` to
+`test`.
+
+## Source
+
+Conversation with Nate Foster. [http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf](http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf)
+
+## Submitting Incomplete Solutions
+
+It's possible to submit an incomplete solution so you can see how others have
+completed the exercise.

--- a/exercises/grep/babel.config.js
+++ b/exercises/grep/babel.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  presets: [
+    [
+      '@babel/env',
+      {
+        targets: {
+          node: 'current',
+        },
+        useBuiltIns: false,
+      },
+
+    ],
+  ],
+};

--- a/exercises/grep/data/iliad.txt
+++ b/exercises/grep/data/iliad.txt
@@ -1,0 +1,9 @@
+Achilles sing, O Goddess! Peleus' son;
+His wrath pernicious, who ten thousand woes
+Caused to Achaia's host, sent many a soul
+Illustrious into Ades premature,
+And Heroes gave (so stood the will of Jove)
+To dogs and to all ravening fowls a prey,
+When fierce dispute had separated once
+The noble Chief Achilles from the son
+Of Atreus, Agamemnon, King of men.

--- a/exercises/grep/data/midsummer-night.txt
+++ b/exercises/grep/data/midsummer-night.txt
@@ -1,0 +1,7 @@
+I do entreat your grace to pardon me.
+I know not by what power I am made bold,
+Nor how it may concern my modesty,
+In such a presence here to plead my thoughts;
+But I beseech your grace that I may know
+The worst that may befall me in this case,
+If I refuse to wed Demetrius.

--- a/exercises/grep/data/paradise-lost.txt
+++ b/exercises/grep/data/paradise-lost.txt
@@ -1,0 +1,8 @@
+Of Mans First Disobedience, and the Fruit
+Of that Forbidden Tree, whose mortal tast
+Brought Death into the World, and all our woe,
+With loss of Eden, till one greater Man
+Restore us, and regain the blissful Seat,
+Sing Heav'nly Muse, that on the secret top
+Of Oreb, or of Sinai, didst inspire
+That Shepherd, who first taught the chosen Seed

--- a/exercises/grep/example.js
+++ b/exercises/grep/example.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+const fs = require('fs')
+
+// Helpers
+const availables_options = [
+  'n', // add line numbers
+  'l', // print file names where pattern is found
+  'i', // ignore case
+  'v', // reverse files results
+  'x'  // match entire line 
+];
+
+const does_line_matche_pattern = (line, pattern) => {
+  let left = line;
+  let right = pattern;
+
+  if (is_option_set('i')) {
+    left = line.toLowerCase()
+    right = pattern.toLowerCase()
+  }
+
+  if (is_option_set('x')) {
+    return left === right;
+  }
+
+  return left.match(right) !== null;
+
+}
+
+const getConfigFromArgs = () => {
+  const config = {
+    'pattern': '',
+    'options': [],
+    'files': []
+  };
+
+  let has_pattern_been_found = false;
+
+  process.argv.slice(2).forEach(val => {
+    if (has_pattern_been_found) {
+      config.files.push(val)
+    } else if (val.indexOf('-') !== -1) {
+      const option = val.replace('-', '')
+
+      if (!availables_options.includes(option)) {
+        throw new Error(`Unknown option ${option}`)
+      }
+
+      config.options.push(option)
+    } else {
+      has_pattern_been_found = true
+      config.pattern = val
+    }
+  })
+
+  return config;
+}
+
+const config = getConfigFromArgs()
+const is_option_set = option => config.options.includes(option);
+
+// Actual script
+config.files.forEach(file => {
+  const data = fs.readFileSync(file, { encoding: 'utf-8' })
+
+  if (is_option_set('l')) {
+    data.split('\n').find(line => {
+      const does_line_match_pattern = does_line_matche_pattern(line, config.pattern)
+      
+      return is_option_set('v') ? !does_line_match_pattern : does_line_match_pattern
+    }) && console.log(file)
+  } else {
+    data.split('\n').forEach((line, index) => {
+      let result = '';
+      let should_output_line = does_line_matche_pattern(line, config.pattern);
+  
+      if (is_option_set('v')) {
+        should_output_line = !should_output_line;
+      }
+     
+      if (should_output_line) {
+        if (config.files.length > 1) {
+          result += `${file}:`
+        }
+
+        if (is_option_set('n')) {
+          result += `${index+1}:`;
+        }
+  
+        result += line;
+  
+        console.log(result)
+      }
+    })
+  }
+});

--- a/exercises/grep/example.js
+++ b/exercises/grep/example.js
@@ -1,96 +1,95 @@
 #!/usr/bin/env node
-const fs = require('fs')
+const fs = require("fs");
 
 // Helpers
 const availables_options = [
-  'n', // add line numbers
-  'l', // print file names where pattern is found
-  'i', // ignore case
-  'v', // reverse files results
-  'x'  // match entire line 
+  "n", // add line numbers
+  "l", // print file names where pattern is found
+  "i", // ignore case
+  "v", // reverse files results
+  "x" // match entire line
 ];
 
 const does_line_matche_pattern = (line, pattern) => {
   let left = line;
   let right = pattern;
 
-  if (is_option_set('i')) {
-    left = line.toLowerCase()
-    right = pattern.toLowerCase()
+  if (is_option_set("i")) {
+    left = line.toLowerCase();
+    right = pattern.toLowerCase();
   }
 
-  if (is_option_set('x')) {
+  if (is_option_set("x")) {
     return left === right;
   }
 
   return left.match(right) !== null;
-
-}
+};
 
 const getConfigFromArgs = () => {
   const config = {
-    'pattern': '',
-    'options': [],
-    'files': []
+    pattern: "",
+    options: [],
+    files: []
   };
 
   let has_pattern_been_found = false;
 
   process.argv.slice(2).forEach(val => {
     if (has_pattern_been_found) {
-      config.files.push(val)
-    } else if (val.indexOf('-') !== -1) {
-      const option = val.replace('-', '')
+      config.files.push(val);
+    } else if (val.indexOf("-") !== -1) {
+      const option = val.replace("-", "");
 
       if (!availables_options.includes(option)) {
-        throw new Error(`Unknown option ${option}`)
+        throw new Error(`Unknown option ${option}`);
       }
 
-      config.options.push(option)
+      config.options.push(option);
     } else {
-      has_pattern_been_found = true
-      config.pattern = val
+      has_pattern_been_found = true;
+      config.pattern = val;
     }
-  })
+  });
 
   return config;
-}
+};
 
-const config = getConfigFromArgs()
+const config = getConfigFromArgs();
 const is_option_set = option => config.options.includes(option);
 
 // Actual script
 config.files.forEach(file => {
-  const data = fs.readFileSync(file, { encoding: 'utf-8' })
+  const data = fs.readFileSync(file, { encoding: "utf-8" });
 
-  if (is_option_set('l')) {
-    data.split('\n').find(line => {
-      const does_line_match_pattern = does_line_matche_pattern(line, config.pattern)
-      
-      return is_option_set('v') ? !does_line_match_pattern : does_line_match_pattern
-    }) && console.log(file)
+  if (is_option_set("l")) {
+    data.split("\n").find(line => {
+      const does_line_match_pattern = does_line_matche_pattern(line, config.pattern);
+
+      return is_option_set("v") ? !does_line_match_pattern : does_line_match_pattern;
+    }) && console.log(file);
   } else {
-    data.split('\n').forEach((line, index) => {
-      let result = '';
+    data.split("\n").forEach((line, index) => {
+      let result = "";
       let should_output_line = does_line_matche_pattern(line, config.pattern);
-  
-      if (is_option_set('v')) {
+
+      if (is_option_set("v")) {
         should_output_line = !should_output_line;
       }
-     
+
       if (should_output_line) {
         if (config.files.length > 1) {
-          result += `${file}:`
+          result += `${file}:`;
         }
 
-        if (is_option_set('n')) {
-          result += `${index+1}:`;
+        if (is_option_set("n")) {
+          result += `${index + 1}:`;
         }
-  
+
         result += line;
-  
-        console.log(result)
+
+        console.log(result);
       }
-    })
+    });
   }
 });

--- a/exercises/grep/grep.js
+++ b/exercises/grep/grep.js
@@ -6,7 +6,7 @@
 //
 // node grep.js args
 //
-// Instead of "grep args".
+// Instead of "./grep.js args".
 // 
 // Read more about shebangs here: https://en.wikipedia.org/wiki/Shebang_(Unix)
 // 

--- a/exercises/grep/grep.js
+++ b/exercises/grep/grep.js
@@ -1,0 +1,4 @@
+//
+// This is only a SKELETON file for the 'Grep' exercise. It's been provided as a
+// convenience to get you started writing code faster.
+//

--- a/exercises/grep/grep.js
+++ b/exercises/grep/grep.js
@@ -1,4 +1,15 @@
+#!/usr/bin/env node
+
+// The above line is a shebang. On Unix-like operating systems, or environments, this will allow the script to be
+// run by node, and thus turn this JavaScript file into an executable. If you don't have a Unix-like operating
+// system or environment, for example Windows without WSL, you can use 
 //
+// node grep.js args
+//
+// Instead of "grep args".
+// 
+// Read more about shebangs here: https://en.wikipedia.org/wiki/Shebang_(Unix)
+// 
 // This is only a SKELETON file for the 'Grep' exercise. It's been provided as a
 // convenience to get you started writing code faster.
 //

--- a/exercises/grep/grep.spec.js
+++ b/exercises/grep/grep.spec.js
@@ -20,9 +20,9 @@ const spawn_grep = config => {
 
     if (stderr) {
       reject(stderr);
+    } else {
+      resolve(stdout);
     }
-
-    resolve(stdout);
   });
 };
 
@@ -116,11 +116,9 @@ describe("grep exercise", () => {
           files: ["midsummer-night.txt"]
         })
       ).resolves.toBe(
-        formatStringTemplate(
-          `3:Nor how it may concern my modesty,
-            5:But I beseech your grace that I may know
-            6:The worst that may befall me in this case,`
-        )
+        formatStringTemplate(`3:Nor how it may concern my modesty,
+        5:But I beseech your grace that I may know
+        6:The worst that may befall me in this case,`)
       );
     });
 

--- a/exercises/grep/grep.spec.js
+++ b/exercises/grep/grep.spec.js
@@ -1,233 +1,371 @@
-const { spawnSync } = require('child_process')
-const path = require('path')
+const { spawnSync } = require("child_process");
+const path = require("path");
 
-const BASE_DIR = './tmp_exercises';
+const BASE_DIR = path.resolve(__dirname);
 
-const resolveDataFile = file => path.resolve(BASE_DIR, 'data', file);
+const resolveDataFile = file => path.resolve(BASE_DIR, "data", file);
 
 const spawn_grep = config => {
   const args = [
-    path.resolve(BASE_DIR, './grep.js'),
+    path.resolve(BASE_DIR, "grep.js"),
     ...config.flags,
     config.pattern,
-    ...config.files.map(file => path.resolve(BASE_DIR, 'data', file))
-  ]
+    ...config.files.map(file => path.resolve(BASE_DIR, "data", file))
+  ];
 
   return new Promise((resolve, reject) => {
-    const child = spawnSync('node', args, { stdio: 'pipe' })
-    const stderr = child.stderr.toString().trim()
-    const stdout = child.stdout.toString().trim()
+    const child = spawnSync("node", args, { stdio: "pipe" });
+    const stderr = child.stderr.toString().trim();
+    const stdout = child.stdout.toString().trim();
 
     if (stderr) {
-      reject(stderr)
+      reject(stderr);
     }
 
-    resolve(stdout)
+    resolve(stdout);
   });
-}
+};
 
-describe('grep exercise', () => {
-  describe('Test grepping a single file', () => {
-    it('One file, one match, no flags', () => {
-      return expect(spawn_grep({
-        pattern: "Agamemnon",
-        flags: [],
-        files: ["iliad.txt"]
-      })).resolves.toBe("Of Atreus, Agamemnon, King of men.")
-    })
+const formatStringTemplate = stringTemplate =>
+  stringTemplate
+    .split("\n")
+    .map(sentence => sentence.trim())
+    .join("\n");
 
-    it('One file, one match, print line numbers flag', () => {
-      return expect(spawn_grep({
-        pattern: "Forbidden",
-        flags: ["-n"],
-        files: ["paradise-lost.txt"]
-      })).resolves.toBe("2:Of that Forbidden Tree, whose mortal tast")
-    })
+describe("grep exercise", () => {
+  describe("Test grepping a single file", () => {
+    it("One file, one match, no flags", () => {
+      return expect(
+        spawn_grep({
+          pattern: "Agamemnon",
+          flags: [],
+          files: ["iliad.txt"]
+        })
+      ).resolves.toBe("Of Atreus, Agamemnon, King of men.");
+    });
 
-    it('One file, one match, case-insensitive flag', () => {
-      return expect(spawn_grep({
-        pattern: "FORBIDDEN",
-        flags: ["-i"],
-        files: ["paradise-lost.txt"]
-      })).resolves.toBe("Of that Forbidden Tree, whose mortal tast")
-    })
+    it("One file, one match, print line numbers flag", () => {
+      return expect(
+        spawn_grep({
+          pattern: "Forbidden",
+          flags: ["-n"],
+          files: ["paradise-lost.txt"]
+        })
+      ).resolves.toBe("2:Of that Forbidden Tree, whose mortal tast");
+    });
 
-    it('One file, one match, print file names flag', () => {
-      return expect(spawn_grep({
-        pattern: "Forbidden",
-        flags: ["-l"],
-        files: ["paradise-lost.txt"]
-      })).resolves.toBe(resolveDataFile("paradise-lost.txt"))
-    })
+    it("One file, one match, case-insensitive flag", () => {
+      return expect(
+        spawn_grep({
+          pattern: "FORBIDDEN",
+          flags: ["-i"],
+          files: ["paradise-lost.txt"]
+        })
+      ).resolves.toBe("Of that Forbidden Tree, whose mortal tast");
+    });
 
-    it('One file, one match, match entire lines flag', () => {
-      return expect(spawn_grep({
-        pattern: "With loss of Eden, till one greater Man",
-        flags: ["-x"],
-        files: ["paradise-lost.txt"]
-      })).resolves.toBe("With loss of Eden, till one greater Man")
-    })
+    it("One file, one match, print file names flag", () => {
+      return expect(
+        spawn_grep({
+          pattern: "Forbidden",
+          flags: ["-l"],
+          files: ["paradise-lost.txt"]
+        })
+      ).resolves.toBe(resolveDataFile("paradise-lost.txt"));
+    });
 
-    it('One file, one match, multiple flags', () => {
-      return expect(spawn_grep({
-        pattern: "OF ATREUS, Agamemnon, KIng of MEN.",
-        flags: ["-n", "-i", "-x"],
-        files: ["iliad.txt"]
-      })).resolves.toBe("9:Of Atreus, Agamemnon, King of men.")
-    })
+    it("One file, one match, match entire lines flag", () => {
+      return expect(
+        spawn_grep({
+          pattern: "With loss of Eden, till one greater Man",
+          flags: ["-x"],
+          files: ["paradise-lost.txt"]
+        })
+      ).resolves.toBe("With loss of Eden, till one greater Man");
+    });
 
-    it('One file, several matches, no flags', () => {
-      return expect(spawn_grep({
-        pattern: "may",
-        flags: [],
-        files: ["midsummer-night.txt"]
-      })).resolves.toBe(`Nor how it may concern my modesty,\nBut I beseech your grace that I may know\nThe worst that may befall me in this case,`)
-    })
+    it("One file, one match, multiple flags", () => {
+      return expect(
+        spawn_grep({
+          pattern: "OF ATREUS, Agamemnon, KIng of MEN.",
+          flags: ["-n", "-i", "-x"],
+          files: ["iliad.txt"]
+        })
+      ).resolves.toBe("9:Of Atreus, Agamemnon, King of men.");
+    });
 
-    it('One file, several matches, print line numbers flag', () => {
-      return expect(spawn_grep({
-        pattern: "may",
-        flags: ["-n"],
-        files: ["midsummer-night.txt"]
-      })).resolves.toBe(`3:Nor how it may concern my modesty,\n5:But I beseech your grace that I may know\n6:The worst that may befall me in this case,`)
-    })
+    it("One file, several matches, no flags", () => {
+      return expect(
+        spawn_grep({
+          pattern: "may",
+          flags: [],
+          files: ["midsummer-night.txt"]
+        })
+      ).resolves.toBe(
+        formatStringTemplate(`Nor how it may concern my modesty,
+        But I beseech your grace that I may know
+        The worst that may befall me in this case,`)
+      );
+    });
 
-    it('One file, several matches, match entire lines flag', () => {
-      return expect(spawn_grep({
-        pattern: "may",
-        flags: ["-x"],
-        files: ["midsummer-night.txt"]
-      })).resolves.toBe('')
-    })
+    it("One file, several matches, print line numbers flag", () => {
+      return expect(
+        spawn_grep({
+          pattern: "may",
+          flags: ["-n"],
+          files: ["midsummer-night.txt"]
+        })
+      ).resolves.toBe(
+        formatStringTemplate(
+          `3:Nor how it may concern my modesty,
+            5:But I beseech your grace that I may know
+            6:The worst that may befall me in this case,`
+        )
+      );
+    });
 
-    it('One file, several matches, case-insensitive flag', () => {
-      return expect(spawn_grep({
-        pattern: "ACHILLES",
-        flags: ["-i"],
-        files: ["iliad.txt"]
-      })).resolves.toBe(`Achilles sing, O Goddess! Peleus' son;\nThe noble Chief Achilles from the son`)
-    })
+    it("One file, several matches, match entire lines flag", () => {
+      return expect(
+        spawn_grep({
+          pattern: "may",
+          flags: ["-x"],
+          files: ["midsummer-night.txt"]
+        })
+      ).resolves.toBe("");
+    });
 
-    it('One file, several matches, inverted flag', () => {
-      return expect(spawn_grep({
-        pattern: "Of",
-        flags: ["-v"],
-        files: ["paradise-lost.txt"]
-      })).resolves.toBe(`Brought Death into the World, and all our woe,\nWith loss of Eden, till one greater Man\nRestore us, and regain the blissful Seat,\nSing Heav'nly Muse, that on the secret top\nThat Shepherd, who first taught the chosen Seed`)
-    })
+    it("One file, several matches, case-insensitive flag", () => {
+      return expect(
+        spawn_grep({
+          pattern: "ACHILLES",
+          flags: ["-i"],
+          files: ["iliad.txt"]
+        })
+      ).resolves.toBe(
+        formatStringTemplate(`Achilles sing, O Goddess! Peleus' son;
+        The noble Chief Achilles from the son`)
+      );
+    });
 
-    it('One file, no matches, various flags', () => {
-      return expect(spawn_grep({
-        pattern: "Gandalf",
-        flags: ["-n", "-l", "-x", "-i"],
-        files: ["iliad.txt"]
-      })).resolves.toBe('')
-    })
+    it("One file, several matches, inverted flag", () => {
+      return expect(
+        spawn_grep({
+          pattern: "Of",
+          flags: ["-v"],
+          files: ["paradise-lost.txt"]
+        })
+      ).resolves.toBe(
+        formatStringTemplate(`Brought Death into the World, and all our woe,
+        With loss of Eden, till one greater Man
+        Restore us, and regain the blissful Seat,
+        Sing Heav'nly Muse, that on the secret top
+        That Shepherd, who first taught the chosen Seed`)
+      );
+    });
 
-    it('One file, one match, file flag takes precedence over line flag', () => {
-      return expect(spawn_grep({
-        pattern: "ten",
-        flags: ["-n", "-l"],
-        files: ["iliad.txt"]
-      })).resolves.toBe(resolveDataFile('iliad.txt'))
-    })
+    it("One file, no matches, various flags", () => {
+      return expect(
+        spawn_grep({
+          pattern: "Gandalf",
+          flags: ["-n", "-l", "-x", "-i"],
+          files: ["iliad.txt"]
+        })
+      ).resolves.toBe("");
+    });
 
-    it('One file, several matches, inverted and match entire lines flags', () => {
-      return expect(spawn_grep({
-        pattern: "Illustrious into Ades premature,",
-        flags: ["-x", "-v"],
-        files: ["iliad.txt"]
-      })).resolves.toBe(`Achilles sing, O Goddess! Peleus' son;\nHis wrath pernicious, who ten thousand woes\nCaused to Achaia's host, sent many a soul\nAnd Heroes gave (so stood the will of Jove)\nTo dogs and to all ravening fowls a prey,\nWhen fierce dispute had separated once\nThe noble Chief Achilles from the son\nOf Atreus, Agamemnon, King of men.`)
-    })
-  })
+    it("One file, one match, file flag takes precedence over line flag", () => {
+      return expect(
+        spawn_grep({
+          pattern: "ten",
+          flags: ["-n", "-l"],
+          files: ["iliad.txt"]
+        })
+      ).resolves.toBe(resolveDataFile("iliad.txt"));
+    });
 
-  describe('Test grepping multiples files at once', () => {
-    it('Multiple files, one match, no flags', () => {
-      return expect(spawn_grep({
-        pattern: "Agamemnon",
-        flags: [],
-        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
-      })).resolves.toBe(`${resolveDataFile('iliad.txt')}:Of Atreus, Agamemnon, King of men.`)
-    })
+    it("One file, several matches, inverted and match entire lines flags", () => {
+      return expect(
+        spawn_grep({
+          pattern: "Illustrious into Ades premature,",
+          flags: ["-x", "-v"],
+          files: ["iliad.txt"]
+        })
+      ).resolves.toBe(
+        formatStringTemplate(`Achilles sing, O Goddess! Peleus' son;
+        His wrath pernicious, who ten thousand woes
+        Caused to Achaia's host, sent many a soul
+        And Heroes gave (so stood the will of Jove)
+        To dogs and to all ravening fowls a prey,
+        When fierce dispute had separated once
+        The noble Chief Achilles from the son
+        Of Atreus, Agamemnon, King of men.`)
+      );
+    });
+  });
 
-    it('Multiple files, several matches, no flags', () => {
-      return expect(spawn_grep({
-        pattern: "may",
-        flags: [],
-        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
-      })).resolves.toBe(`${resolveDataFile('midsummer-night.txt')}:Nor how it may concern my modesty,\n${resolveDataFile('midsummer-night.txt')}:But I beseech your grace that I may know\n${resolveDataFile('midsummer-night.txt')}:The worst that may befall me in this case,`)
-    })
+  describe("Test grepping multiples files at once", () => {
+    it("Multiple files, one match, no flags", () => {
+      return expect(
+        spawn_grep({
+          pattern: "Agamemnon",
+          flags: [],
+          files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+        })
+      ).resolves.toBe(`${resolveDataFile("iliad.txt")}:Of Atreus, Agamemnon, King of men.`);
+    });
 
-    it('Multiple files, several matches, print line numbers flag', () => {
-      return expect(spawn_grep({
-        pattern: "that",
-        flags: ["-n"],
-        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
-      })).resolves.toBe(`${resolveDataFile('midsummer-night.txt')}:5:But I beseech your grace that I may know\n${resolveDataFile('midsummer-night.txt')}:6:The worst that may befall me in this case,\n${resolveDataFile('paradise-lost.txt')}:2:Of that Forbidden Tree, whose mortal tast\n${resolveDataFile('paradise-lost.txt')}:6:Sing Heav'nly Muse, that on the secret top`)
-    })
+    it("Multiple files, several matches, no flags", () => {
+      return expect(
+        spawn_grep({
+          pattern: "may",
+          flags: [],
+          files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+        })
+      ).resolves.toBe(
+        formatStringTemplate(`${resolveDataFile("midsummer-night.txt")}:Nor how it may concern my modesty,
+        ${resolveDataFile("midsummer-night.txt")}:But I beseech your grace that I may know
+        ${resolveDataFile("midsummer-night.txt")}:The worst that may befall me in this case,`)
+      );
+    });
 
-    it('Multiple files, one match, print file names flag', () => {
-      return expect(spawn_grep({
-        pattern: "who",
-        flags: ["-l"],
-        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
-      })).resolves.toBe(`${resolveDataFile('iliad.txt')}\n${resolveDataFile('paradise-lost.txt')}`)
-    })
+    it("Multiple files, several matches, print line numbers flag", () => {
+      return expect(
+        spawn_grep({
+          pattern: "that",
+          flags: ["-n"],
+          files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+        })
+      ).resolves.toBe(
+        formatStringTemplate(`${resolveDataFile("midsummer-night.txt")}:5:But I beseech your grace that I may know
+        ${resolveDataFile("midsummer-night.txt")}:6:The worst that may befall me in this case,
+        ${resolveDataFile("paradise-lost.txt")}:2:Of that Forbidden Tree, whose mortal tast
+        ${resolveDataFile("paradise-lost.txt")}:6:Sing Heav'nly Muse, that on the secret top`)
+      );
+    });
 
-    it('Multiple files, several matches, case-insensitive flag', () => {
-      return expect(spawn_grep({
-        pattern: "TO",
-        flags: ["-i"],
-        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
-      })).resolves.toBe(`${resolveDataFile('iliad.txt')}:Caused to Achaia's host, sent many a soul\n${resolveDataFile('iliad.txt')}:Illustrious into Ades premature,\n${resolveDataFile('iliad.txt')}:And Heroes gave (so stood the will of Jove)\n${resolveDataFile('iliad.txt')}:To dogs and to all ravening fowls a prey,\n${resolveDataFile('midsummer-night.txt')}:I do entreat your grace to pardon me.\n${resolveDataFile('midsummer-night.txt')}:In such a presence here to plead my thoughts;\n${resolveDataFile('midsummer-night.txt')}:If I refuse to wed Demetrius.\n${resolveDataFile('paradise-lost.txt')}:Brought Death into the World, and all our woe,\n${resolveDataFile('paradise-lost.txt')}:Restore us, and regain the blissful Seat,\n${resolveDataFile('paradise-lost.txt')}:Sing Heav'nly Muse, that on the secret top`)
-    })
+    it("Multiple files, one match, print file names flag", () => {
+      return expect(
+        spawn_grep({
+          pattern: "who",
+          flags: ["-l"],
+          files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+        })
+      ).resolves.toBe(
+        formatStringTemplate(`${resolveDataFile("iliad.txt")}
+        ${resolveDataFile("paradise-lost.txt")}`)
+      );
+    });
 
-    it('Multiple files, several matches, inverted flag', () => {
-      return expect(spawn_grep({
-        pattern: "a",
-        flags: ["-v"],
-        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
-      })).resolves.toBe(`${resolveDataFile('iliad.txt')}:Achilles sing, O Goddess! Peleus' son;\n${resolveDataFile('iliad.txt')}:The noble Chief Achilles from the son\n${resolveDataFile('midsummer-night.txt')}:If I refuse to wed Demetrius.`)
-    })
+    it("Multiple files, several matches, case-insensitive flag", () => {
+      return expect(
+        spawn_grep({
+          pattern: "TO",
+          flags: ["-i"],
+          files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+        })
+      ).resolves.toBe(
+        formatStringTemplate(`${resolveDataFile("iliad.txt")}:Caused to Achaia's host, sent many a soul
+        ${resolveDataFile("iliad.txt")}:Illustrious into Ades premature,
+        ${resolveDataFile("iliad.txt")}:And Heroes gave (so stood the will of Jove)
+        ${resolveDataFile("iliad.txt")}:To dogs and to all ravening fowls a prey,
+        ${resolveDataFile("midsummer-night.txt")}:I do entreat your grace to pardon me.
+        ${resolveDataFile("midsummer-night.txt")}:In such a presence here to plead my thoughts;
+        ${resolveDataFile("midsummer-night.txt")}:If I refuse to wed Demetrius.
+        ${resolveDataFile("paradise-lost.txt")}:Brought Death into the World, and all our woe,
+        ${resolveDataFile("paradise-lost.txt")}:Restore us, and regain the blissful Seat,
+        ${resolveDataFile("paradise-lost.txt")}:Sing Heav'nly Muse, that on the secret top`)
+      );
+    });
 
-    it('Multiple files, one match, match entire lines flag', () => {
-      return expect(spawn_grep({
-        pattern: "But I beseech your grace that I may know",
-        flags: ["-x"],
-        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
-      })).resolves.toBe(`${resolveDataFile('midsummer-night.txt:But I beseech your grace that I may know')}`)
-    })
+    it("Multiple files, several matches, inverted flag", () => {
+      return expect(
+        spawn_grep({
+          pattern: "a",
+          flags: ["-v"],
+          files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+        })
+      ).resolves.toBe(
+        formatStringTemplate(`${resolveDataFile("iliad.txt")}:Achilles sing, O Goddess! Peleus' son;
+        ${resolveDataFile("iliad.txt")}:The noble Chief Achilles from the son
+        ${resolveDataFile("midsummer-night.txt")}:If I refuse to wed Demetrius.`)
+      );
+    });
 
-    it('Multiple files, one match, multiple flags', () => {
-      return expect(spawn_grep({
-        pattern: "WITH LOSS OF EDEN, TILL ONE GREATER MAN",
-        flags: ["-n", "-i", "-x"],
-        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
-      })).resolves.toBe(`${resolveDataFile('paradise-lost.txt')}:4:With loss of Eden, till one greater Man`)
-    })
+    it("Multiple files, one match, match entire lines flag", () => {
+      return expect(
+        spawn_grep({
+          pattern: "But I beseech your grace that I may know",
+          flags: ["-x"],
+          files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+        })
+      ).resolves.toBe(`${resolveDataFile("midsummer-night.txt:But I beseech your grace that I may know")}`);
+    });
 
-    it('Multiple files, no matches, various flags', () => {
-      return expect(spawn_grep({
-        pattern: "Frodo",
-        flags: ["-n", "-l", "-x", "-i"],
-        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
-      })).resolves.toBe('')
-    })
+    it("Multiple files, one match, multiple flags", () => {
+      return expect(
+        spawn_grep({
+          pattern: "WITH LOSS OF EDEN, TILL ONE GREATER MAN",
+          flags: ["-n", "-i", "-x"],
+          files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+        })
+      ).resolves.toBe(`${resolveDataFile("paradise-lost.txt")}:4:With loss of Eden, till one greater Man`);
+    });
 
-    it('Multiple files, several matches, file flag takes precedence over line number flag', () => {
-      return expect(spawn_grep({
-        pattern: "who",
-        flags: ["-n", "-l"],
-        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
-      })).resolves.toBe(`${resolveDataFile('iliad.txt')}\n${resolveDataFile('paradise-lost.txt')}`)
-    })
+    it("Multiple files, no matches, various flags", () => {
+      return expect(
+        spawn_grep({
+          pattern: "Frodo",
+          flags: ["-n", "-l", "-x", "-i"],
+          files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+        })
+      ).resolves.toBe("");
+    });
 
-    it('Multiple files, several matches, inverted and match entire lines flags', () => {
-      return expect(spawn_grep({
-        pattern: "Illustrious into Ades premature,",
-        flags: ["-x", "-v"],
-        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
-      })).resolves.toBe(`${resolveDataFile('iliad.txt')}:Achilles sing, O Goddess! Peleus' son;\n${resolveDataFile('iliad.txt')}:His wrath pernicious, who ten thousand woes\n${resolveDataFile('iliad.txt')}:Caused to Achaia's host, sent many a soul\n${resolveDataFile('iliad.txt')}:And Heroes gave (so stood the will of Jove)\n${resolveDataFile('iliad.txt')}:To dogs and to all ravening fowls a prey,\n${resolveDataFile('iliad.txt')}:When fierce dispute had separated once\n${resolveDataFile('iliad.txt')}:The noble Chief Achilles from the son\n${resolveDataFile('iliad.txt')}:Of Atreus, Agamemnon, King of men.\n${resolveDataFile('midsummer-night.txt')}:I do entreat your grace to pardon me.\n${resolveDataFile('midsummer-night.txt')}:I know not by what power I am made bold,\n${resolveDataFile('midsummer-night.txt')}:Nor how it may concern my modesty,\n${resolveDataFile('midsummer-night.txt')}:In such a presence here to plead my thoughts;\n${resolveDataFile('midsummer-night.txt')}:But I beseech your grace that I may know\n${resolveDataFile('midsummer-night.txt')}:The worst that may befall me in this case,\n${resolveDataFile('midsummer-night.txt')}:If I refuse to wed Demetrius.\n${resolveDataFile('paradise-lost.txt')}:Of Mans First Disobedience, and the Fruit\n${resolveDataFile('paradise-lost.txt')}:Of that Forbidden Tree, whose mortal tast\n${resolveDataFile('paradise-lost.txt')}:Brought Death into the World, and all our woe,\n${resolveDataFile('paradise-lost.txt')}:With loss of Eden, till one greater Man\n${resolveDataFile('paradise-lost.txt')}:Restore us, and regain the blissful Seat,\n${resolveDataFile('paradise-lost.txt')}:Sing Heav'nly Muse, that on the secret top\n${resolveDataFile('paradise-lost.txt')}:Of Oreb, or of Sinai, didst inspire\n${resolveDataFile('paradise-lost.txt')}:That Shepherd, who first taught the chosen Seed`)
-    })
-  })
-})
+    it("Multiple files, several matches, file flag takes precedence over line number flag", () => {
+      return expect(
+        spawn_grep({
+          pattern: "who",
+          flags: ["-n", "-l"],
+          files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+        })
+      ).resolves.toBe(
+        formatStringTemplate(`${resolveDataFile("iliad.txt")}
+        ${resolveDataFile("paradise-lost.txt")}`)
+      );
+    });
+
+    it("Multiple files, several matches, inverted and match entire lines flags", () => {
+      return expect(
+        spawn_grep({
+          pattern: "Illustrious into Ades premature,",
+          flags: ["-x", "-v"],
+          files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+        })
+      ).resolves.toBe(
+        formatStringTemplate(`${resolveDataFile("iliad.txt")}:Achilles sing, O Goddess! Peleus' son;
+        ${resolveDataFile("iliad.txt")}:His wrath pernicious, who ten thousand woes
+        ${resolveDataFile("iliad.txt")}:Caused to Achaia's host, sent many a soul
+        ${resolveDataFile("iliad.txt")}:And Heroes gave (so stood the will of Jove)
+        ${resolveDataFile("iliad.txt")}:To dogs and to all ravening fowls a prey,
+        ${resolveDataFile("iliad.txt")}:When fierce dispute had separated once
+        ${resolveDataFile("iliad.txt")}:The noble Chief Achilles from the son
+        ${resolveDataFile("iliad.txt")}:Of Atreus, Agamemnon, King of men.
+        ${resolveDataFile("midsummer-night.txt")}:I do entreat your grace to pardon me.
+        ${resolveDataFile("midsummer-night.txt")}:I know not by what power I am made bold,
+        ${resolveDataFile("midsummer-night.txt")}:Nor how it may concern my modesty,
+        ${resolveDataFile("midsummer-night.txt")}:In such a presence here to plead my thoughts;
+        ${resolveDataFile("midsummer-night.txt")}:But I beseech your grace that I may know
+        ${resolveDataFile("midsummer-night.txt")}:The worst that may befall me in this case,
+        ${resolveDataFile("midsummer-night.txt")}:If I refuse to wed Demetrius.
+        ${resolveDataFile("paradise-lost.txt")}:Of Mans First Disobedience, and the Fruit
+        ${resolveDataFile("paradise-lost.txt")}:Of that Forbidden Tree, whose mortal tast
+        ${resolveDataFile("paradise-lost.txt")}:Brought Death into the World, and all our woe,
+        ${resolveDataFile("paradise-lost.txt")}:With loss of Eden, till one greater Man
+        ${resolveDataFile("paradise-lost.txt")}:Restore us, and regain the blissful Seat,
+        ${resolveDataFile("paradise-lost.txt")}:Sing Heav'nly Muse, that on the secret top
+        ${resolveDataFile("paradise-lost.txt")}:Of Oreb, or of Sinai, didst inspire
+        ${resolveDataFile("paradise-lost.txt")}:That Shepherd, who first taught the chosen Seed`)
+      );
+    });
+  });
+});

--- a/exercises/grep/grep.spec.js
+++ b/exercises/grep/grep.spec.js
@@ -1,0 +1,233 @@
+const { spawnSync } = require('child_process')
+const path = require('path')
+
+const BASE_DIR = './tmp_exercises';
+
+const resolveDataFile = file => path.resolve(BASE_DIR, 'data', file);
+
+const spawn_grep = config => {
+  const args = [
+    path.resolve(BASE_DIR, './grep.js'),
+    ...config.flags,
+    config.pattern,
+    ...config.files.map(file => path.resolve(BASE_DIR, 'data', file))
+  ]
+
+  return new Promise((resolve, reject) => {
+    const child = spawnSync('node', args, { stdio: 'pipe' })
+    const stderr = child.stderr.toString().trim()
+    const stdout = child.stdout.toString().trim()
+
+    if (stderr) {
+      reject(stderr)
+    }
+
+    resolve(stdout)
+  });
+}
+
+describe('grep exercise', () => {
+  describe('Test grepping a single file', () => {
+    it('One file, one match, no flags', () => {
+      return expect(spawn_grep({
+        pattern: "Agamemnon",
+        flags: [],
+        files: ["iliad.txt"]
+      })).resolves.toBe("Of Atreus, Agamemnon, King of men.")
+    })
+
+    it('One file, one match, print line numbers flag', () => {
+      return expect(spawn_grep({
+        pattern: "Forbidden",
+        flags: ["-n"],
+        files: ["paradise-lost.txt"]
+      })).resolves.toBe("2:Of that Forbidden Tree, whose mortal tast")
+    })
+
+    it('One file, one match, case-insensitive flag', () => {
+      return expect(spawn_grep({
+        pattern: "FORBIDDEN",
+        flags: ["-i"],
+        files: ["paradise-lost.txt"]
+      })).resolves.toBe("Of that Forbidden Tree, whose mortal tast")
+    })
+
+    it('One file, one match, print file names flag', () => {
+      return expect(spawn_grep({
+        pattern: "Forbidden",
+        flags: ["-l"],
+        files: ["paradise-lost.txt"]
+      })).resolves.toBe(resolveDataFile("paradise-lost.txt"))
+    })
+
+    it('One file, one match, match entire lines flag', () => {
+      return expect(spawn_grep({
+        pattern: "With loss of Eden, till one greater Man",
+        flags: ["-x"],
+        files: ["paradise-lost.txt"]
+      })).resolves.toBe("With loss of Eden, till one greater Man")
+    })
+
+    it('One file, one match, multiple flags', () => {
+      return expect(spawn_grep({
+        pattern: "OF ATREUS, Agamemnon, KIng of MEN.",
+        flags: ["-n", "-i", "-x"],
+        files: ["iliad.txt"]
+      })).resolves.toBe("9:Of Atreus, Agamemnon, King of men.")
+    })
+
+    it('One file, several matches, no flags', () => {
+      return expect(spawn_grep({
+        pattern: "may",
+        flags: [],
+        files: ["midsummer-night.txt"]
+      })).resolves.toBe(`Nor how it may concern my modesty,\nBut I beseech your grace that I may know\nThe worst that may befall me in this case,`)
+    })
+
+    it('One file, several matches, print line numbers flag', () => {
+      return expect(spawn_grep({
+        pattern: "may",
+        flags: ["-n"],
+        files: ["midsummer-night.txt"]
+      })).resolves.toBe(`3:Nor how it may concern my modesty,\n5:But I beseech your grace that I may know\n6:The worst that may befall me in this case,`)
+    })
+
+    it('One file, several matches, match entire lines flag', () => {
+      return expect(spawn_grep({
+        pattern: "may",
+        flags: ["-x"],
+        files: ["midsummer-night.txt"]
+      })).resolves.toBe('')
+    })
+
+    it('One file, several matches, case-insensitive flag', () => {
+      return expect(spawn_grep({
+        pattern: "ACHILLES",
+        flags: ["-i"],
+        files: ["iliad.txt"]
+      })).resolves.toBe(`Achilles sing, O Goddess! Peleus' son;\nThe noble Chief Achilles from the son`)
+    })
+
+    it('One file, several matches, inverted flag', () => {
+      return expect(spawn_grep({
+        pattern: "Of",
+        flags: ["-v"],
+        files: ["paradise-lost.txt"]
+      })).resolves.toBe(`Brought Death into the World, and all our woe,\nWith loss of Eden, till one greater Man\nRestore us, and regain the blissful Seat,\nSing Heav'nly Muse, that on the secret top\nThat Shepherd, who first taught the chosen Seed`)
+    })
+
+    it('One file, no matches, various flags', () => {
+      return expect(spawn_grep({
+        pattern: "Gandalf",
+        flags: ["-n", "-l", "-x", "-i"],
+        files: ["iliad.txt"]
+      })).resolves.toBe('')
+    })
+
+    it('One file, one match, file flag takes precedence over line flag', () => {
+      return expect(spawn_grep({
+        pattern: "ten",
+        flags: ["-n", "-l"],
+        files: ["iliad.txt"]
+      })).resolves.toBe(resolveDataFile('iliad.txt'))
+    })
+
+    it('One file, several matches, inverted and match entire lines flags', () => {
+      return expect(spawn_grep({
+        pattern: "Illustrious into Ades premature,",
+        flags: ["-x", "-v"],
+        files: ["iliad.txt"]
+      })).resolves.toBe(`Achilles sing, O Goddess! Peleus' son;\nHis wrath pernicious, who ten thousand woes\nCaused to Achaia's host, sent many a soul\nAnd Heroes gave (so stood the will of Jove)\nTo dogs and to all ravening fowls a prey,\nWhen fierce dispute had separated once\nThe noble Chief Achilles from the son\nOf Atreus, Agamemnon, King of men.`)
+    })
+  })
+
+  describe('Test grepping multiples files at once', () => {
+    it('Multiple files, one match, no flags', () => {
+      return expect(spawn_grep({
+        pattern: "Agamemnon",
+        flags: [],
+        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+      })).resolves.toBe(`${resolveDataFile('iliad.txt')}:Of Atreus, Agamemnon, King of men.`)
+    })
+
+    it('Multiple files, several matches, no flags', () => {
+      return expect(spawn_grep({
+        pattern: "may",
+        flags: [],
+        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+      })).resolves.toBe(`${resolveDataFile('midsummer-night.txt')}:Nor how it may concern my modesty,\n${resolveDataFile('midsummer-night.txt')}:But I beseech your grace that I may know\n${resolveDataFile('midsummer-night.txt')}:The worst that may befall me in this case,`)
+    })
+
+    it('Multiple files, several matches, print line numbers flag', () => {
+      return expect(spawn_grep({
+        pattern: "that",
+        flags: ["-n"],
+        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+      })).resolves.toBe(`${resolveDataFile('midsummer-night.txt')}:5:But I beseech your grace that I may know\n${resolveDataFile('midsummer-night.txt')}:6:The worst that may befall me in this case,\n${resolveDataFile('paradise-lost.txt')}:2:Of that Forbidden Tree, whose mortal tast\n${resolveDataFile('paradise-lost.txt')}:6:Sing Heav'nly Muse, that on the secret top`)
+    })
+
+    it('Multiple files, one match, print file names flag', () => {
+      return expect(spawn_grep({
+        pattern: "who",
+        flags: ["-l"],
+        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+      })).resolves.toBe(`${resolveDataFile('iliad.txt')}\n${resolveDataFile('paradise-lost.txt')}`)
+    })
+
+    it('Multiple files, several matches, case-insensitive flag', () => {
+      return expect(spawn_grep({
+        pattern: "TO",
+        flags: ["-i"],
+        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+      })).resolves.toBe(`${resolveDataFile('iliad.txt')}:Caused to Achaia's host, sent many a soul\n${resolveDataFile('iliad.txt')}:Illustrious into Ades premature,\n${resolveDataFile('iliad.txt')}:And Heroes gave (so stood the will of Jove)\n${resolveDataFile('iliad.txt')}:To dogs and to all ravening fowls a prey,\n${resolveDataFile('midsummer-night.txt')}:I do entreat your grace to pardon me.\n${resolveDataFile('midsummer-night.txt')}:In such a presence here to plead my thoughts;\n${resolveDataFile('midsummer-night.txt')}:If I refuse to wed Demetrius.\n${resolveDataFile('paradise-lost.txt')}:Brought Death into the World, and all our woe,\n${resolveDataFile('paradise-lost.txt')}:Restore us, and regain the blissful Seat,\n${resolveDataFile('paradise-lost.txt')}:Sing Heav'nly Muse, that on the secret top`)
+    })
+
+    it('Multiple files, several matches, inverted flag', () => {
+      return expect(spawn_grep({
+        pattern: "a",
+        flags: ["-v"],
+        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+      })).resolves.toBe(`${resolveDataFile('iliad.txt')}:Achilles sing, O Goddess! Peleus' son;\n${resolveDataFile('iliad.txt')}:The noble Chief Achilles from the son\n${resolveDataFile('midsummer-night.txt')}:If I refuse to wed Demetrius.`)
+    })
+
+    it('Multiple files, one match, match entire lines flag', () => {
+      return expect(spawn_grep({
+        pattern: "But I beseech your grace that I may know",
+        flags: ["-x"],
+        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+      })).resolves.toBe(`${resolveDataFile('midsummer-night.txt:But I beseech your grace that I may know')}`)
+    })
+
+    it('Multiple files, one match, multiple flags', () => {
+      return expect(spawn_grep({
+        pattern: "WITH LOSS OF EDEN, TILL ONE GREATER MAN",
+        flags: ["-n", "-i", "-x"],
+        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+      })).resolves.toBe(`${resolveDataFile('paradise-lost.txt')}:4:With loss of Eden, till one greater Man`)
+    })
+
+    it('Multiple files, no matches, various flags', () => {
+      return expect(spawn_grep({
+        pattern: "Frodo",
+        flags: ["-n", "-l", "-x", "-i"],
+        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+      })).resolves.toBe('')
+    })
+
+    it('Multiple files, several matches, file flag takes precedence over line number flag', () => {
+      return expect(spawn_grep({
+        pattern: "who",
+        flags: ["-n", "-l"],
+        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+      })).resolves.toBe(`${resolveDataFile('iliad.txt')}\n${resolveDataFile('paradise-lost.txt')}`)
+    })
+
+    it('Multiple files, several matches, inverted and match entire lines flags', () => {
+      return expect(spawn_grep({
+        pattern: "Illustrious into Ades premature,",
+        flags: ["-x", "-v"],
+        files: ["iliad.txt", "midsummer-night.txt", "paradise-lost.txt"]
+      })).resolves.toBe(`${resolveDataFile('iliad.txt')}:Achilles sing, O Goddess! Peleus' son;\n${resolveDataFile('iliad.txt')}:His wrath pernicious, who ten thousand woes\n${resolveDataFile('iliad.txt')}:Caused to Achaia's host, sent many a soul\n${resolveDataFile('iliad.txt')}:And Heroes gave (so stood the will of Jove)\n${resolveDataFile('iliad.txt')}:To dogs and to all ravening fowls a prey,\n${resolveDataFile('iliad.txt')}:When fierce dispute had separated once\n${resolveDataFile('iliad.txt')}:The noble Chief Achilles from the son\n${resolveDataFile('iliad.txt')}:Of Atreus, Agamemnon, King of men.\n${resolveDataFile('midsummer-night.txt')}:I do entreat your grace to pardon me.\n${resolveDataFile('midsummer-night.txt')}:I know not by what power I am made bold,\n${resolveDataFile('midsummer-night.txt')}:Nor how it may concern my modesty,\n${resolveDataFile('midsummer-night.txt')}:In such a presence here to plead my thoughts;\n${resolveDataFile('midsummer-night.txt')}:But I beseech your grace that I may know\n${resolveDataFile('midsummer-night.txt')}:The worst that may befall me in this case,\n${resolveDataFile('midsummer-night.txt')}:If I refuse to wed Demetrius.\n${resolveDataFile('paradise-lost.txt')}:Of Mans First Disobedience, and the Fruit\n${resolveDataFile('paradise-lost.txt')}:Of that Forbidden Tree, whose mortal tast\n${resolveDataFile('paradise-lost.txt')}:Brought Death into the World, and all our woe,\n${resolveDataFile('paradise-lost.txt')}:With loss of Eden, till one greater Man\n${resolveDataFile('paradise-lost.txt')}:Restore us, and regain the blissful Seat,\n${resolveDataFile('paradise-lost.txt')}:Sing Heav'nly Muse, that on the secret top\n${resolveDataFile('paradise-lost.txt')}:Of Oreb, or of Sinai, didst inspire\n${resolveDataFile('paradise-lost.txt')}:That Shepherd, who first taught the chosen Seed`)
+    })
+  })
+})

--- a/exercises/grep/package.json
+++ b/exercises/grep/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "exercism-javascript",
+  "description": "Exercism exercises in Javascript.",
+  "author": "Katrina Owen",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/exercism/javascript"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.5.5",
+    "@babel/core": "^7.5.5",
+    "@babel/preset-env": "^7.5.5",
+    "@types/jest": "^24.0.16",
+    "@types/node": "^12.6.8",
+    "babel-eslint": "^10.0.2",
+    "babel-jest": "^24.8.0",
+    "eslint": "^6.1.0",
+    "eslint-plugin-import": "^2.18.2",
+    "jest": "^24.8.0"
+  },
+  "jest": {
+    "modulePathIgnorePatterns": [
+      "package.json"
+    ]
+  },
+  "scripts": {
+    "test": "jest --no-cache ./*",
+    "watch": "jest --no-cache --watch ./*",
+    "lint": "eslint .",
+    "lint-test": "eslint . && jest --no-cache ./* "
+  },
+  "license": "MIT",
+  "dependencies": {}
+}

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -75,6 +75,13 @@ function prepare(assignment) {
   if(shell.test('-d', libDir)) {
     shell.cp(libDir + '/*.js', 'tmp_exercises/lib');
   }
+
+  shell.mkdir('-p', 'tmp_exercises/data');
+  const dataDir = ['exercises', assignment, 'data'].join('/');
+
+  if(shell.test('-d', dataDir)) {
+    shell.cp([dataDir, '*'].join('/'), 'tmp_exercises/data');
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes #737 .

I was wondering about the fact that this exercise is a CLI.

Unless I missed something, it's not possible to test a file that just executes a set of instructions.

I was thinking about exporting a function that takes the pattern, the files and options as arguments like that :

```js
export default (pattern, files, options =  {}) => {}
```
Is the user supposed to use the filesystem or should I provide him the data in the files in some way ?