### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "6d918e50-98b6-4d02-b587-6ec521366e71",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing JavaScript locally",
+      "blurb": "Learn how to install JavaScript locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "9c7db941-c36e-4dfd-8839-11085a4ed7ed",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn JavaScript",
+      "blurb": "An overview of how to get started from scratch with JavaScript"
+    },
+    {
+      "uuid": "87ede7e1-1f7b-4044-9bac-f021333dee5e",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the JavaScript track",
+      "blurb": "Learn how to test your JavaScript exercises on Exercism"
+    },
+    {
+      "uuid": "eaeb19f7-b713-4250-a129-aeb6cb3a950c",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful JavaScript resources",
+      "blurb": "A collection of useful resources to help you master JavaScript"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
