### PR TITLE
Remove Tasks heading from instructions.md

### DIFF
--- a/exercises/concept/annalyns-infiltration/.docs/instructions.md
+++ b/exercises/concept/annalyns-infiltration/.docs/instructions.md
@@ -19,8 +19,6 @@ Having found the kidnappers, Annalyn considers which of the following actions sh
 
 You have four tasks: to implement the logic for determining if the above actions are available based on the state of the three characters found in the forest and whether Annalyn's pet dog is present or not.
 
-
-
 ## 1. Check if the 'Fast Attack' action is possible
 
 Implement a function named `canExecuteFastAttack` that takes a boolean value which indicates if the knight is awake.

--- a/exercises/concept/annalyns-infiltration/.docs/instructions.md
+++ b/exercises/concept/annalyns-infiltration/.docs/instructions.md
@@ -19,7 +19,7 @@ Having found the kidnappers, Annalyn considers which of the following actions sh
 
 You have four tasks: to implement the logic for determining if the above actions are available based on the state of the three characters found in the forest and whether Annalyn's pet dog is present or not.
 
-## Tasks
+
 
 ## 1. Check if the 'Fast Attack' action is possible
 

--- a/exercises/concept/errors/.docs/instructions.md
+++ b/exercises/concept/errors/.docs/instructions.md
@@ -30,7 +30,7 @@ Now that your machine is able to detect errors, you will implement a function th
 - If the temperature is too high, you will either shutdown the machine if the temperature exceeds 600°C or turn on a warning light if it is less than that.
 - If another error happens, you'll rethrow it.
 
-## Tasks
+
 
 ## 1. Monitor the humidity level of the room
 

--- a/exercises/concept/errors/.docs/instructions.md
+++ b/exercises/concept/errors/.docs/instructions.md
@@ -30,8 +30,6 @@ Now that your machine is able to detect errors, you will implement a function th
 - If the temperature is too high, you will either shutdown the machine if the temperature exceeds 600°C or turn on a warning light if it is less than that.
 - If another error happens, you'll rethrow it.
 
-
-
 ## 1. Monitor the humidity level of the room
 
 Implements a function `checkHumidityLevel` that takes the humidity percentage as a parameter.

--- a/exercises/concept/freelancer-rates/.docs/instructions.md
+++ b/exercises/concept/freelancer-rates/.docs/instructions.md
@@ -11,8 +11,6 @@ If the freelancer bills the project manager per month, there is a discount appli
 
 Discounts are modeled as fractional numbers (percentage) between `0.0` (`0%`, no discount) and `0.90` (`90%`, maximum discount).
 
-
-
 ## 1. Calculate the day rate given an hourly rate
 
 Implement a function to calculate the day rate given an hourly rate:

--- a/exercises/concept/freelancer-rates/.docs/instructions.md
+++ b/exercises/concept/freelancer-rates/.docs/instructions.md
@@ -11,7 +11,7 @@ If the freelancer bills the project manager per month, there is a discount appli
 
 Discounts are modeled as fractional numbers (percentage) between `0.0` (`0%`, no discount) and `0.90` (`90%`, maximum discount).
 
-## Tasks
+
 
 ## 1. Calculate the day rate given an hourly rate
 

--- a/exercises/concept/lucky-numbers/.docs/instructions.md
+++ b/exercises/concept/lucky-numbers/.docs/instructions.md
@@ -1,7 +1,5 @@
 # Instructions
 
-
-
 ## 1. Find the sum of two arrays
 
 Given two arrays made up of digits, write a function that interprets the arrays as numbers and sums them:

--- a/exercises/concept/lucky-numbers/.docs/instructions.md
+++ b/exercises/concept/lucky-numbers/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-## Tasks
+
 
 ## 1. Find the sum of two arrays
 

--- a/exercises/concept/poetry-club-door-policy/.docs/instructions.md
+++ b/exercises/concept/poetry-club-door-policy/.docs/instructions.md
@@ -52,7 +52,7 @@ When the guard recites **Stands so high**, you'll respond **h**, when the guard 
 
 Finally the password you write down is `Horse, please`, and you can party with the renowned poets.
 
-## Tasks
+
 
 ## 1. Get the first letter of a sentence
 

--- a/exercises/concept/poetry-club-door-policy/.docs/instructions.md
+++ b/exercises/concept/poetry-club-door-policy/.docs/instructions.md
@@ -52,8 +52,6 @@ When the guard recites **Stands so high**, you'll respond **h**, when the guard 
 
 Finally the password you write down is `Horse, please`, and you can party with the renowned poets.
 
-
-
 ## 1. Get the first letter of a sentence
 
 Implement a function that returns first letter of a sentence:


### PR DESCRIPTION
The `## Tasks` heading should not be in `instructions.md` files.