### PR TITLE
Update queen-attack.js as per Issue #938

### DIFF
--- a/exercises/queen-attack/queen-attack.js
+++ b/exercises/queen-attack/queen-attack.js
@@ -5,8 +5,8 @@
 
 export class QueenAttack {
   constructor({
-    black: [blackRow, blackColumn],
-    white: [whiteRow, whiteColumn],
+    black: [blackRow, blackColumn] = [],
+    white: [whiteRow, whiteColumn] = [],
   } = {}) {
     throw new Error('Remove this statement and implement this function');
   }


### PR DESCRIPTION
This implementation ensures that the `blackRow` `blackColumn` `whiteRow` `whiteColumn` are defined and that the original TypeError does not happen upon testing. #938 