### PR TITLE
resistor-color-duo: rename export

### DIFF
--- a/exercises/resistor-color-duo/example.js
+++ b/exercises/resistor-color-duo/example.js
@@ -7,4 +7,4 @@ const COLORS = [
 const colorCode = color => COLORS.indexOf(color)
 // resistor-color solution END
 
-export const value = ([tens, ones]) => colorCode(tens) * 10 + colorCode(ones);
+export const decodedValue = ([tens, ones]) => colorCode(tens) * 10 + colorCode(ones);

--- a/exercises/resistor-color-duo/resistor-color-duo.js
+++ b/exercises/resistor-color-duo/resistor-color-duo.js
@@ -3,6 +3,6 @@
 // convenience to get you started writing code faster.
 //
 
-export const value = () => {
+export const decodedValue = () => {
   throw new Error("Remove this statement and implement this function");
 };

--- a/exercises/resistor-color-duo/resistor-color-duo.spec.js
+++ b/exercises/resistor-color-duo/resistor-color-duo.spec.js
@@ -1,23 +1,23 @@
-import { value } from './resistor-color-duo.js';
+import { decodedValue } from './resistor-color-duo.js';
 
 describe('Resistor Colors', () => {
   test('Brown and black', () => {
-    expect(value(['brown', 'black'])).toEqual(10);
+    expect(decodedValue(['brown', 'black'])).toEqual(10);
   });
 
   xtest('Blue and grey', () => {
-    expect(value(['blue', 'grey'])).toEqual(68);
+    expect(decodedValue(['blue', 'grey'])).toEqual(68);
   });
 
   xtest('Yellow and violet', () => {
-    expect(value(['yellow', 'violet'])).toEqual(47);
+    expect(decodedValue(['yellow', 'violet'])).toEqual(47);
   });
 
   xtest('Orange and orange', () => {
-    expect(value(['orange', 'orange'])).toEqual(33);
+    expect(decodedValue(['orange', 'orange'])).toEqual(33);
   });
 
   xtest('Ignore additional colors', () => {
-    expect(value(['green', 'brown', 'orange'])).toEqual(51);
+    expect(decodedValue(['green', 'brown', 'orange'])).toEqual(51);
   })
 });


### PR DESCRIPTION
function rename: improved descriptiveness of default exported function; created corresponding changes in test suite and examples