### PR TITLE
Add instructions to not use `Date` for `clock` exercise

### DIFF
--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -1,0 +1,3 @@
+# Instructions append
+
+Using the built-in [Date class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) and its methods is not allowed.


### PR DESCRIPTION
Came across a solution where student used `Date` class to implement `clock` exercise.