### PR TITLE
🤖 Add blurb to .meta/config.json files

### DIFF
--- a/exercises/concept/array-loops/.meta/config.json
+++ b/exercises/concept/array-loops/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for array-loops exercise",
   "authors": [
     {
       "github_username": "rishiosaur",
@@ -12,9 +13,15 @@
     }
   ],
   "files": {
-    "solution": ["array-loops.js"],
-    "test": ["array-loops.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "array-loops.js"
+    ],
+    "test": [
+      "array-loops.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
   "forked_from": []
 }

--- a/exercises/concept/array-loops/.meta/config.json
+++ b/exercises/concept/array-loops/.meta/config.json
@@ -13,15 +13,9 @@
     }
   ],
   "files": {
-    "solution": [
-      "array-loops.js"
-    ],
-    "test": [
-      "array-loops.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["array-loops.js"],
+    "test": ["array-loops.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/basics/.meta/config.json
+++ b/exercises/concept/basics/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for basics exercise",
   "authors": [
     {
       "github_username": "SleeplessByte",
@@ -6,9 +7,17 @@
     }
   ],
   "files": {
-    "solution": ["basics.js"],
-    "test": ["basics.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "basics.js"
+    ],
+    "test": [
+      "basics.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": ["ruby/basics"]
+  "forked_from": [
+    "ruby/basics"
+  ]
 }

--- a/exercises/concept/basics/.meta/config.json
+++ b/exercises/concept/basics/.meta/config.json
@@ -7,17 +7,9 @@
     }
   ],
   "files": {
-    "solution": [
-      "basics.js"
-    ],
-    "test": [
-      "basics.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["basics.js"],
+    "test": ["basics.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": [
-    "ruby/basics"
-  ]
+  "forked_from": ["ruby/basics"]
 }

--- a/exercises/concept/booleans/.meta/config.json
+++ b/exercises/concept/booleans/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for booleans exercise",
   "authors": [
     {
       "github_username": "ovidiu141",
@@ -16,9 +17,15 @@
     }
   ],
   "files": {
-    "solution": ["booleans.js"],
-    "test": ["booleans.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "booleans.js"
+    ],
+    "test": [
+      "booleans.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
   "forked_from": []
 }

--- a/exercises/concept/booleans/.meta/config.json
+++ b/exercises/concept/booleans/.meta/config.json
@@ -17,15 +17,9 @@
     }
   ],
   "files": {
-    "solution": [
-      "booleans.js"
-    ],
-    "test": [
-      "booleans.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["booleans.js"],
+    "test": ["booleans.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/closures/.meta/config.json
+++ b/exercises/concept/closures/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for closures exercise",
   "authors": [
     {
       "github_username": "neenjaw",
@@ -12,9 +13,15 @@
     }
   ],
   "files": {
-    "solution": ["closures.js"],
-    "test": ["closures.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "closures.js"
+    ],
+    "test": [
+      "closures.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
   "forked_from": []
 }

--- a/exercises/concept/closures/.meta/config.json
+++ b/exercises/concept/closures/.meta/config.json
@@ -13,15 +13,9 @@
     }
   ],
   "files": {
-    "solution": [
-      "closures.js"
-    ],
-    "test": [
-      "closures.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["closures.js"],
+    "test": ["closures.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/elyses-analytic-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-analytic-enchantments/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for elyses-analytic-enchantments exercise",
   "authors": [
     {
       "github_username": "peterchu999",
@@ -11,9 +12,15 @@
   ],
   "contributors": [],
   "files": {
-    "solution": ["enchantments.js"],
-    "test": ["enchantments.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "enchantments.js"
+    ],
+    "test": [
+      "enchantments.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
   "forked_from": []
 }

--- a/exercises/concept/elyses-analytic-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-analytic-enchantments/.meta/config.json
@@ -12,15 +12,9 @@
   ],
   "contributors": [],
   "files": {
-    "solution": [
-      "enchantments.js"
-    ],
-    "test": [
-      "enchantments.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["enchantments.js"],
+    "test": ["enchantments.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/elyses-destructured-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-destructured-enchantments/.meta/config.json
@@ -13,15 +13,9 @@
     }
   ],
   "files": {
-    "solution": [
-      "enchantments.js"
-    ],
-    "test": [
-      "enchantments.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["enchantments.js"],
+    "test": ["enchantments.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/elyses-destructured-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-destructured-enchantments/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for elyses-destructured-enchantments exercise",
   "authors": [
     {
       "github_username": "kristinaborn",
@@ -12,9 +13,15 @@
     }
   ],
   "files": {
-    "solution": ["enchantments.js"],
-    "test": ["enchantments.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "enchantments.js"
+    ],
+    "test": [
+      "enchantments.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
   "forked_from": []
 }

--- a/exercises/concept/elyses-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-enchantments/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for elyses-enchantments exercise",
   "authors": [
     {
       "github_username": "ovidiu141",
@@ -16,9 +17,17 @@
     }
   ],
   "files": {
-    "solution": ["enchantments.js"],
-    "test": ["enchantments.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "enchantments.js"
+    ],
+    "test": [
+      "enchantments.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": ["go/basic-slices"]
+  "forked_from": [
+    "go/basic-slices"
+  ]
 }

--- a/exercises/concept/elyses-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-enchantments/.meta/config.json
@@ -17,17 +17,9 @@
     }
   ],
   "files": {
-    "solution": [
-      "enchantments.js"
-    ],
-    "test": [
-      "enchantments.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["enchantments.js"],
+    "test": ["enchantments.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": [
-    "go/basic-slices"
-  ]
+  "forked_from": ["go/basic-slices"]
 }

--- a/exercises/concept/elyses-transformative-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-transformative-enchantments/.meta/config.json
@@ -13,15 +13,9 @@
     }
   ],
   "files": {
-    "solution": [
-      "enchantments.js"
-    ],
-    "test": [
-      "enchantments.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["enchantments.js"],
+    "test": ["enchantments.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/elyses-transformative-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-transformative-enchantments/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for elyses-transformative-enchantments exercise",
   "authors": [
     {
       "github_username": "yyyc514",
@@ -12,9 +13,15 @@
     }
   ],
   "files": {
-    "solution": ["enchantments.js"],
-    "test": ["enchantments.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "enchantments.js"
+    ],
+    "test": [
+      "enchantments.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
   "forked_from": []
 }

--- a/exercises/concept/fruit-picker/.meta/config.json
+++ b/exercises/concept/fruit-picker/.meta/config.json
@@ -13,15 +13,8 @@
     }
   ],
   "files": {
-    "solution": [
-      "fruit-picker.js",
-      "grocer.js"
-    ],
-    "test": [
-      "fruit-picker.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["fruit-picker.js", "grocer.js"],
+    "test": ["fruit-picker.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   }
 }

--- a/exercises/concept/fruit-picker/.meta/config.json
+++ b/exercises/concept/fruit-picker/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for fruit-picker exercise",
   "authors": [
     {
       "github_username": "neenjaw",
@@ -12,8 +13,15 @@
     }
   ],
   "files": {
-    "solution": ["fruit-picker.js", "grocer.js"],
-    "test": ["fruit-picker.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "fruit-picker.js",
+      "grocer.js"
+    ],
+    "test": [
+      "fruit-picker.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   }
 }

--- a/exercises/concept/lucky-numbers/.meta/config.json
+++ b/exercises/concept/lucky-numbers/.meta/config.json
@@ -17,15 +17,9 @@
     }
   ],
   "files": {
-    "solution": [
-      "lucky-numbers.js"
-    ],
-    "test": [
-      "lucky-numbers.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["lucky-numbers.js"],
+    "test": ["lucky-numbers.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/lucky-numbers/.meta/config.json
+++ b/exercises/concept/lucky-numbers/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for lucky-numbers exercise",
   "authors": [
     {
       "github_username": "shubhsk88",
@@ -16,9 +17,15 @@
     }
   ],
   "files": {
-    "solution": ["lucky-numbers.js"],
-    "test": ["lucky-numbers.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "lucky-numbers.js"
+    ],
+    "test": [
+      "lucky-numbers.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
   "forked_from": []
 }

--- a/exercises/concept/nullability/.meta/config.json
+++ b/exercises/concept/nullability/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for nullability exercise",
   "authors": [
     {
       "github_username": "SleeplessByte",
@@ -11,9 +12,17 @@
   ],
   "contributors": [],
   "files": {
-    "solution": ["nullability.js"],
-    "test": ["nullability.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "nullability.js"
+    ],
+    "test": [
+      "nullability.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": ["csharp/nullability"]
+  "forked_from": [
+    "csharp/nullability"
+  ]
 }

--- a/exercises/concept/nullability/.meta/config.json
+++ b/exercises/concept/nullability/.meta/config.json
@@ -12,17 +12,9 @@
   ],
   "contributors": [],
   "files": {
-    "solution": [
-      "nullability.js"
-    ],
-    "test": [
-      "nullability.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["nullability.js"],
+    "test": ["nullability.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": [
-    "csharp/nullability"
-  ]
+  "forked_from": ["csharp/nullability"]
 }

--- a/exercises/concept/numbers/.meta/config.json
+++ b/exercises/concept/numbers/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for numbers exercise",
   "authors": [
     {
       "github_username": "SleeplessByte",
@@ -7,9 +8,15 @@
   ],
   "contributors": [],
   "files": {
-    "solution": ["numbers.js"],
-    "test": ["numbers.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "numbers.js"
+    ],
+    "test": [
+      "numbers.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
   "forked_from": []
 }

--- a/exercises/concept/numbers/.meta/config.json
+++ b/exercises/concept/numbers/.meta/config.json
@@ -8,15 +8,9 @@
   ],
   "contributors": [],
   "files": {
-    "solution": [
-      "numbers.js"
-    ],
-    "test": [
-      "numbers.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["numbers.js"],
+    "test": ["numbers.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/promises/.meta/config.json
+++ b/exercises/concept/promises/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for promises exercise",
   "authors": [
     {
       "github_username": "SleeplessByte",
@@ -7,9 +8,15 @@
   ],
   "contributors": [],
   "files": {
-    "solution": ["promises.js"],
-    "test": ["promises.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "promises.js"
+    ],
+    "test": [
+      "promises.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
   "forked_from": []
 }

--- a/exercises/concept/promises/.meta/config.json
+++ b/exercises/concept/promises/.meta/config.json
@@ -8,15 +8,9 @@
   ],
   "contributors": [],
   "files": {
-    "solution": [
-      "promises.js"
-    ],
-    "test": [
-      "promises.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["promises.js"],
+    "test": ["promises.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/recursion/.meta/config.json
+++ b/exercises/concept/recursion/.meta/config.json
@@ -8,17 +8,9 @@
   ],
   "contributors": [],
   "files": {
-    "solution": [
-      "recursion.js"
-    ],
-    "test": [
-      "recursion.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["recursion.js"],
+    "test": ["recursion.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": [
-    "csharp/nullability"
-  ]
+  "forked_from": ["csharp/nullability"]
 }

--- a/exercises/concept/recursion/.meta/config.json
+++ b/exercises/concept/recursion/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for recursion exercise",
   "authors": [
     {
       "github_username": "SleeplessByte",
@@ -7,9 +8,17 @@
   ],
   "contributors": [],
   "files": {
-    "solution": ["recursion.js"],
-    "test": ["recursion.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "recursion.js"
+    ],
+    "test": [
+      "recursion.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": ["csharp/nullability"]
+  "forked_from": [
+    "csharp/nullability"
+  ]
 }

--- a/exercises/concept/strings/.meta/config.json
+++ b/exercises/concept/strings/.meta/config.json
@@ -13,15 +13,9 @@
     }
   ],
   "files": {
-    "solution": [
-      "strings.js"
-    ],
-    "test": [
-      "strings.spec.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["strings.js"],
+    "test": ["strings.spec.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "forked_from": []
 }

--- a/exercises/concept/strings/.meta/config.json
+++ b/exercises/concept/strings/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for strings exercise",
   "authors": [
     {
       "github_username": "SleeplessByte",
@@ -12,9 +13,15 @@
     }
   ],
   "files": {
-    "solution": ["strings.js"],
-    "test": ["strings.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "strings.js"
+    ],
+    "test": [
+      "strings.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
   "forked_from": []
 }

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
   "authors": [],
   "files": {
-    "solution": [
-      "accumulate.js"
-    ],
-    "test": [
-      "accumulate.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["accumulate.js"],
+    "test": ["accumulate.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
   "authors": [],
   "files": {
-    "solution": ["accumulate.js"],
-    "test": ["accumulate.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "accumulate.js"
+    ],
+    "test": [
+      "accumulate.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Convert a long phrase to its acronym",
   "authors": [],
   "files": {
-    "solution": [
-      "acronym.js"
-    ],
-    "test": [
-      "acronym.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["acronym.js"],
+    "test": ["acronym.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Julien Vanier",
   "source_url": "https://github.com/monkbroc"

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Convert a long phrase to its acronym",
   "authors": [],
   "files": {
-    "solution": ["acronym.js"],
-    "test": ["acronym.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "acronym.js"
+    ],
+    "test": [
+      "acronym.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Julien Vanier",
   "source_url": "https://github.com/monkbroc"

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East.",
   "authors": [],
   "files": {
-    "solution": [
-      "affine-cipher.js"
-    ],
-    "test": [
-      "affine-cipher.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["affine-cipher.js"],
+    "test": ["affine-cipher.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Affine_cipher"

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East.",
   "authors": [],
   "files": {
-    "solution": ["affine-cipher.js"],
-    "test": ["affine-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "affine-cipher.js"
+    ],
+    "test": [
+      "affine-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Affine_cipher"

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,8 +1,15 @@
 {
+  "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
   "authors": [],
   "files": {
-    "solution": ["all-your-base.js"],
-    "test": ["all-your-base.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "all-your-base.js"
+    ],
+    "test": [
+      "all-your-base.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -2,14 +2,8 @@
   "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
   "authors": [],
   "files": {
-    "solution": [
-      "all-your-base.js"
-    ],
-    "test": [
-      "all-your-base.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["all-your-base.js"],
+    "test": ["all-your-base.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
   "authors": [],
   "files": {
-    "solution": ["allergies.js"],
-    "test": ["allergies.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "allergies.js"
+    ],
+    "test": [
+      "allergies.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Jumpstart Lab Warm-up",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
   "authors": [],
   "files": {
-    "solution": [
-      "allergies.js"
-    ],
-    "test": [
-      "allergies.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["allergies.js"],
+    "test": ["allergies.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Jumpstart Lab Warm-up",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -1,8 +1,15 @@
 {
+  "blurb": "Write a function to solve alphametics puzzles.",
   "authors": [],
   "files": {
-    "solution": ["alphametics.js"],
-    "test": ["alphametics.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "alphametics.js"
+    ],
+    "test": [
+      "alphametics.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -2,14 +2,8 @@
   "blurb": "Write a function to solve alphametics puzzles.",
   "authors": [],
   "files": {
-    "solution": [
-      "alphametics.js"
-    ],
-    "test": [
-      "alphametics.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["alphametics.js"],
+    "test": ["alphametics.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
   "authors": [],
   "files": {
-    "solution": [
-      "anagram.js"
-    ],
-    "test": [
-      "anagram.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["anagram.js"],
+    "test": ["anagram.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
   "authors": [],
   "files": {
-    "solution": ["anagram.js"],
-    "test": ["anagram.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "anagram.js"
+    ],
+    "test": [
+      "anagram.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Determine if a number is an Armstrong number",
   "authors": [],
   "files": {
-    "solution": [
-      "armstrong-numbers.js"
-    ],
-    "test": [
-      "armstrong-numbers.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["armstrong-numbers.js"],
+    "test": ["armstrong-numbers.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number"

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Determine if a number is an Armstrong number",
   "authors": [],
   "files": {
-    "solution": ["armstrong-numbers.js"],
-    "test": ["armstrong-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "armstrong-numbers.js"
+    ],
+    "test": [
+      "armstrong-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number"

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
   "authors": [],
   "files": {
-    "solution": [
-      "atbash-cipher.js"
-    ],
-    "test": [
-      "atbash-cipher.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["atbash-cipher.js"],
+    "test": ["atbash-cipher.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Atbash"

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
   "authors": [],
   "files": {
-    "solution": ["atbash-cipher.js"],
-    "test": ["atbash-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "atbash-cipher.js"
+    ],
+    "test": [
+      "atbash-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Atbash"

--- a/exercises/practice/bank-account/.meta/config.json
+++ b/exercises/practice/bank-account/.meta/config.json
@@ -2,14 +2,8 @@
   "blurb": "Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!",
   "authors": [],
   "files": {
-    "solution": [
-      "bank-account.js"
-    ],
-    "test": [
-      "bank-account.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["bank-account.js"],
+    "test": ["bank-account.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/bank-account/.meta/config.json
+++ b/exercises/practice/bank-account/.meta/config.json
@@ -1,8 +1,15 @@
 {
+  "blurb": "Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!",
   "authors": [],
   "files": {
-    "solution": ["bank-account.js"],
-    "test": ["bank-account.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "bank-account.js"
+    ],
+    "test": [
+      "bank-account.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
   "authors": [],
   "files": {
-    "solution": [
-      "beer-song.js"
-    ],
-    "test": [
-      "beer-song.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["beer-song.js"],
+    "test": ["beer-song.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Learn to Program by Chris Pine",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
   "authors": [],
   "files": {
-    "solution": ["beer-song.js"],
-    "test": ["beer-song.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "beer-song.js"
+    ],
+    "test": [
+      "beer-song.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Learn to Program by Chris Pine",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Insert and search for numbers in a binary tree.",
   "authors": [],
   "files": {
-    "solution": [
-      "binary-search-tree.js"
-    ],
-    "test": [
-      "binary-search-tree.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["binary-search-tree.js"],
+    "test": ["binary-search-tree.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Josh Cheek",
   "source_url": "https://twitter.com/josh_cheek"

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Insert and search for numbers in a binary tree.",
   "authors": [],
   "files": {
-    "solution": ["binary-search-tree.js"],
-    "test": ["binary-search-tree.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "binary-search-tree.js"
+    ],
+    "test": [
+      "binary-search-tree.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Josh Cheek",
   "source_url": "https://twitter.com/josh_cheek"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Implement a binary search algorithm.",
   "authors": [],
   "files": {
-    "solution": ["binary-search.js"],
-    "test": ["binary-search.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "binary-search.js"
+    ],
+    "test": [
+      "binary-search.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Implement a binary search algorithm.",
   "authors": [],
   "files": {
-    "solution": [
-      "binary-search.js"
-    ],
-    "test": [
-      "binary-search.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["binary-search.js"],
+    "test": ["binary-search.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm"

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
   "authors": [],
   "files": {
-    "solution": [
-      "binary.js"
-    ],
-    "test": [
-      "binary.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["binary.js"],
+    "test": ["binary.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
   "authors": [],
   "files": {
-    "solution": ["binary.js"],
-    "test": ["binary.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "binary.js"
+    ],
+    "test": [
+      "binary.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
   "authors": [],
   "files": {
-    "solution": [
-      "bob.js"
-    ],
-    "test": [
-      "bob.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["bob.js"],
+    "test": ["bob.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
   "authors": [],
   "files": {
-    "solution": ["bob.js"],
-    "test": ["bob.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "bob.js"
+    ],
+    "test": [
+      "bob.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Score a bowling game",
   "authors": [],
   "files": {
-    "solution": ["bowling.js"],
-    "test": ["bowling.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "bowling.js"
+    ],
+    "test": [
+      "bowling.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Bowling Game Kata at but UncleBob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Score a bowling game",
   "authors": [],
   "files": {
-    "solution": [
-      "bowling.js"
-    ],
-    "test": [
-      "bowling.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["bowling.js"],
+    "test": ["bowling.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Bowling Game Kata at but UncleBob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Correctly determine change to be given using the least number of coins",
   "authors": [],
   "files": {
-    "solution": ["change.js"],
-    "test": ["change.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "change.js"
+    ],
+    "test": [
+      "change.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Software Craftsmanship - Coin Change Kata",
   "source_url": "https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata"

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Correctly determine change to be given using the least number of coins",
   "authors": [],
   "files": {
-    "solution": [
-      "change.js"
-    ],
-    "test": [
-      "change.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["change.js"],
+    "test": ["change.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Software Craftsmanship - Coin Change Kata",
   "source_url": "https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata"

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end.",
   "authors": [],
   "files": {
-    "solution": [
-      "circular-buffer.js"
-    ],
-    "test": [
-      "circular-buffer.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["circular-buffer.js"],
+    "test": ["circular-buffer.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Circular_buffer"

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end.",
   "authors": [],
   "files": {
-    "solution": ["circular-buffer.js"],
-    "test": ["circular-buffer.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "circular-buffer.js"
+    ],
+    "test": [
+      "circular-buffer.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Circular_buffer"

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Implement a clock that handles times without dates.",
   "authors": [],
   "files": {
-    "solution": ["clock.js"],
-    "test": ["clock.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "clock.js"
+    ],
+    "test": [
+      "clock.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Pairing session with Erin Drummond",
   "source_url": "https://twitter.com/ebdrummond"

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Implement a clock that handles times without dates.",
   "authors": [],
   "files": {
-    "solution": [
-      "clock.js"
-    ],
-    "test": [
-      "clock.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["clock.js"],
+    "test": ["clock.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Pairing session with Erin Drummond",
   "source_url": "https://twitter.com/ebdrummond"

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
   "authors": [],
   "files": {
-    "solution": ["collatz-conjecture.js"],
-    "test": ["collatz-conjecture.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "collatz-conjecture.js"
+    ],
+    "test": [
+      "collatz-conjecture.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
   "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
   "authors": [],
   "files": {
-    "solution": [
-      "collatz-conjecture.js"
-    ],
-    "test": [
-      "collatz-conjecture.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["collatz-conjecture.js"],
+    "test": ["collatz-conjecture.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
   "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Implement complex numbers.",
   "authors": [],
   "files": {
-    "solution": ["complex-numbers.js"],
-    "test": ["complex-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "complex-numbers.js"
+    ],
+    "test": [
+      "complex-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Complex_number"

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Implement complex numbers.",
   "authors": [],
   "files": {
-    "solution": [
-      "complex-numbers.js"
-    ],
-    "test": [
-      "complex-numbers.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["complex-numbers.js"],
+    "test": ["complex-numbers.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Complex_number"

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -2,14 +2,8 @@
   "blurb": "Compute the result for a game of Hex / Polygon",
   "authors": [],
   "files": {
-    "solution": [
-      "connect.js"
-    ],
-    "test": [
-      "connect.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["connect.js"],
+    "test": ["connect.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -1,8 +1,15 @@
 {
+  "blurb": "Compute the result for a game of Hex / Polygon",
   "authors": [],
   "files": {
-    "solution": ["connect.js"],
-    "test": ["connect.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "connect.js"
+    ],
+    "test": [
+      "connect.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Implement the classic method for composing secret messages called a square code.",
   "authors": [],
   "files": {
-    "solution": ["crypto-square.js"],
-    "test": ["crypto-square.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "crypto-square.js"
+    ],
+    "test": [
+      "crypto-square.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Implement the classic method for composing secret messages called a square code.",
   "authors": [],
   "files": {
-    "solution": [
-      "crypto-square.js"
-    ],
-    "test": [
-      "crypto-square.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["crypto-square.js"],
+    "test": ["crypto-square.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -1,8 +1,15 @@
 {
+  "blurb": "Create a custom set type.",
   "authors": [],
   "files": {
-    "solution": ["custom-set.js"],
-    "test": ["custom-set.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "custom-set.js"
+    ],
+    "test": [
+      "custom-set.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -2,14 +2,8 @@
   "blurb": "Create a custom set type.",
   "authors": [],
   "files": {
-    "solution": [
-      "custom-set.js"
-    ],
-    "test": [
-      "custom-set.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["custom-set.js"],
+    "test": ["custom-set.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
   "authors": [],
   "files": {
-    "solution": [
-      "darts.js"
-    ],
-    "test": [
-      "darts.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["darts.js"],
+    "test": ["darts.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
 }

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
   "authors": [],
   "files": {
-    "solution": ["darts.js"],
-    "test": ["darts.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "darts.js"
+    ],
+    "test": [
+      "darts.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
 }

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.",
   "authors": [],
   "files": {
-    "solution": [
-      "diamond.js"
-    ],
-    "test": [
-      "diamond.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["diamond.js"],
+    "test": ["diamond.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Seb Rose",
   "source_url": "http://claysnow.co.uk/recycling-tests-in-tdd/"

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.",
   "authors": [],
   "files": {
-    "solution": ["diamond.js"],
-    "test": ["diamond.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "diamond.js"
+    ],
+    "test": [
+      "diamond.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Seb Rose",
   "source_url": "http://claysnow.co.uk/recycling-tests-in-tdd/"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "authors": [],
   "files": {
-    "solution": ["difference-of-squares.js"],
-    "test": ["difference-of-squares.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "difference-of-squares.js"
+    ],
+    "test": [
+      "difference-of-squares.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Problem 6 at Project Euler",
   "source_url": "http://projecteuler.net/problem=6"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "authors": [],
   "files": {
-    "solution": [
-      "difference-of-squares.js"
-    ],
-    "test": [
-      "difference-of-squares.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["difference-of-squares.js"],
+    "test": ["difference-of-squares.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Problem 6 at Project Euler",
   "source_url": "http://projecteuler.net/problem=6"

--- a/exercises/practice/diffie-hellman/.meta/config.json
+++ b/exercises/practice/diffie-hellman/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Diffie-Hellman key exchange.",
   "authors": [],
   "files": {
-    "solution": [
-      "diffie-hellman.js"
-    ],
-    "test": [
-      "diffie-hellman.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["diffie-hellman.js"],
+    "test": ["diffie-hellman.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia, 1024 bit key from www.cryptopp.com/wiki.",
   "source_url": "http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange"

--- a/exercises/practice/diffie-hellman/.meta/config.json
+++ b/exercises/practice/diffie-hellman/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Diffie-Hellman key exchange.",
   "authors": [],
   "files": {
-    "solution": ["diffie-hellman.js"],
-    "test": ["diffie-hellman.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "diffie-hellman.js"
+    ],
+    "test": [
+      "diffie-hellman.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia, 1024 bit key from www.cryptopp.com/wiki.",
   "source_url": "http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange"

--- a/exercises/practice/dnd-character/.meta/config.json
+++ b/exercises/practice/dnd-character/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Randomly generate Dungeons & Dragons characters",
   "authors": [],
   "files": {
-    "solution": [
-      "dnd-character.js"
-    ],
-    "test": [
-      "dnd-character.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["dnd-character.js"],
+    "test": ["dnd-character.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Simon Shine, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/616#issuecomment-437358945"

--- a/exercises/practice/dnd-character/.meta/config.json
+++ b/exercises/practice/dnd-character/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Randomly generate Dungeons & Dragons characters",
   "authors": [],
   "files": {
-    "solution": ["dnd-character.js"],
-    "test": ["dnd-character.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "dnd-character.js"
+    ],
+    "test": [
+      "dnd-character.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Simon Shine, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/616#issuecomment-437358945"

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -1,8 +1,15 @@
 {
+  "blurb": "Make a chain of dominoes.",
   "authors": [],
   "files": {
-    "solution": ["dominoes.js"],
-    "test": ["dominoes.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "dominoes.js"
+    ],
+    "test": [
+      "dominoes.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -2,14 +2,8 @@
   "blurb": "Make a chain of dominoes.",
   "authors": [],
   "files": {
-    "solution": [
-      "dominoes.js"
-    ],
-    "test": [
-      "dominoes.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["dominoes.js"],
+    "test": ["dominoes.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
   "authors": [],
   "files": {
-    "solution": [
-      "etl.js"
-    ],
-    "test": [
-      "etl.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["etl.js"],
+    "test": ["etl.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Jumpstart Lab team",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
   "authors": [],
   "files": {
-    "solution": ["etl.js"],
-    "test": ["etl.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "etl.js"
+    ],
+    "test": [
+      "etl.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Jumpstart Lab team",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Take a nested list and return a single list with all values except nil/null",
   "authors": [],
   "files": {
-    "solution": [
-      "flatten-array.js"
-    ],
-    "test": [
-      "flatten-array.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["flatten-array.js"],
+    "test": ["flatten-array.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Interview Question",
   "source_url": "https://reference.wolfram.com/language/ref/Flatten.html"

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Take a nested list and return a single list with all values except nil/null",
   "authors": [],
   "files": {
-    "solution": ["flatten-array.js"],
-    "test": ["flatten-array.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "flatten-array.js"
+    ],
+    "test": [
+      "flatten-array.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Interview Question",
   "source_url": "https://reference.wolfram.com/language/ref/Flatten.html"

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'",
   "authors": [],
   "files": {
-    "solution": ["food-chain.js"],
-    "test": ["food-chain.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "food-chain.js"
+    ],
+    "test": [
+      "food-chain.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly"

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'",
   "authors": [],
   "files": {
-    "solution": [
-      "food-chain.js"
-    ],
-    "test": [
-      "food-chain.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["food-chain.js"],
+    "test": ["food-chain.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly"

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -2,14 +2,8 @@
   "blurb": "Implement an evaluator for a very simple subset of Forth",
   "authors": [],
   "files": {
-    "solution": [
-      "forth.js"
-    ],
-    "test": [
-      "forth.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["forth.js"],
+    "test": ["forth.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -1,8 +1,15 @@
 {
+  "blurb": "Implement an evaluator for a very simple subset of Forth",
   "authors": [],
   "files": {
-    "solution": ["forth.js"],
-    "test": ["forth.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "forth.js"
+    ],
+    "test": [
+      "forth.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
   "authors": [],
   "files": {
-    "solution": ["gigasecond.js"],
-    "test": ["gigasecond.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "gigasecond.js"
+    ],
+    "test": [
+      "gigasecond.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=09"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
   "authors": [],
   "files": {
-    "solution": [
-      "gigasecond.js"
-    ],
-    "test": [
-      "gigasecond.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["gigasecond.js"],
+    "test": ["gigasecond.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=09"

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
   "authors": [],
   "files": {
-    "solution": [
-      "grade-school.js"
-    ],
-    "test": [
-      "grade-school.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["grade-school.js"],
+    "test": ["grade-school.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A pairing session with Phil Battos at gSchool",
   "source_url": "http://gschool.it"

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
   "authors": [],
   "files": {
-    "solution": ["grade-school.js"],
-    "test": ["grade-school.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "grade-school.js"
+    ],
+    "test": [
+      "grade-school.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A pairing session with Phil Battos at gSchool",
   "source_url": "http://gschool.it"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
   "authors": [],
   "files": {
-    "solution": ["grains.js"],
-    "test": ["grains.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "grains.js"
+    ],
+    "test": [
+      "grains.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "JavaRanch Cattle Drive, exercise 6",
   "source_url": "http://www.javaranch.com/grains.jsp"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
   "authors": [],
   "files": {
-    "solution": [
-      "grains.js"
-    ],
-    "test": [
-      "grains.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["grains.js"],
+    "test": ["grains.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "JavaRanch Cattle Drive, exercise 6",
   "source_url": "http://www.javaranch.com/grains.jsp"

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line.",
   "authors": [],
   "files": {
-    "solution": [
-      "grep.js"
-    ],
-    "test": [
-      "grep.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["grep.js"],
+    "test": ["grep.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Conversation with Nate Foster.",
   "source_url": "http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf"

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line.",
   "authors": [],
   "files": {
-    "solution": ["grep.js"],
-    "test": ["grep.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "grep.js"
+    ],
+    "test": [
+      "grep.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Conversation with Nate Foster.",
   "source_url": "http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Calculate the Hamming difference between two DNA strands.",
   "authors": [],
   "files": {
-    "solution": [
-      "hamming.js"
-    ],
-    "test": [
-      "hamming.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["hamming.js"],
+    "test": ["hamming.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Calculate the Hamming difference between two DNA strands.",
   "authors": [],
   "files": {
-    "solution": ["hamming.js"],
-    "test": ["hamming.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "hamming.js"
+    ],
+    "test": [
+      "hamming.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
   "authors": [],
   "files": {
-    "solution": ["hello-world.js"],
-    "test": ["hello-world.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "hello-world.js"
+    ],
+    "test": [
+      "hello-world.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
   "authors": [],
   "files": {
-    "solution": [
-      "hello-world.js"
-    ],
-    "test": [
-      "hello-world.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["hello-world.js"],
+    "test": ["hello-world.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"

--- a/exercises/practice/hexadecimal/.meta/config.json
+++ b/exercises/practice/hexadecimal/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Convert a hexadecimal number, represented as a string (e.g. \"10af8c\"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
   "authors": [],
   "files": {
-    "solution": ["hexadecimal.js"],
-    "test": ["hexadecimal.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "hexadecimal.js"
+    ],
+    "test": [
+      "hexadecimal.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/examples/NumberBases.html"

--- a/exercises/practice/hexadecimal/.meta/config.json
+++ b/exercises/practice/hexadecimal/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Convert a hexadecimal number, represented as a string (e.g. \"10af8c\"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
   "authors": [],
   "files": {
-    "solution": [
-      "hexadecimal.js"
-    ],
-    "test": [
-      "hexadecimal.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["hexadecimal.js"],
+    "test": ["hexadecimal.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/examples/NumberBases.html"

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Manage a player's High Score list",
   "authors": [],
   "files": {
-    "solution": [
-      "high-scores.js"
-    ],
-    "test": [
-      "high-scores.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["high-scores.js"],
+    "test": ["high-scores.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Tribute to the eighties' arcade game Frogger"
 }

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Manage a player's High Score list",
   "authors": [],
   "files": {
-    "solution": ["high-scores.js"],
-    "test": ["high-scores.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "high-scores.js"
+    ],
+    "test": [
+      "high-scores.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Tribute to the eighties' arcade game Frogger"
 }

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Output the nursery rhyme 'This is the House that Jack Built'.",
   "authors": [],
   "files": {
-    "solution": ["house.js"],
-    "test": ["house.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "house.js"
+    ],
+    "test": [
+      "house.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "British nursery rhyme",
   "source_url": "http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built"

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Output the nursery rhyme 'This is the House that Jack Built'.",
   "authors": [],
   "files": {
-    "solution": [
-      "house.js"
-    ],
-    "test": [
-      "house.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["house.js"],
+    "test": ["house.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "British nursery rhyme",
   "source_url": "http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built"

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Check if a given string is a valid ISBN-10 number.",
   "authors": [],
   "files": {
-    "solution": ["isbn-verifier.js"],
-    "test": ["isbn-verifier.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "isbn-verifier.js"
+    ],
+    "test": [
+      "isbn-verifier.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Converting a string into a number and some basic processing utilizing a relatable real world example.",
   "source_url": "https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation"

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Check if a given string is a valid ISBN-10 number.",
   "authors": [],
   "files": {
-    "solution": [
-      "isbn-verifier.js"
-    ],
-    "test": [
-      "isbn-verifier.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["isbn-verifier.js"],
+    "test": ["isbn-verifier.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Converting a string into a number and some basic processing utilizing a relatable real world example.",
   "source_url": "https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation"

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Determine if a word or phrase is an isogram.",
   "authors": [],
   "files": {
-    "solution": ["isogram.js"],
-    "test": ["isogram.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "isogram.js"
+    ],
+    "test": [
+      "isogram.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Isogram"

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Determine if a word or phrase is an isogram.",
   "authors": [],
   "files": {
-    "solution": [
-      "isogram.js"
-    ],
-    "test": [
-      "isogram.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["isogram.js"],
+    "test": ["isogram.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Isogram"

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a diagram, determine which plants each child in the kindergarten class is responsible for.",
   "authors": [],
   "files": {
-    "solution": ["kindergarten-garden.js"],
-    "test": ["kindergarten-garden.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "kindergarten-garden.js"
+    ],
+    "test": [
+      "kindergarten-garden.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Random musings during airplane trip.",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a diagram, determine which plants each child in the kindergarten class is responsible for.",
   "authors": [],
   "files": {
-    "solution": [
-      "kindergarten-garden.js"
-    ],
-    "test": [
-      "kindergarten-garden.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["kindergarten-garden.js"],
+    "test": ["kindergarten-garden.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Random musings during airplane trip.",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
   "authors": [],
   "files": {
-    "solution": ["largest-series-product.js"],
-    "test": ["largest-series-product.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "largest-series-product.js"
+    ],
+    "test": [
+      "largest-series-product.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A variation on Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
   "authors": [],
   "files": {
-    "solution": [
-      "largest-series-product.js"
-    ],
-    "test": [
-      "largest-series-product.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["largest-series-product.js"],
+    "test": ["largest-series-product.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a year, report if it is a leap year.",
   "authors": [],
   "files": {
-    "solution": [
-      "leap.js"
-    ],
-    "test": [
-      "leap.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["leap.js"],
+    "test": ["leap.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "JavaRanch Cattle Drive, exercise 3",
   "source_url": "http://www.javaranch.com/leap.jsp"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a year, report if it is a leap year.",
   "authors": [],
   "files": {
-    "solution": ["leap.js"],
-    "test": ["leap.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "leap.js"
+    ],
+    "test": [
+      "leap.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "JavaRanch Cattle Drive, exercise 3",
   "source_url": "http://www.javaranch.com/leap.jsp"

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Implement a doubly linked list",
   "authors": [],
   "files": {
-    "solution": ["linked-list.js"],
-    "test": ["linked-list.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "linked-list.js"
+    ],
+    "test": [
+      "linked-list.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Classic computer science topic"
 }

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Implement a doubly linked list",
   "authors": [],
   "files": {
-    "solution": [
-      "linked-list.js"
-    ],
-    "test": [
-      "linked-list.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["linked-list.js"],
+    "test": ["linked-list.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Classic computer science topic"
 }

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,8 +1,15 @@
 {
+  "blurb": "Implement basic list operations",
   "authors": [],
   "files": {
-    "solution": ["list-ops.js"],
-    "test": ["list-ops.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "list-ops.js"
+    ],
+    "test": [
+      "list-ops.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -2,14 +2,8 @@
   "blurb": "Implement basic list operations",
   "authors": [],
   "files": {
-    "solution": [
-      "list-ops.js"
-    ],
-    "test": [
-      "list-ops.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["list-ops.js"],
+    "test": ["list-ops.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
   "authors": [],
   "files": {
-    "solution": [
-      "luhn.js"
-    ],
-    "test": [
-      "luhn.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["luhn.js"],
+    "test": ["luhn.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Luhn Algorithm on Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm"

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
   "authors": [],
   "files": {
-    "solution": ["luhn.js"],
-    "test": ["luhn.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "luhn.js"
+    ],
+    "test": [
+      "luhn.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Luhn Algorithm on Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm"

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Make sure the brackets and braces all match.",
   "authors": [],
   "files": {
-    "solution": [
-      "matching-brackets.js"
-    ],
-    "test": [
-      "matching-brackets.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["matching-brackets.js"],
+    "test": ["matching-brackets.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Ginna Baker"
 }

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Make sure the brackets and braces all match.",
   "authors": [],
   "files": {
-    "solution": ["matching-brackets.js"],
-    "test": ["matching-brackets.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "matching-brackets.js"
+    ],
+    "test": [
+      "matching-brackets.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Ginna Baker"
 }

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a string representing a matrix of numbers, return the rows and columns of that matrix.",
   "authors": [],
   "files": {
-    "solution": [
-      "matrix.js"
-    ],
-    "test": [
-      "matrix.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["matrix.js"],
+    "test": ["matrix.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Warmup to the `saddle-points` warmup.",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a string representing a matrix of numbers, return the rows and columns of that matrix.",
   "authors": [],
   "files": {
-    "solution": ["matrix.js"],
-    "test": ["matrix.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "matrix.js"
+    ],
+    "test": [
+      "matrix.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Warmup to the `saddle-points` warmup.",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Calculate the date of meetups.",
   "authors": [],
   "files": {
-    "solution": ["meetup.js"],
-    "test": ["meetup.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "meetup.js"
+    ],
+    "test": [
+      "meetup.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
   "source_url": "https://twitter.com/copiousfreetime"

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Calculate the date of meetups.",
   "authors": [],
   "files": {
-    "solution": [
-      "meetup.js"
-    ],
-    "test": [
-      "meetup.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["meetup.js"],
+    "test": ["meetup.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
   "source_url": "https://twitter.com/copiousfreetime"

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -2,14 +2,8 @@
   "blurb": "Add the numbers to a minesweeper board",
   "authors": [],
   "files": {
-    "solution": [
-      "minesweeper.js"
-    ],
-    "test": [
-      "minesweeper.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["minesweeper.js"],
+    "test": ["minesweeper.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -1,8 +1,15 @@
 {
+  "blurb": "Add the numbers to a minesweeper board",
   "authors": [],
   "files": {
-    "solution": ["minesweeper.js"],
-    "test": ["minesweeper.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "minesweeper.js"
+    ],
+    "test": [
+      "minesweeper.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a number n, determine what the nth prime is.",
   "authors": [],
   "files": {
-    "solution": ["nth-prime.js"],
-    "test": ["nth-prime.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "nth-prime.js"
+    ],
+    "test": [
+      "nth-prime.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A variation on Problem 7 at Project Euler",
   "source_url": "http://projecteuler.net/problem=7"

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a number n, determine what the nth prime is.",
   "authors": [],
   "files": {
-    "solution": [
-      "nth-prime.js"
-    ],
-    "test": [
-      "nth-prime.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["nth-prime.js"],
+    "test": ["nth-prime.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on Problem 7 at Project Euler",
   "source_url": "http://projecteuler.net/problem=7"

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
   "authors": [],
   "files": {
-    "solution": ["nucleotide-count.js"],
-    "test": ["nucleotide-count.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "nucleotide-count.js"
+    ],
+    "test": [
+      "nucleotide-count.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
   "source_url": "http://rosalind.info/problems/dna/"

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
   "authors": [],
   "files": {
-    "solution": [
-      "nucleotide-count.js"
-    ],
-    "test": [
-      "nucleotide-count.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["nucleotide-count.js"],
+    "test": ["nucleotide-count.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
   "source_url": "http://rosalind.info/problems/dna/"

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.",
   "authors": [],
   "files": {
-    "solution": [
-      "ocr-numbers.js"
-    ],
-    "test": [
-      "ocr-numbers.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["ocr-numbers.js"],
+    "test": ["ocr-numbers.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the Bank OCR kata",
   "source_url": "http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR"

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.",
   "authors": [],
   "files": {
-    "solution": ["ocr-numbers.js"],
-    "test": ["ocr-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "ocr-numbers.js"
+    ],
+    "test": [
+      "ocr-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by the Bank OCR kata",
   "source_url": "http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR"

--- a/exercises/practice/octal/.meta/config.json
+++ b/exercises/practice/octal/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
   "authors": [],
   "files": {
-    "solution": ["octal.js"],
-    "test": ["octal.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "octal.js"
+    ],
+    "test": [
+      "octal.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=base+8"

--- a/exercises/practice/octal/.meta/config.json
+++ b/exercises/practice/octal/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
   "authors": [],
   "files": {
-    "solution": [
-      "octal.js"
-    ],
-    "test": [
-      "octal.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["octal.js"],
+    "test": ["octal.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=base+8"

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Detect palindrome products in a given range.",
   "authors": [],
   "files": {
-    "solution": [
-      "palindrome-products.js"
-    ],
-    "test": [
-      "palindrome-products.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["palindrome-products.js"],
+    "test": ["palindrome-products.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Problem 4 at Project Euler",
   "source_url": "http://projecteuler.net/problem=4"

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Detect palindrome products in a given range.",
   "authors": [],
   "files": {
-    "solution": ["palindrome-products.js"],
-    "test": ["palindrome-products.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "palindrome-products.js"
+    ],
+    "test": [
+      "palindrome-products.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Problem 4 at Project Euler",
   "source_url": "http://projecteuler.net/problem=4"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Determine if a sentence is a pangram.",
   "authors": [],
   "files": {
-    "solution": [
-      "pangram.js"
-    ],
-    "test": [
-      "pangram.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["pangram.js"],
+    "test": ["pangram.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Pangram"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Determine if a sentence is a pangram.",
   "authors": [],
   "files": {
-    "solution": ["pangram.js"],
-    "test": ["pangram.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pangram.js"
+    ],
+    "test": [
+      "pangram.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Pangram"

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Compute Pascal's triangle up to a given number of rows.",
   "authors": [],
   "files": {
-    "solution": ["pascals-triangle.js"],
-    "test": ["pascals-triangle.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pascals-triangle.js"
+    ],
+    "test": [
+      "pascals-triangle.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Pascal's Triangle at Wolfram Math World",
   "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html"

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
   "authors": [],
   "files": {
-    "solution": [
-      "pascals-triangle.js"
-    ],
-    "test": [
-      "pascals-triangle.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["pascals-triangle.js"],
+    "test": ["pascals-triangle.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Pascal's Triangle at Wolfram Math World",
   "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html"

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
   "authors": [],
   "files": {
-    "solution": [
-      "perfect-numbers.js"
-    ],
-    "test": [
-      "perfect-numbers.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["perfect-numbers.js"],
+    "test": ["perfect-numbers.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
   "source_url": "http://shop.oreilly.com/product/0636920029687.do"

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
   "authors": [],
   "files": {
-    "solution": ["perfect-numbers.js"],
-    "test": ["perfect-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "perfect-numbers.js"
+    ],
+    "test": [
+      "perfect-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
   "source_url": "http://shop.oreilly.com/product/0636920029687.do"

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
   "authors": [],
   "files": {
-    "solution": [
-      "phone-number.js"
-    ],
-    "test": [
-      "phone-number.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["phone-number.js"],
+    "test": ["phone-number.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Event Manager by JumpstartLab",
   "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html"

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
   "authors": [],
   "files": {
-    "solution": ["phone-number.js"],
-    "test": ["phone-number.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "phone-number.js"
+    ],
+    "test": [
+      "phone-number.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Event Manager by JumpstartLab",
   "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html"

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Implement a program that translates from English to Pig Latin",
   "authors": [],
   "files": {
-    "solution": ["pig-latin.js"],
-    "test": ["pig-latin.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pig-latin.js"
+    ],
+    "test": [
+      "pig-latin.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",
   "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/"

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Implement a program that translates from English to Pig Latin",
   "authors": [],
   "files": {
-    "solution": [
-      "pig-latin.js"
-    ],
-    "test": [
-      "pig-latin.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["pig-latin.js"],
+    "test": ["pig-latin.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",
   "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/"

--- a/exercises/practice/point-mutations/.meta/config.json
+++ b/exercises/practice/point-mutations/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Calculate the Hamming difference between two DNA strands.",
   "authors": [],
   "files": {
-    "solution": [
-      "point-mutations.js"
-    ],
-    "test": [
-      "point-mutations.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["point-mutations.js"],
+    "test": ["point-mutations.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/point-mutations/.meta/config.json
+++ b/exercises/practice/point-mutations/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Calculate the Hamming difference between two DNA strands.",
   "authors": [],
   "files": {
-    "solution": ["point-mutations.js"],
-    "test": ["point-mutations.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "point-mutations.js"
+    ],
+    "test": [
+      "point-mutations.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Compute the prime factors of a given natural number.",
   "authors": [],
   "files": {
-    "solution": ["prime-factors.js"],
-    "test": ["prime-factors.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "prime-factors.js"
+    ],
+    "test": [
+      "prime-factors.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Prime Factors Kata by Uncle Bob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata"

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Compute the prime factors of a given natural number.",
   "authors": [],
   "files": {
-    "solution": [
-      "prime-factors.js"
-    ],
-    "test": [
-      "prime-factors.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["prime-factors.js"],
+    "test": ["prime-factors.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Prime Factors Kata by Uncle Bob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata"

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Translate RNA sequences into proteins.",
   "authors": [],
   "files": {
-    "solution": ["protein-translation.js"],
-    "test": ["protein-translation.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "protein-translation.js"
+    ],
+    "test": [
+      "protein-translation.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Tyler Long"
 }

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Translate RNA sequences into proteins.",
   "authors": [],
   "files": {
-    "solution": [
-      "protein-translation.js"
-    ],
-    "test": [
-      "protein-translation.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["protein-translation.js"],
+    "test": ["protein-translation.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Tyler Long"
 }

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
   "authors": [],
   "files": {
-    "solution": ["proverb.js"],
-    "test": ["proverb.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "proverb.js"
+    ],
+    "test": [
+      "proverb.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/For_Want_of_a_Nail"

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
   "authors": [],
   "files": {
-    "solution": [
-      "proverb.js"
-    ],
-    "test": [
-      "proverb.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["proverb.js"],
+    "test": ["proverb.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/For_Want_of_a_Nail"

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
   "authors": [],
   "files": {
-    "solution": [
-      "pythagorean-triplet.js"
-    ],
-    "test": [
-      "pythagorean-triplet.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["pythagorean-triplet.js"],
+    "test": ["pythagorean-triplet.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Problem 9 at Project Euler",
   "source_url": "http://projecteuler.net/problem=9"

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
   "authors": [],
   "files": {
-    "solution": ["pythagorean-triplet.js"],
-    "test": ["pythagorean-triplet.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pythagorean-triplet.js"
+    ],
+    "test": [
+      "pythagorean-triplet.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Problem 9 at Project Euler",
   "source_url": "http://projecteuler.net/problem=9"

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
   "authors": [],
   "files": {
-    "solution": [
-      "queen-attack.js"
-    ],
-    "test": [
-      "queen-attack.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["queen-attack.js"],
+    "test": ["queen-attack.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
   "authors": [],
   "files": {
-    "solution": ["queen-attack.js"],
-    "test": ["queen-attack.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "queen-attack.js"
+    ],
+    "test": [
+      "queen-attack.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
   "authors": [],
   "files": {
-    "solution": ["raindrops.js"],
-    "test": ["raindrops.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "raindrops.js"
+    ],
+    "test": [
+      "raindrops.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
   "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
   "authors": [],
   "files": {
-    "solution": [
-      "raindrops.js"
-    ],
-    "test": [
-      "raindrops.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["raindrops.js"],
+    "test": ["raindrops.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
   "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz"

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Implement rational numbers.",
   "authors": [],
   "files": {
-    "solution": ["rational-numbers.js"],
-    "test": ["rational-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rational-numbers.js"
+    ],
+    "test": [
+      "rational-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Rational_number"

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Implement rational numbers.",
   "authors": [],
   "files": {
-    "solution": [
-      "rational-numbers.js"
-    ],
-    "test": [
-      "rational-numbers.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["rational-numbers.js"],
+    "test": ["rational-numbers.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Rational_number"

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -1,8 +1,15 @@
 {
+  "blurb": "Implement a basic reactive system.",
   "authors": [],
   "files": {
-    "solution": ["react.js"],
-    "test": ["react.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "react.js"
+    ],
+    "test": [
+      "react.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -2,14 +2,8 @@
   "blurb": "Implement a basic reactive system.",
   "authors": [],
   "files": {
-    "solution": [
-      "react.js"
-    ],
-    "test": [
-      "react.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["react.js"],
+    "test": ["react.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -2,14 +2,8 @@
   "blurb": "Count the rectangles in an ASCII diagram.",
   "authors": [],
   "files": {
-    "solution": [
-      "rectangles.js"
-    ],
-    "test": [
-      "rectangles.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["rectangles.js"],
+    "test": ["rectangles.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -1,8 +1,15 @@
 {
+  "blurb": "Count the rectangles in an ASCII diagram.",
   "authors": [],
   "files": {
-    "solution": ["rectangles.js"],
-    "test": ["rectangles.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rectangles.js"
+    ],
+    "test": [
+      "rectangles.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Convert color codes, as used on resistors, to a numeric value.",
   "authors": [],
   "files": {
-    "solution": ["resistor-color-duo.js"],
-    "test": ["resistor-color-duo.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "resistor-color-duo.js"
+    ],
+    "test": [
+      "resistor-color-duo.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1464"

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Convert color codes, as used on resistors, to a numeric value.",
   "authors": [],
   "files": {
-    "solution": [
-      "resistor-color-duo.js"
-    ],
-    "test": [
-      "resistor-color-duo.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["resistor-color-duo.js"],
+    "test": ["resistor-color-duo.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1464"

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Convert color codes, as used on resistors, to a human-readable label.",
   "authors": [],
   "files": {
-    "solution": [
-      "resistor-color-trio.js"
-    ],
-    "test": [
-      "resistor-color-trio.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["resistor-color-trio.js"],
+    "test": ["resistor-color-trio.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1549"

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Convert color codes, as used on resistors, to a human-readable label.",
   "authors": [],
   "files": {
-    "solution": ["resistor-color-trio.js"],
-    "test": ["resistor-color-trio.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "resistor-color-trio.js"
+    ],
+    "test": [
+      "resistor-color-trio.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1549"

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Convert a resistor band's color to its numeric representation",
   "authors": [],
   "files": {
-    "solution": ["resistor-color.js"],
-    "test": ["resistor-color.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "resistor-color.js"
+    ],
+    "test": [
+      "resistor-color.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1458"

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Convert a resistor band's color to its numeric representation",
   "authors": [],
   "files": {
-    "solution": [
-      "resistor-color.js"
-    ],
-    "test": [
-      "resistor-color.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["resistor-color.js"],
+    "test": ["resistor-color.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1458"

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Reverse a string",
   "authors": [],
   "files": {
-    "solution": ["reverse-string.js"],
-    "test": ["reverse-string.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "reverse-string.js"
+    ],
+    "test": [
+      "reverse-string.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Introductory challenge to reverse an input string",
   "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Reverse a string",
   "authors": [],
   "files": {
-    "solution": [
-      "reverse-string.js"
-    ],
-    "test": [
-      "reverse-string.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["reverse-string.js"],
+    "test": ["reverse-string.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Introductory challenge to reverse an input string",
   "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "authors": [],
   "files": {
-    "solution": ["rna-transcription.js"],
-    "test": ["rna-transcription.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rna-transcription.js"
+    ],
+    "test": [
+      "rna-transcription.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Hyperphysics",
   "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "authors": [],
   "files": {
-    "solution": [
-      "rna-transcription.js"
-    ],
-    "test": [
-      "rna-transcription.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["rna-transcription.js"],
+    "test": ["rna-transcription.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Hyperphysics",
   "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Manage robot factory settings.",
   "authors": [],
   "files": {
-    "solution": ["robot-name.js"],
-    "test": ["robot-name.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "robot-name.js"
+    ],
+    "test": [
+      "robot-name.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A debugging session with Paul Blackwell at gSchool."
 }

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Manage robot factory settings.",
   "authors": [],
   "files": {
-    "solution": [
-      "robot-name.js"
-    ],
-    "test": [
-      "robot-name.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["robot-name.js"],
+    "test": ["robot-name.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A debugging session with Paul Blackwell at gSchool."
 }

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Write a robot simulator.",
   "authors": [],
   "files": {
-    "solution": [
-      "robot-simulator.js"
-    ],
-    "test": [
-      "robot-simulator.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["robot-simulator.js"],
+    "test": ["robot-simulator.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by an interview question at a famous company.",
   "source_url": ""

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Write a robot simulator.",
   "authors": [],
   "files": {
-    "solution": ["robot-simulator.js"],
-    "test": ["robot-simulator.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "robot-simulator.js"
+    ],
+    "test": [
+      "robot-simulator.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by an interview question at a famous company.",
   "source_url": ""

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
   "authors": [],
   "files": {
-    "solution": ["roman-numerals.js"],
-    "test": ["roman-numerals.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "roman-numerals.js"
+    ],
+    "test": [
+      "roman-numerals.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Roman Numeral Kata",
   "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals"

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
   "authors": [],
   "files": {
-    "solution": [
-      "roman-numerals.js"
-    ],
-    "test": [
-      "roman-numerals.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["roman-numerals.js"],
+    "test": ["roman-numerals.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Roman Numeral Kata",
   "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals"

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
   "authors": [],
   "files": {
-    "solution": [
-      "rotational-cipher.js"
-    ],
-    "test": [
-      "rotational-cipher.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["rotational-cipher.js"],
+    "test": ["rotational-cipher.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Caesar_cipher"

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
   "authors": [],
   "files": {
-    "solution": ["rotational-cipher.js"],
-    "test": ["rotational-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rotational-cipher.js"
+    ],
+    "test": [
+      "rotational-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Caesar_cipher"

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Implement run-length encoding and decoding.",
   "authors": [],
   "files": {
-    "solution": [
-      "run-length-encoding.js"
-    ],
-    "test": [
-      "run-length-encoding.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["run-length-encoding.js"],
+    "test": ["run-length-encoding.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Run-length_encoding"

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Implement run-length encoding and decoding.",
   "authors": [],
   "files": {
-    "solution": ["run-length-encoding.js"],
-    "test": ["run-length-encoding.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "run-length-encoding.js"
+    ],
+    "test": [
+      "run-length-encoding.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Run-length_encoding"

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Detect saddle points in a matrix.",
   "authors": [],
   "files": {
-    "solution": [
-      "saddle-points.js"
-    ],
-    "test": [
-      "saddle-points.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["saddle-points.js"],
+    "test": ["saddle-points.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Detect saddle points in a matrix.",
   "authors": [],
   "files": {
-    "solution": ["saddle-points.js"],
-    "test": ["saddle-points.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "saddle-points.js"
+    ],
+    "test": [
+      "saddle-points.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
   "authors": [],
   "files": {
-    "solution": [
-      "say.js"
-    ],
-    "test": [
-      "say.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["say.js"],
+    "test": ["say.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on JavaRanch CattleDrive, exercise 4a",
   "source_url": "http://www.javaranch.com/say.jsp"

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
   "authors": [],
   "files": {
-    "solution": ["say.js"],
-    "test": ["say.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "say.js"
+    ],
+    "test": [
+      "say.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A variation on JavaRanch CattleDrive, exercise 4a",
   "source_url": "http://www.javaranch.com/say.jsp"

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -2,14 +2,8 @@
   "blurb": "Generate musical scales, given a starting note and a set of intervals. ",
   "authors": [],
   "files": {
-    "solution": [
-      "scale-generator.js"
-    ],
-    "test": [
-      "scale-generator.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["scale-generator.js"],
+    "test": ["scale-generator.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -1,8 +1,15 @@
 {
+  "blurb": "Generate musical scales, given a starting note and a set of intervals. ",
   "authors": [],
   "files": {
-    "solution": ["scale-generator.js"],
-    "test": ["scale-generator.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "scale-generator.js"
+    ],
+    "test": [
+      "scale-generator.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a word, compute the Scrabble score for that word.",
   "authors": [],
   "files": {
-    "solution": ["scrabble-score.js"],
-    "test": ["scrabble-score.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "scrabble-score.js"
+    ],
+    "test": [
+      "scrabble-score.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a word, compute the Scrabble score for that word.",
   "authors": [],
   "files": {
-    "solution": [
-      "scrabble-score.js"
-    ],
-    "test": [
-      "scrabble-score.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["scrabble-score.js"],
+    "test": ["scrabble-score.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
   "authors": [],
   "files": {
-    "solution": ["secret-handshake.js"],
-    "test": ["secret-handshake.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "secret-handshake.js"
+    ],
+    "test": [
+      "secret-handshake.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Bert, in Mary Poppins",
   "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047"

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
   "authors": [],
   "files": {
-    "solution": [
-      "secret-handshake.js"
-    ],
-    "test": [
-      "secret-handshake.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["secret-handshake.js"],
+    "test": ["secret-handshake.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Bert, in Mary Poppins",
   "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047"

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
   "authors": [],
   "files": {
-    "solution": [
-      "series.js"
-    ],
-    "test": [
-      "series.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["series.js"],
+    "test": ["series.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A subset of the Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
   "authors": [],
   "files": {
-    "solution": ["series.js"],
-    "test": ["series.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "series.js"
+    ],
+    "test": [
+      "series.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A subset of the Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
   "authors": [],
   "files": {
-    "solution": [
-      "sieve.js"
-    ],
-    "test": [
-      "sieve.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["sieve.js"],
+    "test": ["sieve.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Sieve of Eratosthenes at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes"

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
   "authors": [],
   "files": {
-    "solution": ["sieve.js"],
-    "test": ["sieve.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "sieve.js"
+    ],
+    "test": [
+      "sieve.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Sieve of Eratosthenes at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes"

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Implement a simple shift cipher like Caesar and a more secure substitution cipher",
   "authors": [],
   "files": {
-    "solution": [
-      "simple-cipher.js"
-    ],
-    "test": [
-      "simple-cipher.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["simple-cipher.js"],
+    "test": ["simple-cipher.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Substitution Cipher at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Substitution_cipher"

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Implement a simple shift cipher like Caesar and a more secure substitution cipher",
   "authors": [],
   "files": {
-    "solution": ["simple-cipher.js"],
-    "test": ["simple-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "simple-cipher.js"
+    ],
+    "test": [
+      "simple-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Substitution Cipher at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Substitution_cipher"

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Write a simple linked list implementation that uses Elements and a List",
   "authors": [],
   "files": {
-    "solution": ["simple-linked-list.js"],
-    "test": ["simple-linked-list.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "simple-linked-list.js"
+    ],
+    "test": [
+      "simple-linked-list.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists.",
   "source_url": "https://web.archive.org/web/20160731005714/http://brpreiss.com/books/opus8/html/page96.html"

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Write a simple linked list implementation that uses Elements and a List",
   "authors": [],
   "files": {
-    "solution": [
-      "simple-linked-list.js"
-    ],
-    "test": [
-      "simple-linked-list.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["simple-linked-list.js"],
+    "test": ["simple-linked-list.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists.",
   "source_url": "https://web.archive.org/web/20160731005714/http://brpreiss.com/books/opus8/html/page96.html"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
   "authors": [],
   "files": {
-    "solution": ["space-age.js"],
-    "test": ["space-age.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "space-age.js"
+    ],
+    "test": [
+      "space-age.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=01"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
   "authors": [],
   "files": {
-    "solution": [
-      "space-age.js"
-    ],
-    "test": [
-      "space-age.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["space-age.js"],
+    "test": ["space-age.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=01"

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": " Given the size, return a square matrix of numbers in spiral order.",
   "authors": [],
   "files": {
-    "solution": [
-      "spiral-matrix.js"
-    ],
-    "test": [
-      "spiral-matrix.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["spiral-matrix.js"],
+    "test": ["spiral-matrix.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension.",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/"

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": " Given the size, return a square matrix of numbers in spiral order.",
   "authors": [],
   "files": {
-    "solution": ["spiral-matrix.js"],
-    "test": ["spiral-matrix.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "spiral-matrix.js"
+    ],
+    "test": [
+      "spiral-matrix.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension.",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/"

--- a/exercises/practice/square-root/.meta/config.json
+++ b/exercises/practice/square-root/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a natural radicand, return its square root.",
   "authors": [],
   "files": {
-    "solution": [
-      "square-root.js"
-    ],
-    "test": [
-      "square-root.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["square-root.js"],
+    "test": ["square-root.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "wolf99",
   "source_url": "https://github.com/exercism/problem-specifications/pull/1582"

--- a/exercises/practice/square-root/.meta/config.json
+++ b/exercises/practice/square-root/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a natural radicand, return its square root.",
   "authors": [],
   "files": {
-    "solution": ["square-root.js"],
-    "test": ["square-root.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "square-root.js"
+    ],
+    "test": [
+      "square-root.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "wolf99",
   "source_url": "https://github.com/exercism/problem-specifications/pull/1582"

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
   "authors": [],
   "files": {
-    "solution": [
-      "strain.js"
-    ],
-    "test": [
-      "strain.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["strain.js"],
+    "test": ["strain.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
   "authors": [],
   "files": {
-    "solution": ["strain.js"],
-    "test": ["strain.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "strain.js"
+    ],
+    "test": [
+      "strain.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -1,8 +1,15 @@
 {
+  "blurb": "Write a function to determine if a list is a sublist of another list.",
   "authors": [],
   "files": {
-    "solution": ["sublist.js"],
-    "test": ["sublist.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "sublist.js"
+    ],
+    "test": [
+      "sublist.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -2,14 +2,8 @@
   "blurb": "Write a function to determine if a list is a sublist of another list.",
   "authors": [],
   "files": {
-    "solution": [
-      "sublist.js"
-    ],
-    "test": [
-      "sublist.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["sublist.js"],
+    "test": ["sublist.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
   "authors": [],
   "files": {
-    "solution": ["sum-of-multiples.js"],
-    "test": ["sum-of-multiples.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "sum-of-multiples.js"
+    ],
+    "test": [
+      "sum-of-multiples.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A variation on Problem 1 at Project Euler",
   "source_url": "http://projecteuler.net/problem=1"

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
   "authors": [],
   "files": {
-    "solution": [
-      "sum-of-multiples.js"
-    ],
-    "test": [
-      "sum-of-multiples.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["sum-of-multiples.js"],
+    "test": ["sum-of-multiples.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on Problem 1 at Project Euler",
   "source_url": "http://projecteuler.net/problem=1"

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Take input text and output it transposed.",
   "authors": [],
   "files": {
-    "solution": ["transpose.js"],
-    "test": ["transpose.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "transpose.js"
+    ],
+    "test": [
+      "transpose.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Reddit r/dailyprogrammer challenge #270 [Easy].",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text"

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Take input text and output it transposed.",
   "authors": [],
   "files": {
-    "solution": [
-      "transpose.js"
-    ],
-    "test": [
-      "transpose.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["transpose.js"],
+    "test": ["transpose.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Reddit r/dailyprogrammer challenge #270 [Easy].",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text"

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
   "authors": [],
   "files": {
-    "solution": ["triangle.js"],
-    "test": ["triangle.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "triangle.js"
+    ],
+    "test": [
+      "triangle.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "The Ruby Koans triangle project, parts 1 & 2",
   "source_url": "http://rubykoans.com"

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
   "authors": [],
   "files": {
-    "solution": [
-      "triangle.js"
-    ],
-    "test": [
-      "triangle.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["triangle.js"],
+    "test": ["triangle.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "The Ruby Koans triangle project, parts 1 & 2",
   "source_url": "http://rubykoans.com"

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.",
   "authors": [],
   "files": {
-    "solution": [
-      "trinary.js"
-    ],
-    "test": [
-      "trinary.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["trinary.js"],
+    "test": ["trinary.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.",
   "authors": [],
   "files": {
-    "solution": ["trinary.js"],
-    "test": ["trinary.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "trinary.js"
+    ],
+    "test": [
+      "trinary.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
   "authors": [],
   "files": {
-    "solution": [
-      "twelve-days.js"
-    ],
-    "test": [
-      "twelve-days.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["twelve-days.js"],
+    "test": ["twelve-days.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)"

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
   "authors": [],
   "files": {
-    "solution": ["twelve-days.js"],
-    "test": ["twelve-days.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "twelve-days.js"
+    ],
+    "test": [
+      "twelve-days.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)"

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given two buckets of different size, demonstrate how to measure an exact number of liters.",
   "authors": [],
   "files": {
-    "solution": [
-      "two-bucket.js"
-    ],
-    "test": [
-      "two-bucket.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["two-bucket.js"],
+    "test": ["two-bucket.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Water Pouring Problem",
   "source_url": "http://demonstrations.wolfram.com/WaterPouringProblem/"

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given two buckets of different size, demonstrate how to measure an exact number of liters.",
   "authors": [],
   "files": {
-    "solution": ["two-bucket.js"],
-    "test": ["two-bucket.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "two-bucket.js"
+    ],
+    "test": [
+      "two-bucket.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Water Pouring Problem",
   "source_url": "http://demonstrations.wolfram.com/WaterPouringProblem/"

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Create a sentence of the form \"One for X, one for me.\"",
   "authors": [],
   "files": {
-    "solution": ["two-fer.js"],
-    "test": ["two-fer.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "two-fer.js"
+    ],
+    "test": [
+      "two-fer.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source_url": "https://github.com/exercism/problem-specifications/issues/757"
 }

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Create a sentence of the form \"One for X, one for me.\"",
   "authors": [],
   "files": {
-    "solution": [
-      "two-fer.js"
-    ],
-    "test": [
-      "two-fer.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["two-fer.js"],
+    "test": ["two-fer.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source_url": "https://github.com/exercism/problem-specifications/issues/757"
 }

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Implement variable length quantity encoding and decoding.",
   "authors": [],
   "files": {
-    "solution": ["variable-length-quantity.js"],
-    "test": ["variable-length-quantity.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "variable-length-quantity.js"
+    ],
+    "test": [
+      "variable-length-quantity.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "A poor Splice developer having to implement MIDI encoding/decoding.",
   "source_url": "https://splice.com"

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Implement variable length quantity encoding and decoding.",
   "authors": [],
   "files": {
-    "solution": [
-      "variable-length-quantity.js"
-    ],
-    "test": [
-      "variable-length-quantity.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["variable-length-quantity.js"],
+    "test": ["variable-length-quantity.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "A poor Splice developer having to implement MIDI encoding/decoding.",
   "source_url": "https://splice.com"

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
   "authors": [],
   "files": {
-    "solution": [
-      "word-count.js"
-    ],
-    "test": [
-      "word-count.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["word-count.js"],
+    "test": ["word-count.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour."
 }

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
   "authors": [],
   "files": {
-    "solution": ["word-count.js"],
-    "test": ["word-count.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "word-count.js"
+    ],
+    "test": [
+      "word-count.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour."
 }

--- a/exercises/practice/word-search/.meta/config.json
+++ b/exercises/practice/word-search/.meta/config.json
@@ -2,14 +2,8 @@
   "blurb": "Create a program to solve a word search puzzle.",
   "authors": [],
   "files": {
-    "solution": [
-      "word-search.js"
-    ],
-    "test": [
-      "word-search.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["word-search.js"],
+    "test": ["word-search.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/word-search/.meta/config.json
+++ b/exercises/practice/word-search/.meta/config.json
@@ -1,8 +1,15 @@
 {
+  "blurb": "Create a program to solve a word search puzzle.",
   "authors": [],
   "files": {
-    "solution": ["word-search.js"],
-    "test": ["word-search.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "word-search.js"
+    ],
+    "test": [
+      "word-search.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
   "authors": [],
   "files": {
-    "solution": [
-      "wordy.js"
-    ],
-    "test": [
-      "wordy.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["wordy.js"],
+    "test": ["wordy.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by one of the generated questions in the Extreme Startup game.",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
   "authors": [],
   "files": {
-    "solution": ["wordy.js"],
-    "test": ["wordy.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "wordy.js"
+    ],
+    "test": [
+      "wordy.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "Inspired by one of the generated questions in the Extreme Startup game.",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Score a single throw of dice in the game Yacht",
   "authors": [],
   "files": {
-    "solution": ["yacht.js"],
-    "test": ["yacht.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "yacht.js"
+    ],
+    "test": [
+      "yacht.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
   "source": "James Kilfiger, using wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Yacht_(dice_game)"

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -2,15 +2,9 @@
   "blurb": "Score a single throw of dice in the game Yacht",
   "authors": [],
   "files": {
-    "solution": [
-      "yacht.js"
-    ],
-    "test": [
-      "yacht.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["yacht.js"],
+    "test": ["yacht.spec.js"],
+    "example": [".meta/proof.ci.js"]
   },
   "source": "James Kilfiger, using wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Yacht_(dice_game)"

--- a/exercises/practice/zipper/.meta/config.json
+++ b/exercises/practice/zipper/.meta/config.json
@@ -2,14 +2,8 @@
   "blurb": "Creating a zipper for a binary tree.",
   "authors": [],
   "files": {
-    "solution": [
-      "zipper.js"
-    ],
-    "test": [
-      "zipper.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ]
+    "solution": ["zipper.js"],
+    "test": ["zipper.spec.js"],
+    "example": [".meta/proof.ci.js"]
   }
 }

--- a/exercises/practice/zipper/.meta/config.json
+++ b/exercises/practice/zipper/.meta/config.json
@@ -1,8 +1,15 @@
 {
+  "blurb": "Creating a zipper for a binary tree.",
   "authors": [],
   "files": {
-    "solution": ["zipper.js"],
-    "test": ["zipper.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "zipper.js"
+    ],
+    "test": [
+      "zipper.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   }
 }


### PR DESCRIPTION
Each Concept and Practice Exercise will have to define a _blurb_, which is a short description of the exercise.
The blurb will be displayed on a track's exercises page and on exercise tooltips. For example:

<img width="1194" alt="Screenshot 2021-03-02 at 13 25 38" src="https://user-images.githubusercontent.com/286476/109655154-da058500-7b5a-11eb-8346-bf733a72b3d0.png">
<img width="400" alt="Screenshot 2021-03-02 at 13 25 51" src="https://user-images.githubusercontent.com/286476/109655162-dd007580-7b5a-11eb-88f8-582532be9b84.png">

Blurbs must be limited to 350 chars and will be truncated in some views.

For Practice Exercises that are based on an exercise defined in the problem-specification repo, the blurb must match the contents of the problem-specifications exercises, which is defined in its `metadata.yml` file. In this PR, we'll do an initial syncing of the blurb. The new [configlet](https://github.com/exercism/configlet) version will add support for doing this syncing automatically.

If the Practice Exercise was _not_ based on a problems-specifications exercise, we've used the blurb from its `.meta/metadata.yml` file as the blurb in the .meta/config.json file.

For Concept Exercises, we've added a placeholder blurb to the .meta/config.json file of each Concept Exercise.

**We've opened an [issue for replacing the Concept Exercise placeholder blurbs](1028) with sensible descriptions. Our recommendation is to merge this PR and then replace the placeholder blurbs in a follow-up PR. For forked exercises, it might be useful to check how other tracks have defined their blurb.**  

See the [Concept Exercise spec](https://github.com/exercism/docs/blob/main/anatomy/tracks/concept-exercises.md#file-metaconfigjson) and [Practice Exercise spec](https://github.com/exercism/docs/blob/main/anatomy/tracks/practice-exercises.md#file-metaconfigjson) for more information.

## Tracking

https://github.com/exercism/v3-launch/issues/21
