### PR TITLE
Add tests.toml file for grains exercise

### DIFF
--- a/.github/workflows/pr.ci.js.yml
+++ b/.github/workflows/pr.ci.js.yml
@@ -50,6 +50,6 @@ jobs:
       - name: Run exercism/javascript ci (runs tests) for changed/added exercises
         run: |
           PULL_REQUEST_URL=$(jq -r ".pull_request.url" "$GITHUB_EVENT_PATH")
-          curl --url $"${PULL_REQUEST_URL}/files" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | \
+          curl --url $"${PULL_REQUEST_URL}/files?per_page=100" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | \
             jq -c '.[] | select(.status == "added" or .status == "modified") | select(.filename | match("\\.(js|jsx|md|json)$")) | .filename' | \
             xargs -r npx babel-node scripts/pr

--- a/exercises/grains/.meta/tests.toml
+++ b/exercises/grains/.meta/tests.toml
@@ -1,0 +1,34 @@
+[canonical-tests]
+
+# 1
+"9fbde8de-36b2-49de-baf2-cd42d6f28405" = true
+
+# 2
+"ee1f30c2-01d8-4298-b25d-c677331b5e6d" = true
+
+# 3
+"10f45584-2fc3-4875-8ec6-666065d1163b" = true
+
+# 4
+"a7cbe01b-36f4-4601-b053-c5f6ae055170" = true
+
+# 16
+"c50acc89-8535-44e4-918f-b848ad2817d4" = true
+
+# 32
+"acd81b46-c2ad-4951-b848-80d15ed5a04f" = true
+
+# 64
+"c73b470a-5efb-4d53-9ac6-c5f6487f227b" = true
+
+# square 0 raises an exception
+"1d47d832-3e85-4974-9466-5bd35af484e3" = true
+
+# negative square raises an exception
+"61974483-eeb2-465e-be54-ca5dde366453" = true
+
+# square greater than 64 raises an exception
+"a95e4374-f32c-45a7-a10d-ffec475c012f" = true
+
+# returns the total number of grains on the board
+"6eb07385-3659-4b45-a6be-9dc474222750" = true

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -21,7 +21,10 @@ export function findExerciseDirectory(input) {
 }
 
 export function hasStub(assignment) {
-  return shell.test("-f", `exercises/${assignment}/${assignment}.js`);
+  return shell.test(
+    "-f",
+    path.join("exercises", assignment, `${assignment}.js`)
+  );
 }
 
 export function envIsThruthy(key, unset = false) {
@@ -102,13 +105,23 @@ export function prepare(assignment) {
     shell.exit(1);
   }
   const exampleFile = path.join("exercises", assignment, "example.js");
-  const specFile = path.join("exercises", assignment, assignment + ".spec.js");
+  const specFile = path.join("exercises", assignment, `${assignment}.spec.js`);
+  const specFileDestination = path.join(
+    "tmp_exercises",
+    `${assignment}.spec.js`
+  );
 
   shell.mkdir("-p", path.join("tmp_exercises", "lib"));
-  shell.cp(exampleFile, path.join("tmp_exercises", assignment + ".js"));
+  shell.cp(exampleFile, path.join("tmp_exercises", `${assignment}.js`));
+  shell.cp(specFile, specFileDestination);
+
+  // Enable tests
   shell
-    .sed(/x(test|it)\(/, "test(", specFile)
-    .to(path.join("tmp_exercises", assignment + ".spec.js"));
+    .sed(/x(test|it)\(/, "test(", specFileDestination)
+    .to(specFileDestination);
+  shell
+    .sed("xdescribe", "describe", specFileDestination)
+    .to(specFileDestination);
 
   const libDir = path.join("exercises", assignment, "lib");
   if (shell.test("-d", libDir)) {

--- a/scripts/lint
+++ b/scripts/lint
@@ -32,7 +32,7 @@ const infoStr = assignment
 const failureStr = "[Failure] Lint check failed!";
 
 // Run lint all at once
-prepareAndRun("npx eslint tmp_exercises", infoStr, failureStr);
+prepareAndRun("npx eslint tmp_exercises -c .eslintrc", infoStr, failureStr);
 
 shell.echo(
   assignment

--- a/scripts/sync
+++ b/scripts/sync
@@ -3,11 +3,14 @@
 /**
  * Run this script (from root directory): npx babel-node scripts/sync
  *
- * This script is used to copy following files to all exercises & keep them in sync:
- * 1. package.json
- * 2. babel.config.js
- * 3. .eslintrc
- * 4. .npmrc
+ * This script is used to copy the following files to all exercises and keep
+ * them in sync:
+ *
+ * - .eslintrc
+ * - babel.config.js
+ * - package.json (modified version)
+ * - .npmrc
+ *
  * There is a CI step which checks that package.json in root & exercises match
  * (see checksum script for more info).
  */


### PR DESCRIPTION
Last week, we sent a PR in which tests.toml file were added for all exercises that have canonical data. Due to an issue, the grains exercise's tests.toml file was not included. This PR adds the tests.toml file for the grains exercise.