### PR TITLE
fix lint file; lint command was broken

### DIFF
--- a/scripts/lint
+++ b/scripts/lint
@@ -14,4 +14,11 @@ const infoStr =
     assignment ? '\nRunning lint for ' + assignment + '...':
     '\nRunning lint for all exercises...';
 const failureStr = 'Lint check failed!';
+
+// Copies the necessary files
+shell.env['PREPARE'] = true
+
+// Cleans up after
+shell.env['CLEANUP'] = true
+
 helpers.prepareAndRun('npx eslint tmp_exercises', infoStr, failureStr);


### PR DESCRIPTION
I noticed that the lint command `npx @babel/node scripts/test` wasn't working. I copied a fix from the test script, as helpers.js relies on the same variables for both lint and test.