### PR TITLE
Improve Forth test

### DIFF
--- a/exercises/practice/forth/.meta/tests.toml
+++ b/exercises/practice/forth/.meta/tests.toml
@@ -158,6 +158,10 @@ include = true
 description = "cannot redefine numbers"
 include = true
 
+[df5b2815-3843-4f55-b16c-c3ed507292a7]
+description = "cannot redefine negative numbers"
+include = true
+
 [5180f261-89dd-491e-b230-62737e09806f]
 description = "errors if executing a non-existent word"
 include = true

--- a/exercises/practice/forth/forth.spec.js
+++ b/exercises/practice/forth/forth.spec.js
@@ -253,6 +253,8 @@ describe('Forth', () => {
       expect(() => {
         forth.evaluate(': 1 2 ;');
       }).toThrow(new Error('Invalid definition'));
+    });
+    xtest('cannot redefine negative numbers', () => {
       expect(() => {
         forth.evaluate(': -1 2 ;');
       }).toThrow(new Error('Invalid definition'));

--- a/exercises/practice/forth/forth.spec.js
+++ b/exercises/practice/forth/forth.spec.js
@@ -253,6 +253,9 @@ describe('Forth', () => {
       expect(() => {
         forth.evaluate(': 1 2 ;');
       }).toThrow(new Error('Invalid definition'));
+      expect(() => {
+        forth.evaluate(': -1 2 ;');
+      }).toThrow(new Error('Invalid definition'));
     });
 
     xtest('errors if executing a non-existent word', () => {


### PR DESCRIPTION
The original version of the test only checks for positive numbers.

`
if(/^\d*$/.test(functionName)) throw new Error("Invalid definition");
`

An implementation like above will work for positive numbers, but not for negative numbers.