### PR TITLE
Update space age - example.js

### DIFF
--- a/exercises/space-age/example.js
+++ b/exercises/space-age/example.js
@@ -13,5 +13,5 @@ export const age = (planet, seconds) => {
   const earthYears = seconds / 31557600;
   const years = earthYears / EARTH_TO_OTHER_PLANETS[planet];
 
-  return parseFloat(years.toFixed(2));
+  return Number(years.toFixed(2));
 };


### PR DESCRIPTION
Across the site `Number` is generally recommended over `parse....` in mentor notes. It's mentioned in this exercise and in others, so I'm updating this example to use `Number`. If there's a specific reason to use it in this case please let me know. 

Perhaps there are more examples where this is the case.