### PR TITLE
Keep version when updating package json

### DIFF
--- a/exercises/scale-generator/package.json
+++ b/exercises/scale-generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "exercism-javascript",
-  "description": "Exercism exercises in Javascript.",
   "version": "2.0.0",
+  "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,
   "repository": {

--- a/exercises/yacht/package.json
+++ b/exercises/yacht/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exercism-javascript",
-  "version":"1.2.0",
+  "version": "1.2.0",
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "exercism-javascript",
+  "version": null,
   "description": "Exercism exercises in Javascript.",
   "author": "Katrina Owen",
   "private": true,

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -45,11 +45,11 @@ function cleanUp() {
 const SKIP_PACKAGES_FOR_CHECKSUM = ['shelljs', '@babel/node'];
 
 // Filter out some unwanted packages and create package.json for exercises
-function createExercisePackageJson() {
+function createExercisePackageJson(assignmentVersion) {
   const packageFile = shell.cat('package.json').toString();
   const packageJson = JSON.parse(packageFile);
 
-  delete packageJson['version'];
+  packageJson['version'] = assignmentVersion;
   SKIP_PACKAGES_FOR_CHECKSUM.forEach(pkg => delete packageJson['devDependencies'][pkg]);
 
   const shellStr = new shell.ShellString(JSON.stringify(packageJson, null, 2) + '\n');

--- a/scripts/sync
+++ b/scripts/sync
@@ -13,13 +13,23 @@ const shell = require('shelljs');
 const assignment = shell.env['ASSIGNMENT'];
 const helpers = require('./helpers');
 
-function copyConfig(destination) {
-  helpers.createExercisePackageJson();
-  shell.cat('exercise-package.json').to(destination + '/package.json');
+function copyConfigForAssignment(assignment) {
+  const destination = 'exercises/' + assignment;
+  const assignmentPackageFilename = destination + '/package.json';
+  const assignmentVersion = getAssignmentVersion(assignmentPackageFilename);
+  helpers.createExercisePackageJson(assignmentVersion);
+  shell.cat('exercise-package.json').to(assignmentPackageFilename);
   shell.rm('exercise-package.json');
 
   shell.cp('babel.config.js', destination);
   shell.cp('.eslintrc', destination);
+}
+
+function getAssignmentVersion(assignmentPackageFilename) {
+  const packageFile = shell.cat(assignmentPackageFilename).toString();
+  const packageJson = JSON.parse(packageFile);
+  console.debug(packageJson)
+  return packageJson['version'];
 }
 
 if(assignment) {
@@ -28,5 +38,5 @@ if(assignment) {
 }
 else {
   shell.echo('Syncing all assignments...');
-  helpers.assignments.forEach(assignment => copyConfig('exercises/' + assignment));
+  helpers.assignments.forEach(copyConfigForAssignment);
 }


### PR DESCRIPTION
Keeps the version of the assignment when updating `package.json` files with the sync script.

Fixes a couple of exercises that were slightly inconsistent due to manual fixes.

Fixes #825.