### PR TITLE
Fix fetch-configlet script to get 'location' header

### DIFF
--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -37,7 +37,7 @@ case $(uname -m) in
 esac)
 
 
-VERSION="$(curl --silent --head $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
+VERSION="$(curl --silent --head $LATEST | awk -v FS=/ '/location:/{print $NF}' | tr -d '\r')"
 URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.$EXT
 
 case $EXT in


### PR DESCRIPTION
## Issue
Travis builds are failing because of fetch-configlet failures, as
tracked in exercism/configlet#173. This
patch is a copy of exercism/cpp#344, and exercism/haskell#898 which
fixed the cpp and haskell track