### PR TITLE
Add command to cd into exercise directory

### DIFF
--- a/config/exercise-readme-insert.md
+++ b/config/exercise-readme-insert.md
@@ -9,7 +9,11 @@ dependencies:
 
 ## Requirements
 
-Please `cd` into exercise directory before running all below commands.
+`cd` into exercise directory:
+
+```bash
+$ cd $(exercism workspace)/javascript/*
+```
 
 Install assignment dependencies:
 


### PR DESCRIPTION
The first step of the requirements assumes the user is familiar with the command-line and the exercism cli. 
Let's guide them so that they won't get stuck early on.

```
cd $(exercism workspace)/javascript/*
```

The above will `cd` into the directory of the first exercise.