### PR TITLE
🤖 Fix invalid UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -679,7 +679,7 @@
       {
         "slug": "high-scores",
         "name": "High Scores",
-        "uuid": "19b41c4a-1466-5c19-b547-40284189fd18",
+        "uuid": "f5af74f7-259c-48e6-828c-bcd98717d8dd",
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
@@ -1017,7 +1017,7 @@
       {
         "slug": "sublist",
         "name": "Sublist",
-        "uuid": "4be85b5e-6b13-11e7-907b-a6006ad3dba0",
+        "uuid": "bb00e97f-8dcf-40ba-b8c2-c3cb72bbaf97",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,

--- a/config.json
+++ b/config.json
@@ -167,7 +167,7 @@
       {
         "slug": "ozans-playlist",
         "name": "Ozan's Playlist",
-        "uuid": "50dba808-070a-4873-b223-d565381c3b4c",
+        "uuid": "347692fb-7b0f-4ef0-9a02-2192b59bdf5d",
         "concepts": ["sets"],
         "prerequisites": [
           "array-destructuring",
@@ -1675,7 +1675,7 @@
       "name": "Switch Statement"
     },
     {
-      "uuid": "50dba808-070a-4873-b223-d565381c3b4c",
+      "uuid": "84e55c29-d403-4a90-8a2a-9960feae8ff3",
       "slug": "sets",
       "name": "Sets"
     }

--- a/config.json
+++ b/config.json
@@ -436,7 +436,7 @@
       {
         "slug": "leap",
         "name": "Leap",
-        "uuid": "7c8294ee-5924-4bf8-a72f-31d0e2d7d9a0",
+        "uuid": "193a0e19-462d-4d26-a117-124f07d5a3d7",
         "practices": [],
         "prerequisites": ["numbers"],
         "difficulty": 1,


### PR DESCRIPTION
This PR regenerates each UUID on the track that was invalid.

To be valid, each value of a `uuid` key must:
- Be a well-formed version 4 UUID (compliant with RFC 4122) in the
  canonical textual representation [1]
- Not exist elsewhere on the track
- Not exist elsewhere on Exercism

A track can generate a suitable UUID by running `configlet uuid`.

In the future, `configlet lint` will produce an error for an invalid
UUID.

[1] That is, it must match this regular expression:
```
^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
```

## Tracking

https://github.com/exercism/v3-launch/issues/29
