### PR TITLE
sync word-count tests with canonical data version 1.4.0

### DIFF
--- a/exercises/word-count/example.js
+++ b/exercises/word-count/example.js
@@ -1,13 +1,18 @@
-export class Words {
-  count(input) {
-    this.counts = {};
-    this.words = input.match(/\S+/g);
-
-    this.words.forEach((word) => {
-      const lcWord = word.toLowerCase();
-      this.counts[lcWord] = Object.prototype.hasOwnProperty.call(this.counts, lcWord)
-        ? this.counts[lcWord] + 1 : 1;
+export const countWords = phrase => {
+  let map = {};
+  phrase
+    .trim()
+    .toLowerCase()
+    .split(/[ ,\n]+/g)
+    .forEach(element => {
+      element = element.replace(/[.,!:"&@$%^]|^'|'$/g, "");
+      if (element) {
+        if (Object.prototype.hasOwnProperty.call(map, element)) {
+          map[element]++;
+        } else {
+          map[element] = 1;
+        }
+      }
     });
-    return this.counts;
-  }
-}
+  return map;
+};

--- a/exercises/word-count/package.json
+++ b/exercises/word-count/package.json
@@ -1,5 +1,6 @@
 {
   "name": "exercism-javascript",
+  "version": "1.4.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/exercises/word-count/word-count.js
+++ b/exercises/word-count/word-count.js
@@ -3,8 +3,6 @@
 // convenience to get you started writing code faster.
 //
 
-export class Words {
-  count() {
-    throw new Error("Remove this statement and implement this function");
-  }
-}
+export const countWords = () => {
+  throw new Error("Remove this statement and implement this function");
+};

--- a/exercises/word-count/word-count.spec.js
+++ b/exercises/word-count/word-count.spec.js
@@ -1,73 +1,135 @@
-import { Words } from './word-count';
+import { countWords } from './word-count';
 
-describe('words()', () => {
-  const words = new Words();
+describe('countWords', () => {
 
-  test('counts one word', () => {
+  test('count one word', () => {
     const expectedCounts = { word: 1 };
-    expect(words.count('word')).toEqual(expectedCounts);
+    expect(countWords('word')).toEqual(expectedCounts);
   });
 
-  xtest('counts one of each', () => {
+  xtest('count one of each word', () => {
     const expectedCounts = { one: 1, of: 1, each: 1 };
-    expect(words.count('one of each')).toEqual(expectedCounts);
+    expect(countWords('one of each')).toEqual(expectedCounts);
   });
 
-  xtest('counts multiple occurrences', () => {
+  xtest('multiple occurrences of a word', () => {
     const expectedCounts = {
-      one: 1, fish: 4, two: 1, red: 1, blue: 1,
+      one: 1,
+      fish: 4,
+      two: 1,
+      red: 1,
+      blue: 1
     };
-    expect(words.count('one fish two fish red fish blue fish')).toEqual(expectedCounts);
+    expect(countWords('one fish two fish red fish blue fish')).toEqual(
+      expectedCounts
+    );
   });
 
-  xtest('includes punctuation', () => {
+  xtest('handles cramped lists', () => {
     const expectedCounts = {
-      car: 1, ':': 2, carpet: 1, as: 1, java: 1, 'javascript!!&@$%^&': 1,
+      one: 1,
+      two: 1,
+      three: 1
     };
-    expect(words.count('car : carpet as java : javascript!!&@$%^&')).toEqual(expectedCounts);
+    expect(countWords('one,two,three')).toEqual(expectedCounts);
   });
 
-  xtest('includes numbers', () => {
-    const expectedCounts = { testing: 2, 1: 1, 2: 1 };
-    expect(words.count('testing 1 2 testing')).toEqual(expectedCounts);
-  });
-
-  xtest('normalizes to lower case', () => {
-    const expectedCounts = { go: 3 };
-    expect(words.count('go Go GO')).toEqual(expectedCounts);
-  });
-
-  xtest('counts properly international characters', () => {
+  xtest('handles expanded lists', () => {
     const expectedCounts = {
-      '¡hola!': 1, '¿qué': 1, 'tal?': 1, 'привет!': 1,
+      one: 1,
+      two: 1,
+      three: 1
     };
-    expect(words.count('¡Hola! ¿Qué tal? Привет!')).toEqual(expectedCounts);
+    expect(countWords('one,\ntwo,\nthree')).toEqual(expectedCounts);
   });
 
-  xtest('counts multiline', () => {
-    const expectedCounts = { hello: 1, world: 1 };
-    expect(words.count('hello\nworld')).toEqual(expectedCounts);
-  });
-
-  xtest('counts tabs', () => {
-    const expectedCounts = { hello: 1, world: 1 };
-    expect(words.count('hello\tworld')).toEqual(expectedCounts);
-  });
-
-  xtest('counts multiple spaces as one', () => {
-    const expectedCounts = { hello: 1, world: 1 };
-    expect(words.count('hello  world')).toEqual(expectedCounts);
-  });
-
-  xtest('does not count leading or trailing whitespace', () => {
-    const expectedCounts = { introductory: 1, course: 1 };
-    expect(words.count('\t\tIntroductory Course      ')).toEqual(expectedCounts);
-  });
-
-  xtest('handles properties that exist on Object’s prototype', () => {
+  xtest('ignore punctuation', () => {
     const expectedCounts = {
-      reserved: 1, words: 1, like: 1, constructor: 1, and: 1, tostring: 1, 'ok?': 1,
+      car: 1,
+      carpet: 1,
+      as: 1,
+      java: 1,
+      javascript: 1
     };
-    expect(words.count('reserved words like constructor and toString ok?')).toEqual(expectedCounts);
+    expect(countWords('car: carpet as java: javascript!!&@$%^&')).toEqual(
+      expectedCounts
+    );
+  });
+
+  xtest('include numbers', () => {
+    const expectedCounts = {
+      testing: 2,
+      '1': 1,
+      '2': 1
+    };
+    expect(countWords('testing, 1, 2 testing')).toEqual(expectedCounts);
+  });
+
+  xtest('normalize case', () => {
+    const expectedCounts = {
+      go: 3,
+      stop: 2
+    };
+    expect(countWords('go Go GO Stop stop')).toEqual(expectedCounts);
+  });
+
+  xtest('with apostrophes', () => {
+    const expectedCounts = {
+      first: 1,
+      'don\'t': 2,
+      laugh: 1,
+      then: 1,
+      cry: 1
+    };
+    expect(countWords('First: don\'t laugh. Then: don\'t cry.')).toEqual(
+      expectedCounts
+    );
+  });
+
+  xtest('with quotations', () => {
+    const expectedCounts = {
+      joe: 1,
+      'can\'t': 1,
+      tell: 1,
+      between: 1,
+      large: 2,
+      and: 1
+    };
+    expect(countWords('Joe can\'t tell between \'large\' and large.')).toEqual(
+      expectedCounts
+    );
+  });
+
+  xtest('substrings from the beginning', () => {
+    const expectedCounts = {
+      joe: 1,
+      'can\'t': 1,
+      tell: 1,
+      between: 1,
+      app: 1,
+      apple: 1,
+      and: 1,
+      a: 1
+    };
+    expect(countWords('Joe can\'t tell between app, apple and a.')).toEqual(
+      expectedCounts
+    );
+  });
+
+  xtest('multiple spaces not detected as a word', () => {
+    const expectedCounts = {
+      multiple: 1,
+      whitespaces: 1
+    };
+    expect(countWords(' multiple   whitespaces')).toEqual(expectedCounts);
+  });
+
+  xtest('alternating word separators not detected as a word', () => {
+    const expectedCounts = {
+      one: 1,
+      two: 1,
+      three: 1
+    };
+    expect(countWords(',\n,one,\n ,two \n \'three\'')).toEqual(expectedCounts);
   });
 });


### PR DESCRIPTION
Updated tests, removed class structure and updated the example.

@tejasbubane I removed a test about handling properties of JavaScript Object’s prototype. Depending on the focus of the language track, having this test might be a good idea (however this test is not preset in the canonical data). What do you think about this, should we keep it?