### PR TITLE
Fix stub for circular-buffer to match test spec

### DIFF
--- a/exercises/practice/circular-buffer/circular-buffer.js
+++ b/exercises/practice/circular-buffer/circular-buffer.js
@@ -16,7 +16,7 @@ class CircularBuffer {
     throw new Error('Remove this statement and implement this function');
   }
 
-  overwrite() {
+  forceWrite() {
     throw new Error('Remove this statement and implement this function');
   }
 


### PR DESCRIPTION
The test spec file `circular-buffer.spec.js` tests the `forceWrite` method of `CircularBuffer` class.
However, the skeleton file `circular-buffer.js` provides an empty method with the name of `overwrite`.
I have renamed this method for the sake of consistency.