### PR TITLE
Two Bucket: fix errant tests

### DIFF
--- a/exercises/two-bucket/two-bucket.spec.js
+++ b/exercises/two-bucket/two-bucket.spec.js
@@ -59,7 +59,7 @@ describe('TwoBucket', () => {
   });
 
   describe('Measure using bucket one of size 2 and bucket two of size 3', () => {
-    xtest('start with bucket one and end with bucket two', () => {
+    test.skip('start with bucket one and end with bucket two', () => {
       const twoBucket = new TwoBucket(2, 3, 3, 'one');
       expect(twoBucket.moves()).toEqual(2);
       expect(twoBucket.goalBucket).toEqual('two');
@@ -72,7 +72,7 @@ describe('TwoBucket', () => {
     const buckTwo = 15;
     const starterBuck = 'one';
 
-    xtest('Not possible to reach the goal', () => {
+    test.skip('Not possible to reach the goal', () => {
       const goal = 5;
       const twoBucket = new TwoBucket(buckOne, buckTwo, goal, starterBuck);
       expect(() => twoBucket.moves()).toThrow();
@@ -88,7 +88,7 @@ describe('TwoBucket', () => {
   });
 
   describe('Goal larger than both buckets', () => {
-    xtest('Is impossible', () => {
+    test.skip('Is impossible', () => {
       const twoBucket = new TwoBucket(5, 7, 8, 'one');
       expect(() => twoBucket.moves()).toThrow();
     });

--- a/exercises/two-bucket/two-bucket.spec.js
+++ b/exercises/two-bucket/two-bucket.spec.js
@@ -59,7 +59,7 @@ describe('TwoBucket', () => {
   });
 
   describe('Measure using bucket one of size 2 and bucket two of size 3', () => {
-    test.skip('start with bucket one and end with bucket two', () => {
+    xtest('start with bucket one and end with bucket two', () => {
       const twoBucket = new TwoBucket(2, 3, 3, 'one');
       expect(twoBucket.moves()).toEqual(2);
       expect(twoBucket.goalBucket).toEqual('two');
@@ -72,10 +72,10 @@ describe('TwoBucket', () => {
     const buckTwo = 15;
     const starterBuck = 'one';
 
-    test.skip('Not possible to reach the goal', () => {
+    xtest('Not possible to reach the goal', () => {
       const goal = 5;
       const twoBucket = new TwoBucket(buckOne, buckTwo, goal, starterBuck);
-      expect(twoBucket.moves()).toThrow();
+      expect(() => twoBucket.moves()).toThrow();
     });
 
     xtest('With the same buckets but a different goal, then it is possible', () => {
@@ -88,9 +88,9 @@ describe('TwoBucket', () => {
   });
 
   describe('Goal larger than both buckets', () => {
-    test.skip('Is impossible', () => {
+    xtest('Is impossible', () => {
       const twoBucket = new TwoBucket(5, 7, 8, 'one');
-      expect(twoBucket.moves()).toThrow();
+      expect(() => twoBucket.moves()).toThrow();
     });
   });
 });


### PR DESCRIPTION
This PR addresses part of the problem tracked in [Issue #901](https://github.com/exercism/javascript/issues/901). A couple of test cases were added that were expected to throw yet were invoked immediately in the spec file. This PR wraps those invocations in an anonymous function.

The example solution provided does not pass the test cases as it stands and will need to be addressed in a separate PR. This is an immediate fix so the tests are working for students.