### PR TITLE
This is a minor update to one of the isosceles tests.

### DIFF
--- a/exercises/triangle/triangle.spec.js
+++ b/exercises/triangle/triangle.spec.js
@@ -40,7 +40,7 @@ describe('Triangle', () => {
     });
 
     xtest('first and last sides are equal', () => {
-      const triangle = new Triangle(4, 3, 4);
+      const triangle = new Triangle(2, 4, 2);
       expect(triangle.isIsosceles()).toBe(true);
     });
 


### PR DESCRIPTION
None of the included tests, hold a scenario where the two of the sides
accumulated are equal to the third side.

This led to a bug in my solution, which I did not spot until I made
a similar solution in the Go track, based on the same algorithm.

The Go track holds a test with the parameters: 2, 2 and 4.

Where all the tests in the JavaScript test suite are with values
further apart.

The lack of a test scenario with parameters resembling 2, 2 and 4 allow
for an implementation allowing for an buggy implementation, like so:

    if (this.a + this.b <= this.c
        || this.a + this.c <= this.b
        || this.b + this.c <= this.a) {
            throw('Triangle not equal');
        }

Where the side lengths of 2, 2 and 4 are representing an isosceles
triangle and not an inequal triangle.

The correction solution, should read as follows:

    if (this.a + this.b < this.c
        || this.a + this.c < this.b
        || this.b + this.c < this.a) {
            throw('Triangle not equal');
        }

The bug is all mine, but a test would have helped to a better solution
and since the Go track holds the test, I think the scenario should be
used in the JavaScript track as well.

If this PR should be for the canonical tests instead, please let me know.