### PR TITLE
Fix spec for complex-numbers exercise

### DIFF
--- a/exercises/complex-numbers/complex-numbers.js
+++ b/exercises/complex-numbers/complex-numbers.js
@@ -32,15 +32,15 @@ export class ComplexNumber {
     throw new Error("Remove this statement and implement this function");
   }
 
-  abs() {
+  get abs() {
     throw new Error("Remove this statement and implement this function");
   }
 
-  conj() {
+  get conj() {
     throw new Error("Remove this statement and implement this function");
   }
 
-  exp() {
+  get exp() {
     throw new Error("Remove this statement and implement this function");
   }
 }

--- a/exercises/complex-numbers/complex-numbers.spec.js
+++ b/exercises/complex-numbers/complex-numbers.spec.js
@@ -136,63 +136,63 @@ describe('Complex numbers', () => {
 
   xtest('Absolute value of a positive purely real number', () => {
     const expected = 5;
-    const actual = new ComplexNumber(5, 0).abs;
+    const actual = new ComplexNumber(5, 0).abs();
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Absolute value of a negative purely real number', () => {
     const expected = 5;
-    const actual = new ComplexNumber(-5, 0).abs;
+    const actual = new ComplexNumber(-5, 0).abs();
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Absolute value of a purely imaginary number with positive imaginary part', () => {
     const expected = 5;
-    const actual = new ComplexNumber(0, 5).abs;
+    const actual = new ComplexNumber(0, 5).abs();
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Absolute value of a purely imaginary number with negative imaginary part', () => {
     const expected = 5;
-    const actual = new ComplexNumber(0, -5).abs;
+    const actual = new ComplexNumber(0, -5).abs();
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Absolute value of a number with real and imaginary part', () => {
     const expected = 5;
-    const actual = new ComplexNumber(3, 4).abs;
+    const actual = new ComplexNumber(3, 4).abs();
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Conjugate a purely real number', () => {
     const expected = new ComplexNumber(5, 0);
-    const actual = new ComplexNumber(5, 0).conj;
+    const actual = new ComplexNumber(5, 0).conj();
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Conjugate a purely imaginary number', () => {
     const expected = new ComplexNumber(0, -5);
-    const actual = new ComplexNumber(0, 5).conj;
+    const actual = new ComplexNumber(0, 5).conj();
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Conjugate a number with real and imaginary part', () => {
     const expected = new ComplexNumber(1, -1);
-    const actual = new ComplexNumber(1, 1).conj;
+    const actual = new ComplexNumber(1, 1).conj();
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Euler\'s identity/formula', () => {
     const expected = new ComplexNumber(-1, 0);
-    const actual = new ComplexNumber(0, Math.PI).exp;
+    const actual = new ComplexNumber(0, Math.PI).exp();
 
     expect(actual.real).toBeCloseTo(expected.real);
     expect(actual.imag).toBeCloseTo(expected.imag);
@@ -200,7 +200,7 @@ describe('Complex numbers', () => {
 
   xtest('Exponential of 0', () => {
     const expected = new ComplexNumber(1, 0);
-    const actual = new ComplexNumber(0, 0).exp;
+    const actual = new ComplexNumber(0, 0).exp();
 
     expect(actual.real).toBeCloseTo(expected.real);
     expect(actual.imag).toBeCloseTo(expected.imag);
@@ -208,7 +208,7 @@ describe('Complex numbers', () => {
 
   xtest('Exponential of a purely real number', () => {
     const expected = new ComplexNumber(Math.E, 0);
-    const actual = new ComplexNumber(1, 0).exp;
+    const actual = new ComplexNumber(1, 0).exp();
 
     expect(actual.real).toBeCloseTo(expected.real);
     expect(actual.imag).toBeCloseTo(expected.imag);
@@ -216,7 +216,7 @@ describe('Complex numbers', () => {
 
   xtest('Exponential of a number with real and imaginary part', () => {
     const expected = new ComplexNumber(-2, 0);
-    const actual = new ComplexNumber(Math.LN2, Math.PI).exp;
+    const actual = new ComplexNumber(Math.LN2, Math.PI).exp();
 
     expect(actual.real).toBeCloseTo(expected.real);
     expect(actual.imag).toBeCloseTo(expected.imag);

--- a/exercises/complex-numbers/complex-numbers.spec.js
+++ b/exercises/complex-numbers/complex-numbers.spec.js
@@ -136,63 +136,63 @@ describe('Complex numbers', () => {
 
   xtest('Absolute value of a positive purely real number', () => {
     const expected = 5;
-    const actual = new ComplexNumber(5, 0).abs();
+    const actual = new ComplexNumber(5, 0).abs;
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Absolute value of a negative purely real number', () => {
     const expected = 5;
-    const actual = new ComplexNumber(-5, 0).abs();
+    const actual = new ComplexNumber(-5, 0).abs;
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Absolute value of a purely imaginary number with positive imaginary part', () => {
     const expected = 5;
-    const actual = new ComplexNumber(0, 5).abs();
+    const actual = new ComplexNumber(0, 5).abs;
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Absolute value of a purely imaginary number with negative imaginary part', () => {
     const expected = 5;
-    const actual = new ComplexNumber(0, -5).abs();
+    const actual = new ComplexNumber(0, -5).abs;
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Absolute value of a number with real and imaginary part', () => {
     const expected = 5;
-    const actual = new ComplexNumber(3, 4).abs();
+    const actual = new ComplexNumber(3, 4).abs;
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Conjugate a purely real number', () => {
     const expected = new ComplexNumber(5, 0);
-    const actual = new ComplexNumber(5, 0).conj();
+    const actual = new ComplexNumber(5, 0).conj;
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Conjugate a purely imaginary number', () => {
     const expected = new ComplexNumber(0, -5);
-    const actual = new ComplexNumber(0, 5).conj();
+    const actual = new ComplexNumber(0, 5).conj;
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Conjugate a number with real and imaginary part', () => {
     const expected = new ComplexNumber(1, -1);
-    const actual = new ComplexNumber(1, 1).conj();
+    const actual = new ComplexNumber(1, 1).conj;
 
     expect(actual).toEqual(expected);
   });
 
   xtest('Euler\'s identity/formula', () => {
     const expected = new ComplexNumber(-1, 0);
-    const actual = new ComplexNumber(0, Math.PI).exp();
+    const actual = new ComplexNumber(0, Math.PI).exp;
 
     expect(actual.real).toBeCloseTo(expected.real);
     expect(actual.imag).toBeCloseTo(expected.imag);
@@ -200,7 +200,7 @@ describe('Complex numbers', () => {
 
   xtest('Exponential of 0', () => {
     const expected = new ComplexNumber(1, 0);
-    const actual = new ComplexNumber(0, 0).exp();
+    const actual = new ComplexNumber(0, 0).exp;
 
     expect(actual.real).toBeCloseTo(expected.real);
     expect(actual.imag).toBeCloseTo(expected.imag);
@@ -208,7 +208,7 @@ describe('Complex numbers', () => {
 
   xtest('Exponential of a purely real number', () => {
     const expected = new ComplexNumber(Math.E, 0);
-    const actual = new ComplexNumber(1, 0).exp();
+    const actual = new ComplexNumber(1, 0).exp;
 
     expect(actual.real).toBeCloseTo(expected.real);
     expect(actual.imag).toBeCloseTo(expected.imag);
@@ -216,7 +216,7 @@ describe('Complex numbers', () => {
 
   xtest('Exponential of a number with real and imaginary part', () => {
     const expected = new ComplexNumber(-2, 0);
-    const actual = new ComplexNumber(Math.LN2, Math.PI).exp();
+    const actual = new ComplexNumber(Math.LN2, Math.PI).exp;
 
     expect(actual.real).toBeCloseTo(expected.real);
     expect(actual.imag).toBeCloseTo(expected.imag);


### PR DESCRIPTION
Specs were failing because `abs`, `conj`, `exp` are defined as functions in the current exercise template, not getters.