### PR TITLE
use plain function for flatten-array exercise (#776)

### DIFF
--- a/exercises/flatten-array/example.js
+++ b/exercises/flatten-array/example.js
@@ -1,9 +1,7 @@
-export class Flattener {
-  flatten(arr) {
-    return arr
-      .reduce((acc, el) => (Array.isArray(el)
-        ? acc.concat(this.flatten(el))
-        : acc.concat(el)), [])
-      .filter(el => el !== null && el !== undefined);
-  }
+export const flatten = (arr) => {
+  return arr
+    .reduce((acc, el) => (Array.isArray(el)
+      ? acc.concat(flatten(el))
+      : acc.concat(el)), [])
+    .filter(el => el !== null && el !== undefined);
 }

--- a/exercises/flatten-array/flatten-array.js
+++ b/exercises/flatten-array/flatten-array.js
@@ -3,8 +3,6 @@
 // convenience to get you started writing code faster.
 //
 
-export class Flattener {
-  flatten() {
-    throw new Error("Remove this statement and implement this function");
-  }
+export const flatten = () => {
+  throw new Error("Remove this statement and implement this function");
 }

--- a/exercises/flatten-array/flatten-array.spec.js
+++ b/exercises/flatten-array/flatten-array.spec.js
@@ -1,46 +1,44 @@
-import { Flattener } from './flatten-array.js';
+import { flatten } from './flatten-array.js';
 
 describe('FlattenArray', () => {
-  const flattener = new Flattener();
   test('flattens a nested list', () => {
-    expect(flattener.flatten([[]])).toEqual([]);
+    expect(flatten([[]])).toEqual([]);
   });
 
   xtest('undefined values are omitted from the final result', () => {
-    expect(flattener.flatten([1, 2, undefined])).toEqual([1, 2]);
+    expect(flatten([1, 2, undefined])).toEqual([1, 2]);
   });
 
   xtest('null values are omitted from the final result', () => {
-    expect(flattener.flatten([1, 2, null])).toEqual([1, 2]);
+    expect(flatten([1, 2, null])).toEqual([1, 2]);
   });
 
   xtest('flattens a 2 level nested list', () => {
-    expect(flattener.flatten([1, [2, 3, 4], 5])).toEqual([1, 2, 3, 4, 5]);
+    expect(flatten([1, [2, 3, 4], 5])).toEqual([1, 2, 3, 4, 5]);
   });
 
   xtest('flattens a  3 level nested list', () => {
-    expect(flattener.flatten([1, [2, 3, 4], 5, [6, [7, 8]]]))
+    expect(flatten([1, [2, 3, 4], 5, [6, [7, 8]]]))
       .toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
   });
 
   xtest('flattens a 5 level nested list', () => {
-    expect(flattener.flatten([0, 2, [[2, 3], 8, 100, 4, [[[50]]]], -2]))
+    expect(flatten([0, 2, [[2, 3], 8, 100, 4, [[[50]]]], -2]))
       .toEqual([0, 2, 2, 3, 8, 100, 4, 50, -2]);
   });
 
   xtest('flattens a 6 level nested list', () => {
-    expect(flattener.flatten([1, [2, [[3]], [4, [[5]]], 6, 7], 8]))
+    expect(flatten([1, [2, [[3]], [4, [[5]]], 6, 7], 8]))
       .toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
   });
 
   xtest('flattens a 6 level nested list with null values', () => {
-    expect(flattener.flatten([0, 2, [[2, 3], 8, [[100]], null, [[null]]], -2]))
+    expect(flatten([0, 2, [[2, 3], 8, [[100]], null, [[null]]], -2]))
       .toEqual([0, 2, 2, 3, 8, 100, -2]);
   });
 
   xtest('returns an empty list if all values in nested list are null', () => {
-    expect(flattener
-      .flatten([null, [[[null]]], null, null, [[null, null], null], null]))
+    expect(flatten([null, [[[null]]], null, null, [[null, null], null], null]))
       .toEqual([]);
   });
 });


### PR DESCRIPTION
Use plain function instead of class on flatten-array exercise (closes https://github.com/exercism/javascript/issues/776)