### PR TITLE
Update fetch-configlet to fix Travis build failures

### DIFF
--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -37,8 +37,11 @@ case $(uname -m) in
 esac)
 
 
-VERSION="$(curl --silent --head $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
-URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.$EXT
+VERSION="$(curl --head --silent $LATEST | perl -nE 's/\R//g; /^Location:/i && print [split/\//]->[-1]')"
+URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
+
+echo "VERSION = $VERSION"
+echo "URL = $URL"
 
 case $EXT in
     (*zip)

--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -38,7 +38,7 @@ esac)
 
 
 VERSION="$(curl --head --silent $LATEST | perl -nE 's/\R//g; /^Location:/i && print [split/\//]->[-1]')"
-URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
+URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.$EXT
 
 echo "VERSION = $VERSION"
 echo "URL = $URL"


### PR DESCRIPTION
## Issue
Travis builds are failing because of fetch-configlet failures, as
tracked in exercism/configlet#173. This
patch is a copy of exercism/cpp#344, and exercism/haskell#898 which
fixed the cpp and haskell track

## Fix
This makes the test case-insensitive rather than simply fixing the
case, by switching to perl. This is taken from
exercism/sml@a721a5c.
 master (#898)