### PR TITLE
Sync 'raindrops' with canonical data 1.1.0 #835

### DIFF
--- a/exercises/raindrops/raindrops.spec.js
+++ b/exercises/raindrops/raindrops.spec.js
@@ -34,7 +34,7 @@ describe('Raindrops', () => {
     expect(convert(25)).toEqual('Plang'));
 
   xtest('the sound for 27 is Pling as it has a factor 3', () =>
-    expect(convert(35)).toEqual('PlangPlong'));
+    expect(convert(27)).toEqual('Pling'));
 
   xtest('the sound for 35 is PlangPlong as it has factors 5 and 7', () =>
     expect(convert(35)).toEqual('PlangPlong'));


### PR DESCRIPTION
Updated raindrops tests to be in sync with canonical data.

Canonical data:

      "description": "the sound for 27 is Pling as it has a factor 3",
      "property": "convert",
      "input": {
        "number": 27
      },
      "expected": "Pling"
Test Spec:

	test('the sound for 27 is Pling as it has a factor 3', () =>
		expect(convert(35)).toEqual('PlangPlong'));
Expected:

	test('the sound for 27 is Pling as it has a factor 3', () =>
		expect(convert(27)).toEqual('Pling'));

Current canonical data is `1.1.0` so I did not update the `package.json`

Closes #835 