### PR TITLE
[gigasecond] Add a test to check that input is not mutated

### DIFF
--- a/exercises/gigasecond/.meta/hints.md
+++ b/exercises/gigasecond/.meta/hints.md
@@ -1,0 +1,1 @@
+It is possible to return a correct value for this exercise by mutating the solution function argument. Although there are legitimate use cases for mutating function arguments, this is usually undesirable, and in the case of this exercise, clearly unexpected. For this reason, the test suite has a test that fails in case the argument has been modified after the function execution.

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -5,6 +5,9 @@ has passed.
 
 A gigasecond is 10^9 (1,000,000,000) seconds.
 
+It is possible to return a correct value for this exercise by mutating the solution function argument. Although there are legitimate use cases for mutating function arguments, this is usually undesirable, and in the case of this exercise, clearly unexpected. For this reason, the test suite has a test that fails in case the argument has been modified after the function execution.
+
+
 ## Setup
 
 Go through the setup instructions for Javascript to install the necessary

--- a/exercises/gigasecond/gigasecond.spec.js
+++ b/exercises/gigasecond/gigasecond.spec.js
@@ -35,4 +35,10 @@ describe('Gigasecond', () => {
     const expectedDate = new Date(Date.parse('2046-10-03T01:46:39Z'));
     expect(gs).toEqual(expectedDate);
   });
+
+  xtest('does not mutate the input', () => {
+    const input = new Date(Date.UTC(2020, 0, 4, 20, 28, 30));
+    gigasecond(input);
+    expect(input).toEqual(new Date(Date.UTC(2020, 0, 4, 20, 28, 30)));
+  });
 });


### PR DESCRIPTION
Adds a test to the **gigasecond** exercise make sure the input is not mutated, since there are some solutions which will pass the current test suite that will mutate the input, which is undesirable. I've now encountered at least twice while mentoring solutions that appear to be correct, but mutate the input, so it makes sense to include this case in the test suite.

Added directly here instead of the problem specifications repository, because unfortunately it's a test case that cannot be defined generically.