### PR TITLE
🤖 Add Ace editor and highlightjs languages to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,18 +18,10 @@
   },
   "test_pattern": ".*[.]spec[.]js$",
   "files": {
-    "solution": [
-      "%{kebab_slug}.js"
-    ],
-    "test": [
-      "%{kebab_slug}.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["%{kebab_slug}.js"],
+    "test": ["%{kebab_slug}.spec.js"],
+    "example": [".meta/proof.ci.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "exercises": {
     "concept": [
@@ -37,9 +29,7 @@
         "slug": "lasagna",
         "name": "Lucian's Luscious Lasagna",
         "uuid": "97bf898a-36fc-47fc-b870-01fc0c7fe554",
-        "concepts": [
-          "basics"
-        ],
+        "concepts": ["basics"],
         "prerequisites": [],
         "status": "active"
       },
@@ -47,158 +37,95 @@
         "slug": "annalyns-infiltration",
         "name": "Annalyn's Infiltration",
         "uuid": "5acafcbb-20a0-45b9-b276-3d167e0de313",
-        "concepts": [
-          "booleans"
-        ],
-        "prerequisites": [
-          "basics"
-        ],
+        "concepts": ["booleans"],
+        "prerequisites": ["basics"],
         "status": "beta"
       },
       {
         "slug": "freelancer-rates",
         "name": "Freelancer Rates",
         "uuid": "0aff2fa7-55ea-47e9-af4a-78927d916baf",
-        "concepts": [
-          "numbers"
-        ],
-        "prerequisites": [
-          "basics"
-        ],
+        "concepts": ["numbers"],
+        "prerequisites": ["basics"],
         "status": "beta"
       },
       {
         "slug": "poetry-club-door-policy",
         "name": "Poetry Club Door Policy",
         "uuid": "39549583-1889-490a-bf98-ffb2e0aefe44",
-        "concepts": [
-          "strings"
-        ],
-        "prerequisites": [
-          "basics"
-        ],
+        "concepts": ["strings"],
+        "prerequisites": ["basics"],
         "status": "beta"
       },
       {
         "slug": "elyses-enchantments",
         "name": "Elyses Enchantments",
         "uuid": "25cb0707-44f8-4800-b993-3fcb2b6d9f61",
-        "concepts": [
-          "arrays"
-        ],
-        "prerequisites": [
-          "numbers"
-        ],
+        "concepts": ["arrays"],
+        "prerequisites": ["numbers"],
         "status": "beta"
       },
       {
         "slug": "vehicle-purchase",
         "name": "Vehicle Purchase",
         "uuid": "f75a7e2c-053a-411e-8b3d-f978a2c5100e",
-        "concepts": [
-          "comparison",
-          "conditionals"
-        ],
-        "prerequisites": [
-          "booleans",
-          "numbers",
-          "strings"
-        ],
+        "concepts": ["comparison", "conditionals"],
+        "prerequisites": ["booleans", "numbers", "strings"],
         "status": "beta"
       },
       {
         "slug": "bird-watcher",
         "name": "Bird Watcher",
         "uuid": "3e648aa0-9ce7-4041-93d2-2b95f3832824",
-        "concepts": [
-          "for-loops",
-          "increment-decrement"
-        ],
-        "prerequisites": [
-          "arrays",
-          "comparison",
-          "conditionals"
-        ],
+        "concepts": ["for-loops", "increment-decrement"],
+        "prerequisites": ["arrays", "comparison", "conditionals"],
         "status": "beta"
       },
       {
         "slug": "mixed-juices",
         "name": "Mixed Juices",
         "uuid": "81c3fb86-af86-4c56-a45f-e021403c4070",
-        "concepts": [
-          "while-loops",
-          "conditionals-switch"
-        ],
-        "prerequisites": [
-          "comparison",
-          "conditionals",
-          "arrays"
-        ],
+        "concepts": ["while-loops", "conditionals-switch"],
+        "prerequisites": ["comparison", "conditionals", "arrays"],
         "status": "beta"
       },
       {
         "slug": "lucky-numbers",
         "name": "Lucky Numbers",
         "uuid": "78bbd7d2-b660-4791-a404-af5bfed31849",
-        "concepts": [
-          "type-conversion"
-        ],
-        "prerequisites": [
-          "arrays",
-          "strings",
-          "numbers"
-        ],
+        "concepts": ["type-conversion"],
+        "prerequisites": ["arrays", "strings", "numbers"],
         "status": "wip"
       },
       {
         "slug": "elyses-analytic-enchantments",
         "name": "Elyses Analytic Enchantments",
         "uuid": "45d956db-d4ef-4468-b1d3-47021f172c15",
-        "concepts": [
-          "array-analysis"
-        ],
-        "prerequisites": [
-          "arrays",
-          "booleans",
-          "callbacks",
-          "numbers"
-        ],
+        "concepts": ["array-analysis"],
+        "prerequisites": ["arrays", "booleans", "callbacks", "numbers"],
         "status": "beta"
       },
       {
         "slug": "elyses-destructured-enchantments",
         "name": "Elyses Destructured Enchantments",
         "uuid": "d9b5cd13-2f2b-4034-a571-e66c847ed6f8",
-        "concepts": [
-          "array-destructuring",
-          "spread-operator",
-          "rest-elements"
-        ],
-        "prerequisites": [
-          "arrays"
-        ],
+        "concepts": ["array-destructuring", "spread-operator", "rest-elements"],
+        "prerequisites": ["arrays"],
         "status": "beta"
       },
       {
         "slug": "nullability",
         "name": "Employee Badges",
         "uuid": "19962010-7b8c-4db1-bdae-ffc857b268e5",
-        "concepts": [
-          "nullability"
-        ],
-        "prerequisites": [
-          "conditionals",
-          "strings"
-        ],
+        "concepts": ["nullability"],
+        "prerequisites": ["conditionals", "strings"],
         "status": "active"
       },
       {
         "slug": "recursion",
         "name": "Pizza Order",
         "uuid": "e9a9fa73-4497-43d5-a4ff-4eb319c98233",
-        "concepts": [
-          "recursion"
-        ],
+        "concepts": ["recursion"],
         "prerequisites": [
           "arrays",
           "array-destructuring",
@@ -211,22 +138,15 @@
         "slug": "closures",
         "name": "Coordinate Transformation",
         "uuid": "5aa39e89-c601-4a66-ab72-5d8512d69e02",
-        "concepts": [
-          "closures"
-        ],
-        "prerequisites": [
-          "arrays",
-          "booleans"
-        ],
+        "concepts": ["closures"],
+        "prerequisites": ["arrays", "booleans"],
         "status": "beta"
       },
       {
         "slug": "fruit-picker",
         "name": "Fruit Picker",
         "uuid": "a6348db8-cc2b-4c53-9f43-3c23248d66f0",
-        "concepts": [
-          "callbacks"
-        ],
+        "concepts": ["callbacks"],
         "prerequisites": [
           "booleans",
           "closures",
@@ -242,24 +162,15 @@
         "slug": "translation-service",
         "name": "Translation Service",
         "uuid": "4a967656-8615-474e-a009-5c0b09f4386f",
-        "concepts": [
-          "promises"
-        ],
-        "prerequisites": [
-          "arrays",
-          "callbacks",
-          "errors",
-          "recursion"
-        ],
+        "concepts": ["promises"],
+        "prerequisites": ["arrays", "callbacks", "errors", "recursion"],
         "status": "beta"
       },
       {
         "slug": "ozans-playlist",
         "name": "Ozan's Playlist",
         "uuid": "347692fb-7b0f-4ef0-9a02-2192b59bdf5d",
-        "concepts": [
-          "sets"
-        ],
+        "concepts": ["sets"],
         "prerequisites": [
           "array-destructuring",
           "array-loops",
@@ -297,95 +208,59 @@
           "optional-parameters"
         ],
         "difficulty": 1,
-        "topics": [
-          "optional_values",
-          "strings",
-          "text_formatting"
-        ]
+        "topics": ["optional_values", "strings", "text_formatting"]
       },
       {
         "slug": "resistor-color",
         "name": "Resistor Color",
         "uuid": "53be6837-c224-45f1-bff3-d7f74d6285ce",
         "practices": [],
-        "prerequisites": [
-          "arrays",
-          "array-analysis"
-        ],
+        "prerequisites": ["arrays", "array-analysis"],
         "difficulty": 1,
-        "topics": [
-          "arrays",
-          "strings"
-        ]
+        "topics": ["arrays", "strings"]
       },
       {
         "slug": "resistor-color-duo",
         "name": "Resistor Color Duo",
         "uuid": "de800041-3dcc-41b9-b101-7314ff685c93",
         "practices": [],
-        "prerequisites": [
-          "array-transformations"
-        ],
+        "prerequisites": ["array-transformations"],
         "difficulty": 2,
-        "topics": [
-          "strings",
-          "arrays"
-        ]
+        "topics": ["strings", "arrays"]
       },
       {
         "slug": "gigasecond",
         "name": "Gigasecond",
         "uuid": "fd7b62d4-266b-4e84-a526-bf3d47901216",
         "practices": [],
-        "prerequisites": [
-          "dates",
-          "immutability",
-          "type-conversion"
-        ],
+        "prerequisites": ["dates", "immutability", "type-conversion"],
         "difficulty": 1,
-        "topics": [
-          "time"
-        ]
+        "topics": ["time"]
       },
       {
         "slug": "rna-transcription",
         "name": "Rna Transcription",
         "uuid": "342974d6-9083-4754-a6c5-ed1e19e40ec5",
         "practices": [],
-        "prerequisites": [
-          "strings",
-          "array-transformations",
-          "objects"
-        ],
+        "prerequisites": ["strings", "array-transformations", "objects"],
         "difficulty": 2,
-        "topics": [
-          "strings",
-          "transforming"
-        ]
+        "topics": ["strings", "transforming"]
       },
       {
         "slug": "space-age",
         "name": "Space Age",
         "uuid": "d9d757ed-ebe6-4d4a-aa73-f6834221cd54",
         "practices": [],
-        "prerequisites": [
-          "objects",
-          "numbers"
-        ],
+        "prerequisites": ["objects", "numbers"],
         "difficulty": 2,
-        "topics": [
-          "floating_point_numbers"
-        ]
+        "topics": ["floating_point_numbers"]
       },
       {
         "slug": "pangram",
         "name": "Pangram",
         "uuid": "da5b2b34-a1a7-4970-81f9-4665d875398b",
         "practices": [],
-        "prerequisites": [
-          "strings",
-          "array-analysis"
-        ],
+        "prerequisites": ["strings", "array-analysis"],
         "difficulty": 2,
         "topics": [
           "algorithms",
@@ -422,11 +297,7 @@
         "name": "Bob",
         "uuid": "a5bf36f0-5d3c-41d4-8d54-e37e484e59cd",
         "practices": [],
-        "prerequisites": [
-          "strings",
-          "booleans",
-          "regular-expressions"
-        ],
+        "prerequisites": ["strings", "booleans", "regular-expressions"],
         "difficulty": 4,
         "topics": [
           "conditionals",
@@ -441,10 +312,7 @@
         "name": "Pascals Triangle",
         "uuid": "99493160-4673-402f-acda-62db5378148d",
         "practices": [],
-        "prerequisites": [
-          "arrays",
-          "for-loops"
-        ],
+        "prerequisites": ["arrays", "for-loops"],
         "difficulty": 4,
         "topics": [
           "conditionals",
@@ -459,10 +327,7 @@
         "name": "Linked List",
         "uuid": "ec60a578-8889-46a1-b7b8-306dbd8551d5",
         "practices": [],
-        "prerequisites": [
-          "classes",
-          "while-loops"
-        ],
+        "prerequisites": ["classes", "while-loops"],
         "difficulty": 5,
         "topics": [
           "algorithms",
@@ -479,36 +344,18 @@
         "name": "Grade School",
         "uuid": "64637322-33bc-401f-8cec-1f9810a41f75",
         "practices": [],
-        "prerequisites": [
-          "classes",
-          "objects",
-          "arrays",
-          "immutability"
-        ],
+        "prerequisites": ["classes", "objects", "arrays", "immutability"],
         "difficulty": 5,
-        "topics": [
-          "arrays",
-          "maps",
-          "sorting"
-        ]
+        "topics": ["arrays", "maps", "sorting"]
       },
       {
         "slug": "list-ops",
         "name": "List Ops",
         "uuid": "7d9db056-5398-41b6-af3b-9707f5eb0dbc",
         "practices": [],
-        "prerequisites": [
-          "classes",
-          "arrays",
-          "functions"
-        ],
+        "prerequisites": ["classes", "arrays", "functions"],
         "difficulty": 6,
-        "topics": [
-          "data_structures",
-          "loops",
-          "lists",
-          "recursion"
-        ]
+        "topics": ["data_structures", "loops", "lists", "recursion"]
       },
       {
         "slug": "robot-name",
@@ -560,11 +407,7 @@
         "name": "Wordy",
         "uuid": "9131bdb8-2e0f-4526-b113-8a77712e7216",
         "practices": [],
-        "prerequisites": [
-          "strings",
-          "regular-expressions",
-          "errors"
-        ],
+        "prerequisites": ["strings", "regular-expressions", "errors"],
         "difficulty": 7,
         "topics": [
           "conditionals",
@@ -581,10 +424,7 @@
         "name": "Secret Handshake",
         "uuid": "74bbc9e3-edc5-41e0-84d7-5b2d98dd8370",
         "practices": [],
-        "prerequisites": [
-          "bit-manipulation",
-          "array-analysis"
-        ],
+        "prerequisites": ["bit-manipulation", "array-analysis"],
         "difficulty": 6,
         "topics": [
           "algorithms",
@@ -600,30 +440,18 @@
         "name": "Leap",
         "uuid": "193a0e19-462d-4d26-a117-124f07d5a3d7",
         "practices": [],
-        "prerequisites": [
-          "numbers"
-        ],
+        "prerequisites": ["numbers"],
         "difficulty": 1,
-        "topics": [
-          "booleans",
-          "integers",
-          "logic"
-        ]
+        "topics": ["booleans", "integers", "logic"]
       },
       {
         "slug": "reverse-string",
         "name": "Reverse String",
         "uuid": "e84c97eb-dbec-487c-b99f-ae9924e16293",
         "practices": [],
-        "prerequisites": [
-          "strings",
-          "array-transformation"
-        ],
+        "prerequisites": ["strings", "array-transformation"],
         "difficulty": 2,
-        "topics": [
-          "loops",
-          "strings"
-        ]
+        "topics": ["loops", "strings"]
       },
       {
         "slug": "collatz-conjecture",
@@ -648,12 +476,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "conditionals",
-          "loops",
-          "exception_handling",
-          "integers"
-        ]
+        "topics": ["conditionals", "loops", "exception_handling", "integers"]
       },
       {
         "slug": "clock",
@@ -662,11 +485,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "dates",
-          "globalization",
-          "time"
-        ]
+        "topics": ["dates", "globalization", "time"]
       },
       {
         "slug": "meetup",
@@ -691,12 +510,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "loops",
-          "integers",
-          "maps",
-          "transforming"
-        ]
+        "topics": ["loops", "integers", "maps", "transforming"]
       },
       {
         "slug": "hamming",
@@ -705,12 +519,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "conditionals",
-          "loops",
-          "equality",
-          "strings"
-        ]
+        "topics": ["conditionals", "loops", "equality", "strings"]
       },
       {
         "slug": "raindrops",
@@ -719,12 +528,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "conditionals",
-          "integers",
-          "strings",
-          "transforming"
-        ]
+        "topics": ["conditionals", "integers", "strings", "transforming"]
       },
       {
         "slug": "nucleotide-count",
@@ -748,12 +552,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops",
-          "maps",
-          "strings"
-        ]
+        "topics": ["conditionals", "loops", "maps", "strings"]
       },
       {
         "slug": "allergies",
@@ -762,12 +561,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": [
-          "arrays",
-          "bitwise_operations",
-          "conditionals",
-          "loops"
-        ]
+        "topics": ["arrays", "bitwise_operations", "conditionals", "loops"]
       },
       {
         "slug": "word-count",
@@ -776,12 +570,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "loops",
-          "lists",
-          "regular_expressions",
-          "strings"
-        ]
+        "topics": ["loops", "lists", "regular_expressions", "strings"]
       },
       {
         "slug": "bank-account",
@@ -790,10 +579,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "classes",
-          "conditionals"
-        ]
+        "topics": ["classes", "conditionals"]
       },
       {
         "slug": "difference-of-squares",
@@ -802,12 +588,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "algorithms",
-          "loops",
-          "integers",
-          "math"
-        ]
+        "topics": ["algorithms", "loops", "integers", "math"]
       },
       {
         "slug": "perfect-numbers",
@@ -816,13 +597,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "arrays",
-          "conditionals",
-          "loops",
-          "integers",
-          "math"
-        ]
+        "topics": ["arrays", "conditionals", "loops", "integers", "math"]
       },
       {
         "slug": "complex-numbers",
@@ -831,9 +606,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "math"
-        ]
+        "topics": ["math"]
       },
       {
         "slug": "luhn",
@@ -842,12 +615,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "conditionals",
-          "loops",
-          "integers",
-          "strings"
-        ]
+        "topics": ["conditionals", "loops", "integers", "strings"]
       },
       {
         "slug": "prime-factors",
@@ -856,13 +624,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "integers",
-          "math"
-        ]
+        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
       },
       {
         "slug": "grains",
@@ -871,10 +633,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "loops",
-          "integers"
-        ]
+        "topics": ["loops", "integers"]
       },
       {
         "slug": "pythagorean-triplet",
@@ -883,13 +642,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "integers",
-          "math"
-        ]
+        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
       },
       {
         "slug": "palindrome-products",
@@ -914,10 +667,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "filtering",
-          "strings"
-        ]
+        "topics": ["filtering", "strings"]
       },
       {
         "slug": "acronym",
@@ -926,12 +676,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "loops",
-          "regular_expressions",
-          "strings",
-          "transforming"
-        ]
+        "topics": ["loops", "regular_expressions", "strings", "transforming"]
       },
       {
         "slug": "high-scores",
@@ -940,9 +685,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "arrays"
-        ]
+        "topics": ["arrays"]
       },
       {
         "slug": "isogram",
@@ -951,10 +694,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "filtering",
-          "strings"
-        ]
+        "topics": ["filtering", "strings"]
       },
       {
         "slug": "matching-brackets",
@@ -978,10 +718,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "parsing",
-          "transforming"
-        ]
+        "topics": ["parsing", "transforming"]
       },
       {
         "slug": "scale-generator",
@@ -990,12 +727,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "loops",
-          "pattern_recognition",
-          "strings",
-          "arrays"
-        ]
+        "topics": ["loops", "pattern_recognition", "strings", "arrays"]
       },
       {
         "slug": "series",
@@ -1004,12 +736,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "loops",
-          "exception_handling",
-          "strings",
-          "text_formatting"
-        ]
+        "topics": ["loops", "exception_handling", "strings", "text_formatting"]
       },
       {
         "slug": "largest-series-product",
@@ -1051,11 +778,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "files",
-          "searching",
-          "text_formatting"
-        ]
+        "topics": ["files", "searching", "text_formatting"]
       },
       {
         "slug": "rectangles",
@@ -1064,13 +787,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "arrays",
-          "conditionals",
-          "loops",
-          "matrices",
-          "strings"
-        ]
+        "topics": ["arrays", "conditionals", "loops", "matrices", "strings"]
       },
       {
         "slug": "spiral-matrix",
@@ -1129,11 +846,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": [
-          "domain_specific_languages",
-          "parsing",
-          "stacks"
-        ]
+        "topics": ["domain_specific_languages", "parsing", "stacks"]
       },
       {
         "slug": "food-chain",
@@ -1142,10 +855,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "text_formatting"
-        ]
+        "topics": ["algorithms", "text_formatting"]
       },
       {
         "slug": "house",
@@ -1154,13 +864,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "arrays",
-          "conditionals",
-          "loops",
-          "recursion",
-          "strings"
-        ]
+        "topics": ["arrays", "conditionals", "loops", "recursion", "strings"]
       },
       {
         "slug": "isbn-verifier",
@@ -1232,11 +936,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "promises",
-          "error_handling",
-          "higher_order_functions"
-        ]
+        "topics": ["promises", "error_handling", "higher_order_functions"]
       },
       {
         "slug": "yacht",
@@ -1245,12 +945,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "arrays",
-          "conditionals",
-          "filtering",
-          "games"
-        ]
+        "topics": ["arrays", "conditionals", "filtering", "games"]
       },
       {
         "slug": "beer-song",
@@ -1259,11 +954,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops",
-          "strings"
-        ]
+        "topics": ["conditionals", "loops", "strings"]
       },
       {
         "slug": "resistor-color-trio",
@@ -1272,10 +963,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops"
-        ]
+        "topics": ["conditionals", "loops"]
       },
       {
         "slug": "dominoes",
@@ -1284,9 +972,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": [
-          "graph_theory"
-        ]
+        "topics": ["graph_theory"]
       },
       {
         "slug": "say",
@@ -1328,11 +1014,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "floating_point_numbers",
-          "math"
-        ]
+        "topics": ["algorithms", "floating_point_numbers", "math"]
       },
       {
         "slug": "sublist",
@@ -1341,10 +1023,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "arrays",
-          "lists"
-        ]
+        "topics": ["arrays", "lists"]
       },
       {
         "slug": "binary-search-tree",
@@ -1353,12 +1032,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "recursion"
-        ]
+        "topics": ["algorithms", "conditionals", "loops", "recursion"]
       },
       {
         "slug": "custom-set",
@@ -1385,13 +1059,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": [
-          "algorithms",
-          "arrays",
-          "conditionals",
-          "loops",
-          "recursion"
-        ]
+        "topics": ["algorithms", "arrays", "conditionals", "loops", "recursion"]
       },
       {
         "slug": "circular-buffer",
@@ -1416,11 +1084,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": [
-          "arrays",
-          "data_structures",
-          "lists"
-        ]
+        "topics": ["arrays", "data_structures", "lists"]
       },
       {
         "slug": "word-search",
@@ -1446,10 +1110,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "bitwise_operations",
-          "transforming"
-        ]
+        "topics": ["bitwise_operations", "transforming"]
       },
       {
         "slug": "two-bucket",
@@ -1475,10 +1136,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": [
-          "algorithms",
-          "games"
-        ]
+        "topics": ["algorithms", "games"]
       },
       {
         "slug": "connect",
@@ -1537,12 +1195,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "callbacks",
-          "loops",
-          "lists"
-        ]
+        "topics": ["algorithms", "callbacks", "loops", "lists"]
       },
       {
         "slug": "flatten-array",
@@ -1551,10 +1204,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "arrays",
-          "recursion"
-        ]
+        "topics": ["arrays", "recursion"]
       },
       {
         "slug": "nth-prime",
@@ -1579,13 +1229,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops",
-          "integers",
-          "math",
-          "recursion"
-        ]
+        "topics": ["conditionals", "loops", "integers", "math", "recursion"]
       },
       {
         "slug": "rotational-cipher",
@@ -1594,12 +1238,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "conditionals",
-          "strings",
-          "text_formatting",
-          "transforming"
-        ]
+        "topics": ["conditionals", "strings", "text_formatting", "transforming"]
       },
       {
         "slug": "diffie-hellman",
@@ -1624,12 +1263,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "arrays",
-          "filtering",
-          "math"
-        ]
+        "topics": ["algorithms", "arrays", "filtering", "math"]
       },
       {
         "slug": "atbash-cipher",
@@ -1703,13 +1337,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops",
-          "integers",
-          "lists",
-          "math"
-        ]
+        "topics": ["conditionals", "loops", "integers", "lists", "math"]
       },
       {
         "slug": "change",
@@ -1718,11 +1346,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": [
-          "algorithms",
-          "performance",
-          "searching"
-        ]
+        "topics": ["algorithms", "performance", "searching"]
       },
       {
         "slug": "point-mutations",
@@ -1741,12 +1365,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "strings"
-        ]
+        "topics": ["algorithms", "conditionals", "loops", "strings"]
       },
       {
         "slug": "armstrong-numbers",
@@ -1755,10 +1374,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "algorithms",
-          "math"
-        ]
+        "topics": ["algorithms", "math"]
       },
       {
         "slug": "dnd-character",
@@ -1767,10 +1383,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "classes",
-          "randomness"
-        ]
+        "topics": ["classes", "randomness"]
       },
       {
         "slug": "run-length-encoding",
@@ -1871,12 +1484,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "bitwise_operations",
-          "algorithms",
-          "loops",
-          "math"
-        ]
+        "topics": ["bitwise_operations", "algorithms", "loops", "math"]
       },
       {
         "slug": "trinary",
@@ -1918,11 +1526,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": [
-          "algorithms",
-          "arrays",
-          "games"
-        ]
+        "topics": ["algorithms", "arrays", "games"]
       },
       {
         "slug": "queen-attack",
@@ -1948,11 +1552,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": [
-          "algorithms",
-          "events",
-          "reactive_programming"
-        ]
+        "topics": ["algorithms", "events", "reactive_programming"]
       },
       {
         "slug": "zipper",
@@ -1961,11 +1561,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": [
-          "recursion",
-          "searching",
-          "trees"
-        ]
+        "topics": ["recursion", "searching", "trees"]
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -12,14 +12,24 @@
   "version": 3,
   "online_editor": {
     "indent_style": "space",
-    "indent_size": 2
+    "indent_size": 2,
+    "ace_editor_language": "javascript",
+    "highlightjs_language": "javascript"
   },
   "test_pattern": ".*[.]spec[.]js$",
   "files": {
-    "solution": ["%{kebab_slug}.js"],
-    "test": ["%{kebab_slug}.spec.js"],
-    "example": [".meta/proof.ci.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "%{kebab_slug}.js"
+    ],
+    "test": [
+      "%{kebab_slug}.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
   "exercises": {
     "concept": [
@@ -27,7 +37,9 @@
         "slug": "lasagna",
         "name": "Lucian's Luscious Lasagna",
         "uuid": "97bf898a-36fc-47fc-b870-01fc0c7fe554",
-        "concepts": ["basics"],
+        "concepts": [
+          "basics"
+        ],
         "prerequisites": [],
         "status": "active"
       },
@@ -35,95 +47,158 @@
         "slug": "annalyns-infiltration",
         "name": "Annalyn's Infiltration",
         "uuid": "5acafcbb-20a0-45b9-b276-3d167e0de313",
-        "concepts": ["booleans"],
-        "prerequisites": ["basics"],
+        "concepts": [
+          "booleans"
+        ],
+        "prerequisites": [
+          "basics"
+        ],
         "status": "beta"
       },
       {
         "slug": "freelancer-rates",
         "name": "Freelancer Rates",
         "uuid": "0aff2fa7-55ea-47e9-af4a-78927d916baf",
-        "concepts": ["numbers"],
-        "prerequisites": ["basics"],
+        "concepts": [
+          "numbers"
+        ],
+        "prerequisites": [
+          "basics"
+        ],
         "status": "beta"
       },
       {
         "slug": "poetry-club-door-policy",
         "name": "Poetry Club Door Policy",
         "uuid": "39549583-1889-490a-bf98-ffb2e0aefe44",
-        "concepts": ["strings"],
-        "prerequisites": ["basics"],
+        "concepts": [
+          "strings"
+        ],
+        "prerequisites": [
+          "basics"
+        ],
         "status": "beta"
       },
       {
         "slug": "elyses-enchantments",
         "name": "Elyses Enchantments",
         "uuid": "25cb0707-44f8-4800-b993-3fcb2b6d9f61",
-        "concepts": ["arrays"],
-        "prerequisites": ["numbers"],
+        "concepts": [
+          "arrays"
+        ],
+        "prerequisites": [
+          "numbers"
+        ],
         "status": "beta"
       },
       {
         "slug": "vehicle-purchase",
         "name": "Vehicle Purchase",
         "uuid": "f75a7e2c-053a-411e-8b3d-f978a2c5100e",
-        "concepts": ["comparison", "conditionals"],
-        "prerequisites": ["booleans", "numbers", "strings"],
+        "concepts": [
+          "comparison",
+          "conditionals"
+        ],
+        "prerequisites": [
+          "booleans",
+          "numbers",
+          "strings"
+        ],
         "status": "beta"
       },
       {
         "slug": "bird-watcher",
         "name": "Bird Watcher",
         "uuid": "3e648aa0-9ce7-4041-93d2-2b95f3832824",
-        "concepts": ["for-loops", "increment-decrement"],
-        "prerequisites": ["arrays", "comparison", "conditionals"],
+        "concepts": [
+          "for-loops",
+          "increment-decrement"
+        ],
+        "prerequisites": [
+          "arrays",
+          "comparison",
+          "conditionals"
+        ],
         "status": "beta"
       },
       {
         "slug": "mixed-juices",
         "name": "Mixed Juices",
         "uuid": "81c3fb86-af86-4c56-a45f-e021403c4070",
-        "concepts": ["while-loops", "conditionals-switch"],
-        "prerequisites": ["comparison", "conditionals", "arrays"],
+        "concepts": [
+          "while-loops",
+          "conditionals-switch"
+        ],
+        "prerequisites": [
+          "comparison",
+          "conditionals",
+          "arrays"
+        ],
         "status": "beta"
       },
       {
         "slug": "lucky-numbers",
         "name": "Lucky Numbers",
         "uuid": "78bbd7d2-b660-4791-a404-af5bfed31849",
-        "concepts": ["type-conversion"],
-        "prerequisites": ["arrays", "strings", "numbers"],
+        "concepts": [
+          "type-conversion"
+        ],
+        "prerequisites": [
+          "arrays",
+          "strings",
+          "numbers"
+        ],
         "status": "wip"
       },
       {
         "slug": "elyses-analytic-enchantments",
         "name": "Elyses Analytic Enchantments",
         "uuid": "45d956db-d4ef-4468-b1d3-47021f172c15",
-        "concepts": ["array-analysis"],
-        "prerequisites": ["arrays", "booleans", "callbacks", "numbers"],
+        "concepts": [
+          "array-analysis"
+        ],
+        "prerequisites": [
+          "arrays",
+          "booleans",
+          "callbacks",
+          "numbers"
+        ],
         "status": "beta"
       },
       {
         "slug": "elyses-destructured-enchantments",
         "name": "Elyses Destructured Enchantments",
         "uuid": "d9b5cd13-2f2b-4034-a571-e66c847ed6f8",
-        "concepts": ["array-destructuring", "spread-operator", "rest-elements"],
-        "prerequisites": ["arrays"],
+        "concepts": [
+          "array-destructuring",
+          "spread-operator",
+          "rest-elements"
+        ],
+        "prerequisites": [
+          "arrays"
+        ],
         "status": "beta"
       },
       {
         "slug": "nullability",
         "name": "Employee Badges",
         "uuid": "19962010-7b8c-4db1-bdae-ffc857b268e5",
-        "concepts": ["nullability"],
-        "prerequisites": ["conditionals", "strings"],
+        "concepts": [
+          "nullability"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "strings"
+        ],
         "status": "active"
       },
       {
         "slug": "recursion",
         "name": "Pizza Order",
         "uuid": "e9a9fa73-4497-43d5-a4ff-4eb319c98233",
-        "concepts": ["recursion"],
+        "concepts": [
+          "recursion"
+        ],
         "prerequisites": [
           "arrays",
           "array-destructuring",
@@ -136,15 +211,22 @@
         "slug": "closures",
         "name": "Coordinate Transformation",
         "uuid": "5aa39e89-c601-4a66-ab72-5d8512d69e02",
-        "concepts": ["closures"],
-        "prerequisites": ["arrays", "booleans"],
+        "concepts": [
+          "closures"
+        ],
+        "prerequisites": [
+          "arrays",
+          "booleans"
+        ],
         "status": "beta"
       },
       {
         "slug": "fruit-picker",
         "name": "Fruit Picker",
         "uuid": "a6348db8-cc2b-4c53-9f43-3c23248d66f0",
-        "concepts": ["callbacks"],
+        "concepts": [
+          "callbacks"
+        ],
         "prerequisites": [
           "booleans",
           "closures",
@@ -160,15 +242,24 @@
         "slug": "translation-service",
         "name": "Translation Service",
         "uuid": "4a967656-8615-474e-a009-5c0b09f4386f",
-        "concepts": ["promises"],
-        "prerequisites": ["arrays", "callbacks", "errors", "recursion"],
+        "concepts": [
+          "promises"
+        ],
+        "prerequisites": [
+          "arrays",
+          "callbacks",
+          "errors",
+          "recursion"
+        ],
         "status": "beta"
       },
       {
         "slug": "ozans-playlist",
         "name": "Ozan's Playlist",
         "uuid": "347692fb-7b0f-4ef0-9a02-2192b59bdf5d",
-        "concepts": ["sets"],
+        "concepts": [
+          "sets"
+        ],
         "prerequisites": [
           "array-destructuring",
           "array-loops",
@@ -206,59 +297,95 @@
           "optional-parameters"
         ],
         "difficulty": 1,
-        "topics": ["optional_values", "strings", "text_formatting"]
+        "topics": [
+          "optional_values",
+          "strings",
+          "text_formatting"
+        ]
       },
       {
         "slug": "resistor-color",
         "name": "Resistor Color",
         "uuid": "53be6837-c224-45f1-bff3-d7f74d6285ce",
         "practices": [],
-        "prerequisites": ["arrays", "array-analysis"],
+        "prerequisites": [
+          "arrays",
+          "array-analysis"
+        ],
         "difficulty": 1,
-        "topics": ["arrays", "strings"]
+        "topics": [
+          "arrays",
+          "strings"
+        ]
       },
       {
         "slug": "resistor-color-duo",
         "name": "Resistor Color Duo",
         "uuid": "de800041-3dcc-41b9-b101-7314ff685c93",
         "practices": [],
-        "prerequisites": ["array-transformations"],
+        "prerequisites": [
+          "array-transformations"
+        ],
         "difficulty": 2,
-        "topics": ["strings", "arrays"]
+        "topics": [
+          "strings",
+          "arrays"
+        ]
       },
       {
         "slug": "gigasecond",
         "name": "Gigasecond",
         "uuid": "fd7b62d4-266b-4e84-a526-bf3d47901216",
         "practices": [],
-        "prerequisites": ["dates", "immutability", "type-conversion"],
+        "prerequisites": [
+          "dates",
+          "immutability",
+          "type-conversion"
+        ],
         "difficulty": 1,
-        "topics": ["time"]
+        "topics": [
+          "time"
+        ]
       },
       {
         "slug": "rna-transcription",
         "name": "Rna Transcription",
         "uuid": "342974d6-9083-4754-a6c5-ed1e19e40ec5",
         "practices": [],
-        "prerequisites": ["strings", "array-transformations", "objects"],
+        "prerequisites": [
+          "strings",
+          "array-transformations",
+          "objects"
+        ],
         "difficulty": 2,
-        "topics": ["strings", "transforming"]
+        "topics": [
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "space-age",
         "name": "Space Age",
         "uuid": "d9d757ed-ebe6-4d4a-aa73-f6834221cd54",
         "practices": [],
-        "prerequisites": ["objects", "numbers"],
+        "prerequisites": [
+          "objects",
+          "numbers"
+        ],
         "difficulty": 2,
-        "topics": ["floating_point_numbers"]
+        "topics": [
+          "floating_point_numbers"
+        ]
       },
       {
         "slug": "pangram",
         "name": "Pangram",
         "uuid": "da5b2b34-a1a7-4970-81f9-4665d875398b",
         "practices": [],
-        "prerequisites": ["strings", "array-analysis"],
+        "prerequisites": [
+          "strings",
+          "array-analysis"
+        ],
         "difficulty": 2,
         "topics": [
           "algorithms",
@@ -295,7 +422,11 @@
         "name": "Bob",
         "uuid": "a5bf36f0-5d3c-41d4-8d54-e37e484e59cd",
         "practices": [],
-        "prerequisites": ["strings", "booleans", "regular-expressions"],
+        "prerequisites": [
+          "strings",
+          "booleans",
+          "regular-expressions"
+        ],
         "difficulty": 4,
         "topics": [
           "conditionals",
@@ -310,7 +441,10 @@
         "name": "Pascals Triangle",
         "uuid": "99493160-4673-402f-acda-62db5378148d",
         "practices": [],
-        "prerequisites": ["arrays", "for-loops"],
+        "prerequisites": [
+          "arrays",
+          "for-loops"
+        ],
         "difficulty": 4,
         "topics": [
           "conditionals",
@@ -325,7 +459,10 @@
         "name": "Linked List",
         "uuid": "ec60a578-8889-46a1-b7b8-306dbd8551d5",
         "practices": [],
-        "prerequisites": ["classes", "while-loops"],
+        "prerequisites": [
+          "classes",
+          "while-loops"
+        ],
         "difficulty": 5,
         "topics": [
           "algorithms",
@@ -342,18 +479,36 @@
         "name": "Grade School",
         "uuid": "64637322-33bc-401f-8cec-1f9810a41f75",
         "practices": [],
-        "prerequisites": ["classes", "objects", "arrays", "immutability"],
+        "prerequisites": [
+          "classes",
+          "objects",
+          "arrays",
+          "immutability"
+        ],
         "difficulty": 5,
-        "topics": ["arrays", "maps", "sorting"]
+        "topics": [
+          "arrays",
+          "maps",
+          "sorting"
+        ]
       },
       {
         "slug": "list-ops",
         "name": "List Ops",
         "uuid": "7d9db056-5398-41b6-af3b-9707f5eb0dbc",
         "practices": [],
-        "prerequisites": ["classes", "arrays", "functions"],
+        "prerequisites": [
+          "classes",
+          "arrays",
+          "functions"
+        ],
         "difficulty": 6,
-        "topics": ["data_structures", "loops", "lists", "recursion"]
+        "topics": [
+          "data_structures",
+          "loops",
+          "lists",
+          "recursion"
+        ]
       },
       {
         "slug": "robot-name",
@@ -405,7 +560,11 @@
         "name": "Wordy",
         "uuid": "9131bdb8-2e0f-4526-b113-8a77712e7216",
         "practices": [],
-        "prerequisites": ["strings", "regular-expressions", "errors"],
+        "prerequisites": [
+          "strings",
+          "regular-expressions",
+          "errors"
+        ],
         "difficulty": 7,
         "topics": [
           "conditionals",
@@ -422,7 +581,10 @@
         "name": "Secret Handshake",
         "uuid": "74bbc9e3-edc5-41e0-84d7-5b2d98dd8370",
         "practices": [],
-        "prerequisites": ["bit-manipulation", "array-analysis"],
+        "prerequisites": [
+          "bit-manipulation",
+          "array-analysis"
+        ],
         "difficulty": 6,
         "topics": [
           "algorithms",
@@ -438,18 +600,30 @@
         "name": "Leap",
         "uuid": "193a0e19-462d-4d26-a117-124f07d5a3d7",
         "practices": [],
-        "prerequisites": ["numbers"],
+        "prerequisites": [
+          "numbers"
+        ],
         "difficulty": 1,
-        "topics": ["booleans", "integers", "logic"]
+        "topics": [
+          "booleans",
+          "integers",
+          "logic"
+        ]
       },
       {
         "slug": "reverse-string",
         "name": "Reverse String",
         "uuid": "e84c97eb-dbec-487c-b99f-ae9924e16293",
         "practices": [],
-        "prerequisites": ["strings", "array-transformation"],
+        "prerequisites": [
+          "strings",
+          "array-transformation"
+        ],
         "difficulty": 2,
-        "topics": ["loops", "strings"]
+        "topics": [
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "collatz-conjecture",
@@ -474,7 +648,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["conditionals", "loops", "exception_handling", "integers"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "exception_handling",
+          "integers"
+        ]
       },
       {
         "slug": "clock",
@@ -483,7 +662,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["dates", "globalization", "time"]
+        "topics": [
+          "dates",
+          "globalization",
+          "time"
+        ]
       },
       {
         "slug": "meetup",
@@ -508,7 +691,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["loops", "integers", "maps", "transforming"]
+        "topics": [
+          "loops",
+          "integers",
+          "maps",
+          "transforming"
+        ]
       },
       {
         "slug": "hamming",
@@ -517,7 +705,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["conditionals", "loops", "equality", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "equality",
+          "strings"
+        ]
       },
       {
         "slug": "raindrops",
@@ -526,7 +719,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["conditionals", "integers", "strings", "transforming"]
+        "topics": [
+          "conditionals",
+          "integers",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "nucleotide-count",
@@ -550,7 +748,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "maps", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "maps",
+          "strings"
+        ]
       },
       {
         "slug": "allergies",
@@ -559,7 +762,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": ["arrays", "bitwise_operations", "conditionals", "loops"]
+        "topics": [
+          "arrays",
+          "bitwise_operations",
+          "conditionals",
+          "loops"
+        ]
       },
       {
         "slug": "word-count",
@@ -568,7 +776,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["loops", "lists", "regular_expressions", "strings"]
+        "topics": [
+          "loops",
+          "lists",
+          "regular_expressions",
+          "strings"
+        ]
       },
       {
         "slug": "bank-account",
@@ -577,7 +790,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["classes", "conditionals"]
+        "topics": [
+          "classes",
+          "conditionals"
+        ]
       },
       {
         "slug": "difference-of-squares",
@@ -586,7 +802,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["algorithms", "loops", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "perfect-numbers",
@@ -595,7 +816,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["arrays", "conditionals", "loops", "integers", "math"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "complex-numbers",
@@ -604,7 +831,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["math"]
+        "topics": [
+          "math"
+        ]
       },
       {
         "slug": "luhn",
@@ -613,7 +842,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["conditionals", "loops", "integers", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "integers",
+          "strings"
+        ]
       },
       {
         "slug": "prime-factors",
@@ -622,7 +856,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "grains",
@@ -631,7 +871,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["loops", "integers"]
+        "topics": [
+          "loops",
+          "integers"
+        ]
       },
       {
         "slug": "pythagorean-triplet",
@@ -640,7 +883,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "palindrome-products",
@@ -665,7 +914,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["filtering", "strings"]
+        "topics": [
+          "filtering",
+          "strings"
+        ]
       },
       {
         "slug": "acronym",
@@ -674,7 +926,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["loops", "regular_expressions", "strings", "transforming"]
+        "topics": [
+          "loops",
+          "regular_expressions",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "high-scores",
@@ -683,7 +940,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["arrays"]
+        "topics": [
+          "arrays"
+        ]
       },
       {
         "slug": "isogram",
@@ -692,7 +951,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["filtering", "strings"]
+        "topics": [
+          "filtering",
+          "strings"
+        ]
       },
       {
         "slug": "matching-brackets",
@@ -716,7 +978,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["parsing", "transforming"]
+        "topics": [
+          "parsing",
+          "transforming"
+        ]
       },
       {
         "slug": "scale-generator",
@@ -725,7 +990,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["loops", "pattern_recognition", "strings", "arrays"]
+        "topics": [
+          "loops",
+          "pattern_recognition",
+          "strings",
+          "arrays"
+        ]
       },
       {
         "slug": "series",
@@ -734,7 +1004,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["loops", "exception_handling", "strings", "text_formatting"]
+        "topics": [
+          "loops",
+          "exception_handling",
+          "strings",
+          "text_formatting"
+        ]
       },
       {
         "slug": "largest-series-product",
@@ -776,7 +1051,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["files", "searching", "text_formatting"]
+        "topics": [
+          "files",
+          "searching",
+          "text_formatting"
+        ]
       },
       {
         "slug": "rectangles",
@@ -785,7 +1064,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "conditionals", "loops", "matrices", "strings"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "matrices",
+          "strings"
+        ]
       },
       {
         "slug": "spiral-matrix",
@@ -844,7 +1129,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": ["domain_specific_languages", "parsing", "stacks"]
+        "topics": [
+          "domain_specific_languages",
+          "parsing",
+          "stacks"
+        ]
       },
       {
         "slug": "food-chain",
@@ -853,7 +1142,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["algorithms", "text_formatting"]
+        "topics": [
+          "algorithms",
+          "text_formatting"
+        ]
       },
       {
         "slug": "house",
@@ -862,7 +1154,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "conditionals", "loops", "recursion", "strings"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "recursion",
+          "strings"
+        ]
       },
       {
         "slug": "isbn-verifier",
@@ -934,7 +1232,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["promises", "error_handling", "higher_order_functions"]
+        "topics": [
+          "promises",
+          "error_handling",
+          "higher_order_functions"
+        ]
       },
       {
         "slug": "yacht",
@@ -943,7 +1245,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "conditionals", "filtering", "games"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "filtering",
+          "games"
+        ]
       },
       {
         "slug": "beer-song",
@@ -952,7 +1259,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "resistor-color-trio",
@@ -961,7 +1272,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops"]
+        "topics": [
+          "conditionals",
+          "loops"
+        ]
       },
       {
         "slug": "dominoes",
@@ -970,7 +1284,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": ["graph_theory"]
+        "topics": [
+          "graph_theory"
+        ]
       },
       {
         "slug": "say",
@@ -1012,7 +1328,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "floating_point_numbers", "math"]
+        "topics": [
+          "algorithms",
+          "floating_point_numbers",
+          "math"
+        ]
       },
       {
         "slug": "sublist",
@@ -1021,7 +1341,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "lists"]
+        "topics": [
+          "arrays",
+          "lists"
+        ]
       },
       {
         "slug": "binary-search-tree",
@@ -1030,7 +1353,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": ["algorithms", "conditionals", "loops", "recursion"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "recursion"
+        ]
       },
       {
         "slug": "custom-set",
@@ -1057,7 +1385,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["algorithms", "arrays", "conditionals", "loops", "recursion"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "conditionals",
+          "loops",
+          "recursion"
+        ]
       },
       {
         "slug": "circular-buffer",
@@ -1082,7 +1416,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": ["arrays", "data_structures", "lists"]
+        "topics": [
+          "arrays",
+          "data_structures",
+          "lists"
+        ]
       },
       {
         "slug": "word-search",
@@ -1108,7 +1446,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["bitwise_operations", "transforming"]
+        "topics": [
+          "bitwise_operations",
+          "transforming"
+        ]
       },
       {
         "slug": "two-bucket",
@@ -1134,7 +1475,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["algorithms", "games"]
+        "topics": [
+          "algorithms",
+          "games"
+        ]
       },
       {
         "slug": "connect",
@@ -1193,7 +1537,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "callbacks", "loops", "lists"]
+        "topics": [
+          "algorithms",
+          "callbacks",
+          "loops",
+          "lists"
+        ]
       },
       {
         "slug": "flatten-array",
@@ -1202,7 +1551,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["arrays", "recursion"]
+        "topics": [
+          "arrays",
+          "recursion"
+        ]
       },
       {
         "slug": "nth-prime",
@@ -1227,7 +1579,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "integers", "math", "recursion"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "integers",
+          "math",
+          "recursion"
+        ]
       },
       {
         "slug": "rotational-cipher",
@@ -1236,7 +1594,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["conditionals", "strings", "text_formatting", "transforming"]
+        "topics": [
+          "conditionals",
+          "strings",
+          "text_formatting",
+          "transforming"
+        ]
       },
       {
         "slug": "diffie-hellman",
@@ -1261,7 +1624,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["algorithms", "arrays", "filtering", "math"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "filtering",
+          "math"
+        ]
       },
       {
         "slug": "atbash-cipher",
@@ -1335,7 +1703,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "integers", "lists", "math"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "integers",
+          "lists",
+          "math"
+        ]
       },
       {
         "slug": "change",
@@ -1344,7 +1718,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": ["algorithms", "performance", "searching"]
+        "topics": [
+          "algorithms",
+          "performance",
+          "searching"
+        ]
       },
       {
         "slug": "point-mutations",
@@ -1363,7 +1741,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["algorithms", "conditionals", "loops", "strings"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "armstrong-numbers",
@@ -1372,7 +1755,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["algorithms", "math"]
+        "topics": [
+          "algorithms",
+          "math"
+        ]
       },
       {
         "slug": "dnd-character",
@@ -1381,7 +1767,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["classes", "randomness"]
+        "topics": [
+          "classes",
+          "randomness"
+        ]
       },
       {
         "slug": "run-length-encoding",
@@ -1482,7 +1871,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["bitwise_operations", "algorithms", "loops", "math"]
+        "topics": [
+          "bitwise_operations",
+          "algorithms",
+          "loops",
+          "math"
+        ]
       },
       {
         "slug": "trinary",
@@ -1524,7 +1918,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["algorithms", "arrays", "games"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "games"
+        ]
       },
       {
         "slug": "queen-attack",
@@ -1550,7 +1948,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": ["algorithms", "events", "reactive_programming"]
+        "topics": [
+          "algorithms",
+          "events",
+          "reactive_programming"
+        ]
       },
       {
         "slug": "zipper",
@@ -1559,7 +1961,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": ["recursion", "searching", "trees"]
+        "topics": [
+          "recursion",
+          "searching",
+          "trees"
+        ]
       }
     ]
   },


### PR DESCRIPTION
This PR adds adds two new keys to the `online_editor` property in the `config.json` files:

1. `ace_editor_language`: the language identifier for the Ace editor that is used to edit code on the website
2. `highlightjs_language`: the language identifier for Highlight.js which is used to highlight code on the website

For more information, see https://github.com/exercism/docs/pull/124/files

## Maintainer TODO list

We've pre-populated the values for the two new keys with the track's slug, which is probably the correct value for most tracks. Please check these values are correct for your track:

- [x] The `ace_editor_language` value is correct. See the [full list of identifiers](https://github.com/ajaxorg/ace/tree/master/lib/ace/mode) (filenames, not directories).
- [x] The `highlightjs_language` value is correct. See the [full list of identifiers](https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md)

## Tracking

https://github.com/exercism/v3-launch/issues/32
