### PR TITLE
Disable npm audit in all exercises

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/accumulate/.npmrc
+++ b/exercises/accumulate/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/acronym/.npmrc
+++ b/exercises/acronym/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/all-your-base/.npmrc
+++ b/exercises/all-your-base/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/allergies/.npmrc
+++ b/exercises/allergies/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/alphametics/.npmrc
+++ b/exercises/alphametics/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/anagram/.npmrc
+++ b/exercises/anagram/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/armstrong-numbers/.npmrc
+++ b/exercises/armstrong-numbers/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/atbash-cipher/.npmrc
+++ b/exercises/atbash-cipher/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/beer-song/.npmrc
+++ b/exercises/beer-song/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/binary-search-tree/.npmrc
+++ b/exercises/binary-search-tree/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/binary-search/.npmrc
+++ b/exercises/binary-search/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/binary/.npmrc
+++ b/exercises/binary/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/bob/.npmrc
+++ b/exercises/bob/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/bowling/.npmrc
+++ b/exercises/bowling/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/change/.npmrc
+++ b/exercises/change/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/circular-buffer/.npmrc
+++ b/exercises/circular-buffer/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/clock/.npmrc
+++ b/exercises/clock/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/collatz-conjecture/.npmrc
+++ b/exercises/collatz-conjecture/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/complex-numbers/.npmrc
+++ b/exercises/complex-numbers/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/connect/.npmrc
+++ b/exercises/connect/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/crypto-square/.npmrc
+++ b/exercises/crypto-square/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/custom-set/.npmrc
+++ b/exercises/custom-set/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/darts/.npmrc
+++ b/exercises/darts/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/diamond/.npmrc
+++ b/exercises/diamond/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/difference-of-squares/.npmrc
+++ b/exercises/difference-of-squares/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/diffie-hellman/.npmrc
+++ b/exercises/diffie-hellman/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/dnd-character/.npmrc
+++ b/exercises/dnd-character/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/etl/.npmrc
+++ b/exercises/etl/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/flatten-array/.npmrc
+++ b/exercises/flatten-array/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/food-chain/.npmrc
+++ b/exercises/food-chain/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/forth/.npmrc
+++ b/exercises/forth/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/gigasecond/.npmrc
+++ b/exercises/gigasecond/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/grade-school/.npmrc
+++ b/exercises/grade-school/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/grains/.npmrc
+++ b/exercises/grains/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/grep/.npmrc
+++ b/exercises/grep/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/hamming/.npmrc
+++ b/exercises/hamming/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/hello-world/.npmrc
+++ b/exercises/hello-world/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/hexadecimal/.npmrc
+++ b/exercises/hexadecimal/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/high-scores/.npmrc
+++ b/exercises/high-scores/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/house/.npmrc
+++ b/exercises/house/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/isbn-verifier/.npmrc
+++ b/exercises/isbn-verifier/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/isogram/.npmrc
+++ b/exercises/isogram/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/kindergarten-garden/.npmrc
+++ b/exercises/kindergarten-garden/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/largest-series-product/.npmrc
+++ b/exercises/largest-series-product/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/leap/.npmrc
+++ b/exercises/leap/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/linked-list/.npmrc
+++ b/exercises/linked-list/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/list-ops/.npmrc
+++ b/exercises/list-ops/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/luhn/.npmrc
+++ b/exercises/luhn/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/matching-brackets/.npmrc
+++ b/exercises/matching-brackets/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/matrix/.npmrc
+++ b/exercises/matrix/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/meetup/.npmrc
+++ b/exercises/meetup/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/minesweeper/.npmrc
+++ b/exercises/minesweeper/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/nth-prime/.npmrc
+++ b/exercises/nth-prime/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/nucleotide-count/.npmrc
+++ b/exercises/nucleotide-count/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/ocr-numbers/.npmrc
+++ b/exercises/ocr-numbers/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/octal/.npmrc
+++ b/exercises/octal/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/palindrome-products/.npmrc
+++ b/exercises/palindrome-products/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/pangram/.npmrc
+++ b/exercises/pangram/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/pascals-triangle/.npmrc
+++ b/exercises/pascals-triangle/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/perfect-numbers/.npmrc
+++ b/exercises/perfect-numbers/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/phone-number/.npmrc
+++ b/exercises/phone-number/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/pig-latin/.npmrc
+++ b/exercises/pig-latin/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/point-mutations/.npmrc
+++ b/exercises/point-mutations/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/prime-factors/.npmrc
+++ b/exercises/prime-factors/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/protein-translation/.npmrc
+++ b/exercises/protein-translation/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/proverb/.npmrc
+++ b/exercises/proverb/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/pythagorean-triplet/.npmrc
+++ b/exercises/pythagorean-triplet/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/queen-attack/.npmrc
+++ b/exercises/queen-attack/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/raindrops/.npmrc
+++ b/exercises/raindrops/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/rational-numbers/.npmrc
+++ b/exercises/rational-numbers/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/react/.npmrc
+++ b/exercises/react/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/rectangles/.npmrc
+++ b/exercises/rectangles/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/resistor-color-duo/.npmrc
+++ b/exercises/resistor-color-duo/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/resistor-color-trio/.npmrc
+++ b/exercises/resistor-color-trio/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/resistor-color/.npmrc
+++ b/exercises/resistor-color/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/reverse-string/.npmrc
+++ b/exercises/reverse-string/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/rna-transcription/.npmrc
+++ b/exercises/rna-transcription/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/robot-name/.npmrc
+++ b/exercises/robot-name/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/robot-simulator/.npmrc
+++ b/exercises/robot-simulator/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/roman-numerals/.npmrc
+++ b/exercises/roman-numerals/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/rotational-cipher/.npmrc
+++ b/exercises/rotational-cipher/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/run-length-encoding/.npmrc
+++ b/exercises/run-length-encoding/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/saddle-points/.npmrc
+++ b/exercises/saddle-points/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/say/.npmrc
+++ b/exercises/say/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/scale-generator/.npmrc
+++ b/exercises/scale-generator/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/scrabble-score/.npmrc
+++ b/exercises/scrabble-score/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/secret-handshake/.npmrc
+++ b/exercises/secret-handshake/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/series/.npmrc
+++ b/exercises/series/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/sieve/.npmrc
+++ b/exercises/sieve/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/simple-cipher/.npmrc
+++ b/exercises/simple-cipher/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/simple-linked-list/.npmrc
+++ b/exercises/simple-linked-list/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/space-age/.npmrc
+++ b/exercises/space-age/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/spiral-matrix/.npmrc
+++ b/exercises/spiral-matrix/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/strain/.npmrc
+++ b/exercises/strain/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/sublist/.npmrc
+++ b/exercises/sublist/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/sum-of-multiples/.npmrc
+++ b/exercises/sum-of-multiples/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/transpose/.npmrc
+++ b/exercises/transpose/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/triangle/.npmrc
+++ b/exercises/triangle/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/trinary/.npmrc
+++ b/exercises/trinary/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/twelve-days/.npmrc
+++ b/exercises/twelve-days/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/two-bucket/.npmrc
+++ b/exercises/two-bucket/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/two-fer/.npmrc
+++ b/exercises/two-fer/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/variable-length-quantity/.npmrc
+++ b/exercises/variable-length-quantity/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/word-count/.npmrc
+++ b/exercises/word-count/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/word-search/.npmrc
+++ b/exercises/word-search/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/wordy/.npmrc
+++ b/exercises/wordy/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/yacht/.npmrc
+++ b/exercises/yacht/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/exercises/zipper/.npmrc
+++ b/exercises/zipper/.npmrc
@@ -1,0 +1,1 @@
+audit=false

