### PR TITLE
Mark inactive maintainers as alumnus

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -112,7 +112,7 @@
       "bio": "I program JS, Rust and Swift by day, and my own languages by night. 👋I'm Rishi, a JS developer with a passion for helping people! It's great to meet you :)"
     },
     {
-      "github_username": "yyyc514",
+      "github_username": "joshgoebel",
       "alumnus": true,
       "show_on_website": true,
       "name": "Josh Goebel",

--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -43,7 +43,7 @@
     },
     {
       "github_username": "aimorris",
-      "alumnus": false,
+      "alumnus": true,
       "show_on_website": false,
       "name": "Adam Morris",
       "link_text": null,
@@ -53,7 +53,7 @@
     },
     {
       "github_username": "Calamari",
-      "alumnus": false,
+      "alumnus": true,
       "show_on_website": false,
       "name": "Georg Tavonius",
       "link_text": "My website",
@@ -63,7 +63,7 @@
     },
     {
       "github_username": "hayashi-ay",
-      "alumnus": false,
+      "alumnus": true,
       "show_on_website": false,
       "name": "Ayato Hayashi",
       "link_text": null,
@@ -73,7 +73,7 @@
     },
     {
       "github_username": "ovidiu141",
-      "alumnus": false,
+      "alumnus": true,
       "show_on_website": false,
       "name": "Ovidiu Miu",
       "link_text": null,
@@ -83,7 +83,7 @@
     },
     {
       "github_username": "msomji",
-      "alumnus": false,
+      "alumnus": true,
       "show_on_website": false,
       "name": "Maisam Somji",
       "link_text": null,
@@ -113,7 +113,7 @@
     },
     {
       "github_username": "yyyc514",
-      "alumnus": false,
+      "alumnus": true,
       "show_on_website": true,
       "name": "Josh Goebel",
       "link_text": "Blog: Running Blind",


### PR DESCRIPTION
Dear maintainers,

As we near launching V3 for Beta I'm updating the `maintainers` list. If you're tagged in this message, I've flipped your `alumnus` value to `true`, as you've been inactive for the past months. If I don't hear anything in the next seven days it will remain so.

- If you'd like to not show up on the website, please let me know
- If you'd like to stay on as a maintainer, please let me know

Naturally, if you choose to come back in the future, we always have a place for you, but I need to know who I can count on as we hurdle towards the big update and all the support required thereafter. 

A few of you have already indicated privately that you're otherwise occupied and cannot help out at the moment (which is _perfectly fine_ of course); and you can ignore this entire message.

Thank you for all your contributions thusfar.

@ovidiu141 @hayashi-ay  @joshgoebel @msomji  @hayashi-ay @jocelo @rishiosaur @Calamari 