### PR TITLE
Sync Isogram tests with canonical data version 1.7.0

### DIFF
--- a/exercises/isogram/example.js
+++ b/exercises/isogram/example.js
@@ -1,5 +1,8 @@
-export const isIsogram = (string) => {
+export const isIsogram = string => {
   const stringNoSpaceOrHyphen = string.replace(/ |-/g, '');
-  const uniqueLetters = stringNoSpaceOrHyphen.toLowerCase().split('').filter((element, index, self) => self.indexOf(element) === index);
+  const uniqueLetters = stringNoSpaceOrHyphen
+    .toLowerCase()
+    .split('')
+    .filter((element, index, self) => self.indexOf(element) === index);
   return uniqueLetters.length === stringNoSpaceOrHyphen.length;
 };

--- a/exercises/isogram/isogram.spec.js
+++ b/exercises/isogram/isogram.spec.js
@@ -1,51 +1,57 @@
 import { isIsogram } from './isogram';
 
-describe('Isogram Test Suite', () => {
-  test('empty string', () => {
-    expect(isIsogram('')).toEqual(true);
-  });
+describe('Isogram', () => {
+  describe('Check if the given string is an isogram', () => {
+    test('empty string', () => {
+      expect(isIsogram('')).toEqual(true);
+    });
 
-  xtest('isogram with only lower case characters', () => {
-    expect(isIsogram('isogram')).toEqual(true);
-  });
+    xtest('isogram with only lower case characters', () => {
+      expect(isIsogram('isogram')).toEqual(true);
+    });
 
-  xtest('word with one duplicated character', () => {
-    expect(isIsogram('eleven')).toEqual(false);
-  });
+    xtest('word with one duplicated character', () => {
+      expect(isIsogram('eleven')).toEqual(false);
+    });
 
-  xtest('word with one duplicated character from the end of the alphabet', () => {
-    expect(isIsogram('zzyzx')).toEqual(false);
-  });
+    xtest('word with one duplicated character from the end of the alphabet', () => {
+      expect(isIsogram('zzyzx')).toEqual(false);
+    });
 
-  xtest('longest reported english isogram', () => {
-    expect(isIsogram('subdermatoglyphic')).toEqual(true);
-  });
+    xtest('longest reported english isogram', () => {
+      expect(isIsogram('subdermatoglyphic')).toEqual(true);
+    });
 
-  xtest('word with duplicated character in mixed case', () => {
-    expect(isIsogram('Alphabet')).toEqual(false);
-  });
+    xtest('word with duplicated character in mixed case', () => {
+      expect(isIsogram('Alphabet')).toEqual(false);
+    });
 
-  xtest('word with duplicated character in mixed case, lowercase first', () => {
-    expect(isIsogram('alphAbet')).toEqual(false);
-  });
+    xtest('word with duplicated character in mixed case, lowercase first', () => {
+      expect(isIsogram('alphAbet')).toEqual(false);
+    });
 
-  xtest('hypothetical isogrammic word with hyphen', () => {
-    expect(isIsogram('thumbscrew-japingly')).toEqual(true);
-  });
+    xtest('hypothetical isogrammic word with hyphen', () => {
+      expect(isIsogram('thumbscrew-japingly')).toEqual(true);
+    });
 
-  xtest('isogram with duplicated hyphen', () => {
-    expect(isIsogram('six-year-old')).toEqual(true);
-  });
+    xtest('hypothetical word with duplicated character following hyphen', () => {
+      expect(isIsogram('thumbscrew-jappingly')).toEqual(false);
+    });
 
-  xtest('made-up name that is an isogram', () => {
-    expect(isIsogram('Emily Jung Schwartzkopf')).toEqual(true);
-  });
+    xtest('isogram with duplicated hyphen', () => {
+      expect(isIsogram('six-year-old')).toEqual(true);
+    });
 
-  xtest('duplicated character in the middle', () => {
-    expect(isIsogram('accentor')).toEqual(false);
-  });
+    xtest('made-up name that is an isogram', () => {
+      expect(isIsogram('Emily Jung Schwartzkopf')).toEqual(true);
+    });
 
-  xtest('same first and last characters', () => {
-    expect(isIsogram('angola')).toEqual(false);
+    xtest('duplicated character in the middle', () => {
+      expect(isIsogram('accentor')).toEqual(false);
+    });
+
+    xtest('same first and last characters', () => {
+      expect(isIsogram('angola')).toEqual(false);
+    });
   });
 });

--- a/exercises/isogram/package.json
+++ b/exercises/isogram/package.json
@@ -1,5 +1,6 @@
 {
   "name": "exercism-javascript",
+  "version": "1.7.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,


### PR DESCRIPTION
Added missing test: "hypothetical word with duplicated character following hyphen"