--- a/scripts/checksum
+++ b/scripts/checksum
@@ -54,5 +54,6 @@ helpers.createExercisePackageJson();
 checkSumAll('package.json', 'exercise-package.json');
 shell.rm('exercise-package.json');
 
-checkSumAll('.eslintrc');
 checkSumAll('babel.config.js');
+checkSumAll('.eslintrc');
+checkSumAll('.npmrc');

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -4,11 +4,9 @@
  */
 
 const shell = require('shelljs');
-const fs = require('fs');
 
 const exerciseDirs = shell.ls('-d', 'exercises/*');
 
-const config = JSON.parse(fs.readFileSync('config.json'))['exercises'];
 const assignments = exerciseDirs.map(dir => dir.split('/')[1])
       .filter(exercise => !exercise.deprecated);
 

--- a/scripts/sync
+++ b/scripts/sync
@@ -3,8 +3,11 @@
 /**
  * Run this script (from root directory): npx @babel/node scripts/sync
  *
- * This script is used to propagate any change to root package.json to
- * all exercises and keep them in sync.
+ * This script is used to copy following files to all exercises & keep them in sync:
+ * 1. package.json
+ * 2. babel.config.js
+ * 3. .eslintrc
+ * 4. .npmrc
  * There is a CI step which checks that package.json in root & exercises match
  * (see checksum script for more info).
  */
@@ -23,12 +26,12 @@ function copyConfigForAssignment(assignment) {
 
   shell.cp('babel.config.js', destination);
   shell.cp('.eslintrc', destination);
+  shell.cp('.npmrc', destination);
 }
 
 function getAssignmentVersion(assignmentPackageFilename) {
   const packageFile = shell.cat(assignmentPackageFilename).toString();
   const packageJson = JSON.parse(packageFile);
-  console.debug(packageJson)
   return packageJson['version'];
 }
 


### PR DESCRIPTION
Closes #848

https://docs.npmjs.com/misc/config#audit

Add `.npmrc` to switch audit check off after `npm install`.

Sadly this config is not allowed in `package.json` - so had to create new `.npmrc` file.