### PR TITLE
🤖 Add average test runner run time to `config.json`

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,12 +16,23 @@
     "ace_editor_language": "javascript",
     "highlightjs_language": "javascript"
   },
+  "test_runner": {
+    "average_run_time": 5.0
+  },
   "test_pattern": ".*[.]spec[.]js$",
   "files": {
-    "solution": ["%{kebab_slug}.js"],
-    "test": ["%{kebab_slug}.spec.js"],
-    "example": [".meta/proof.ci.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "%{kebab_slug}.js"
+    ],
+    "test": [
+      "%{kebab_slug}.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
   "exercises": {
     "concept": [
@@ -29,7 +40,9 @@
         "slug": "lasagna",
         "name": "Lucian's Luscious Lasagna",
         "uuid": "97bf898a-36fc-47fc-b870-01fc0c7fe554",
-        "concepts": ["basics"],
+        "concepts": [
+          "basics"
+        ],
         "prerequisites": [],
         "status": "active"
       },
@@ -37,95 +50,158 @@
         "slug": "annalyns-infiltration",
         "name": "Annalyn's Infiltration",
         "uuid": "5acafcbb-20a0-45b9-b276-3d167e0de313",
-        "concepts": ["booleans"],
-        "prerequisites": ["basics"],
+        "concepts": [
+          "booleans"
+        ],
+        "prerequisites": [
+          "basics"
+        ],
         "status": "beta"
       },
       {
         "slug": "freelancer-rates",
         "name": "Freelancer Rates",
         "uuid": "0aff2fa7-55ea-47e9-af4a-78927d916baf",
-        "concepts": ["numbers"],
-        "prerequisites": ["basics"],
+        "concepts": [
+          "numbers"
+        ],
+        "prerequisites": [
+          "basics"
+        ],
         "status": "beta"
       },
       {
         "slug": "poetry-club-door-policy",
         "name": "Poetry Club Door Policy",
         "uuid": "39549583-1889-490a-bf98-ffb2e0aefe44",
-        "concepts": ["strings"],
-        "prerequisites": ["basics"],
+        "concepts": [
+          "strings"
+        ],
+        "prerequisites": [
+          "basics"
+        ],
         "status": "beta"
       },
       {
         "slug": "elyses-enchantments",
         "name": "Elyses Enchantments",
         "uuid": "25cb0707-44f8-4800-b993-3fcb2b6d9f61",
-        "concepts": ["arrays"],
-        "prerequisites": ["numbers"],
+        "concepts": [
+          "arrays"
+        ],
+        "prerequisites": [
+          "numbers"
+        ],
         "status": "beta"
       },
       {
         "slug": "vehicle-purchase",
         "name": "Vehicle Purchase",
         "uuid": "f75a7e2c-053a-411e-8b3d-f978a2c5100e",
-        "concepts": ["comparison", "conditionals"],
-        "prerequisites": ["booleans", "numbers", "strings"],
+        "concepts": [
+          "comparison",
+          "conditionals"
+        ],
+        "prerequisites": [
+          "booleans",
+          "numbers",
+          "strings"
+        ],
         "status": "beta"
       },
       {
         "slug": "bird-watcher",
         "name": "Bird Watcher",
         "uuid": "3e648aa0-9ce7-4041-93d2-2b95f3832824",
-        "concepts": ["for-loops", "increment-decrement"],
-        "prerequisites": ["arrays", "comparison", "conditionals"],
+        "concepts": [
+          "for-loops",
+          "increment-decrement"
+        ],
+        "prerequisites": [
+          "arrays",
+          "comparison",
+          "conditionals"
+        ],
         "status": "beta"
       },
       {
         "slug": "mixed-juices",
         "name": "Mixed Juices",
         "uuid": "81c3fb86-af86-4c56-a45f-e021403c4070",
-        "concepts": ["while-loops", "conditionals-switch"],
-        "prerequisites": ["comparison", "conditionals", "arrays"],
+        "concepts": [
+          "while-loops",
+          "conditionals-switch"
+        ],
+        "prerequisites": [
+          "comparison",
+          "conditionals",
+          "arrays"
+        ],
         "status": "beta"
       },
       {
         "slug": "lucky-numbers",
         "name": "Lucky Numbers",
         "uuid": "78bbd7d2-b660-4791-a404-af5bfed31849",
-        "concepts": ["type-conversion"],
-        "prerequisites": ["arrays", "strings", "numbers"],
+        "concepts": [
+          "type-conversion"
+        ],
+        "prerequisites": [
+          "arrays",
+          "strings",
+          "numbers"
+        ],
         "status": "wip"
       },
       {
         "slug": "elyses-analytic-enchantments",
         "name": "Elyses Analytic Enchantments",
         "uuid": "45d956db-d4ef-4468-b1d3-47021f172c15",
-        "concepts": ["array-analysis"],
-        "prerequisites": ["arrays", "booleans", "callbacks", "numbers"],
+        "concepts": [
+          "array-analysis"
+        ],
+        "prerequisites": [
+          "arrays",
+          "booleans",
+          "callbacks",
+          "numbers"
+        ],
         "status": "beta"
       },
       {
         "slug": "elyses-destructured-enchantments",
         "name": "Elyses Destructured Enchantments",
         "uuid": "d9b5cd13-2f2b-4034-a571-e66c847ed6f8",
-        "concepts": ["array-destructuring", "spread-operator", "rest-elements"],
-        "prerequisites": ["arrays"],
+        "concepts": [
+          "array-destructuring",
+          "spread-operator",
+          "rest-elements"
+        ],
+        "prerequisites": [
+          "arrays"
+        ],
         "status": "beta"
       },
       {
         "slug": "nullability",
         "name": "Employee Badges",
         "uuid": "19962010-7b8c-4db1-bdae-ffc857b268e5",
-        "concepts": ["nullability"],
-        "prerequisites": ["conditionals", "strings"],
+        "concepts": [
+          "nullability"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "strings"
+        ],
         "status": "active"
       },
       {
         "slug": "recursion",
         "name": "Pizza Order",
         "uuid": "e9a9fa73-4497-43d5-a4ff-4eb319c98233",
-        "concepts": ["recursion"],
+        "concepts": [
+          "recursion"
+        ],
         "prerequisites": [
           "arrays",
           "array-destructuring",
@@ -138,15 +214,22 @@
         "slug": "closures",
         "name": "Coordinate Transformation",
         "uuid": "5aa39e89-c601-4a66-ab72-5d8512d69e02",
-        "concepts": ["closures"],
-        "prerequisites": ["arrays", "booleans"],
+        "concepts": [
+          "closures"
+        ],
+        "prerequisites": [
+          "arrays",
+          "booleans"
+        ],
         "status": "beta"
       },
       {
         "slug": "fruit-picker",
         "name": "Fruit Picker",
         "uuid": "a6348db8-cc2b-4c53-9f43-3c23248d66f0",
-        "concepts": ["callbacks"],
+        "concepts": [
+          "callbacks"
+        ],
         "prerequisites": [
           "booleans",
           "closures",
@@ -162,15 +245,24 @@
         "slug": "translation-service",
         "name": "Translation Service",
         "uuid": "4a967656-8615-474e-a009-5c0b09f4386f",
-        "concepts": ["promises"],
-        "prerequisites": ["arrays", "callbacks", "errors", "recursion"],
+        "concepts": [
+          "promises"
+        ],
+        "prerequisites": [
+          "arrays",
+          "callbacks",
+          "errors",
+          "recursion"
+        ],
         "status": "beta"
       },
       {
         "slug": "ozans-playlist",
         "name": "Ozan's Playlist",
         "uuid": "347692fb-7b0f-4ef0-9a02-2192b59bdf5d",
-        "concepts": ["sets"],
+        "concepts": [
+          "sets"
+        ],
         "prerequisites": [
           "array-destructuring",
           "array-loops",
@@ -208,59 +300,95 @@
           "optional-parameters"
         ],
         "difficulty": 1,
-        "topics": ["optional_values", "strings", "text_formatting"]
+        "topics": [
+          "optional_values",
+          "strings",
+          "text_formatting"
+        ]
       },
       {
         "slug": "resistor-color",
         "name": "Resistor Color",
         "uuid": "53be6837-c224-45f1-bff3-d7f74d6285ce",
         "practices": [],
-        "prerequisites": ["arrays", "array-analysis"],
+        "prerequisites": [
+          "arrays",
+          "array-analysis"
+        ],
         "difficulty": 1,
-        "topics": ["arrays", "strings"]
+        "topics": [
+          "arrays",
+          "strings"
+        ]
       },
       {
         "slug": "resistor-color-duo",
         "name": "Resistor Color Duo",
         "uuid": "de800041-3dcc-41b9-b101-7314ff685c93",
         "practices": [],
-        "prerequisites": ["array-transformations"],
+        "prerequisites": [
+          "array-transformations"
+        ],
         "difficulty": 2,
-        "topics": ["strings", "arrays"]
+        "topics": [
+          "strings",
+          "arrays"
+        ]
       },
       {
         "slug": "gigasecond",
         "name": "Gigasecond",
         "uuid": "fd7b62d4-266b-4e84-a526-bf3d47901216",
         "practices": [],
-        "prerequisites": ["dates", "immutability", "type-conversion"],
+        "prerequisites": [
+          "dates",
+          "immutability",
+          "type-conversion"
+        ],
         "difficulty": 1,
-        "topics": ["time"]
+        "topics": [
+          "time"
+        ]
       },
       {
         "slug": "rna-transcription",
         "name": "Rna Transcription",
         "uuid": "342974d6-9083-4754-a6c5-ed1e19e40ec5",
         "practices": [],
-        "prerequisites": ["strings", "array-transformations", "objects"],
+        "prerequisites": [
+          "strings",
+          "array-transformations",
+          "objects"
+        ],
         "difficulty": 2,
-        "topics": ["strings", "transforming"]
+        "topics": [
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "space-age",
         "name": "Space Age",
         "uuid": "d9d757ed-ebe6-4d4a-aa73-f6834221cd54",
         "practices": [],
-        "prerequisites": ["objects", "numbers"],
+        "prerequisites": [
+          "objects",
+          "numbers"
+        ],
         "difficulty": 2,
-        "topics": ["floating_point_numbers"]
+        "topics": [
+          "floating_point_numbers"
+        ]
       },
       {
         "slug": "pangram",
         "name": "Pangram",
         "uuid": "da5b2b34-a1a7-4970-81f9-4665d875398b",
         "practices": [],
-        "prerequisites": ["strings", "array-analysis"],
+        "prerequisites": [
+          "strings",
+          "array-analysis"
+        ],
         "difficulty": 2,
         "topics": [
           "algorithms",
@@ -297,7 +425,11 @@
         "name": "Bob",
         "uuid": "a5bf36f0-5d3c-41d4-8d54-e37e484e59cd",
         "practices": [],
-        "prerequisites": ["strings", "booleans", "regular-expressions"],
+        "prerequisites": [
+          "strings",
+          "booleans",
+          "regular-expressions"
+        ],
         "difficulty": 4,
         "topics": [
           "conditionals",
@@ -312,7 +444,10 @@
         "name": "Pascals Triangle",
         "uuid": "99493160-4673-402f-acda-62db5378148d",
         "practices": [],
-        "prerequisites": ["arrays", "for-loops"],
+        "prerequisites": [
+          "arrays",
+          "for-loops"
+        ],
         "difficulty": 4,
         "topics": [
           "conditionals",
@@ -327,7 +462,10 @@
         "name": "Linked List",
         "uuid": "ec60a578-8889-46a1-b7b8-306dbd8551d5",
         "practices": [],
-        "prerequisites": ["classes", "while-loops"],
+        "prerequisites": [
+          "classes",
+          "while-loops"
+        ],
         "difficulty": 5,
         "topics": [
           "algorithms",
@@ -344,18 +482,36 @@
         "name": "Grade School",
         "uuid": "64637322-33bc-401f-8cec-1f9810a41f75",
         "practices": [],
-        "prerequisites": ["classes", "objects", "arrays", "immutability"],
+        "prerequisites": [
+          "classes",
+          "objects",
+          "arrays",
+          "immutability"
+        ],
         "difficulty": 5,
-        "topics": ["arrays", "maps", "sorting"]
+        "topics": [
+          "arrays",
+          "maps",
+          "sorting"
+        ]
       },
       {
         "slug": "list-ops",
         "name": "List Ops",
         "uuid": "7d9db056-5398-41b6-af3b-9707f5eb0dbc",
         "practices": [],
-        "prerequisites": ["classes", "arrays", "functions"],
+        "prerequisites": [
+          "classes",
+          "arrays",
+          "functions"
+        ],
         "difficulty": 6,
-        "topics": ["data_structures", "loops", "lists", "recursion"]
+        "topics": [
+          "data_structures",
+          "loops",
+          "lists",
+          "recursion"
+        ]
       },
       {
         "slug": "robot-name",
@@ -407,7 +563,11 @@
         "name": "Wordy",
         "uuid": "9131bdb8-2e0f-4526-b113-8a77712e7216",
         "practices": [],
-        "prerequisites": ["strings", "regular-expressions", "errors"],
+        "prerequisites": [
+          "strings",
+          "regular-expressions",
+          "errors"
+        ],
         "difficulty": 7,
         "topics": [
           "conditionals",
@@ -424,7 +584,10 @@
         "name": "Secret Handshake",
         "uuid": "74bbc9e3-edc5-41e0-84d7-5b2d98dd8370",
         "practices": [],
-        "prerequisites": ["bit-manipulation", "array-analysis"],
+        "prerequisites": [
+          "bit-manipulation",
+          "array-analysis"
+        ],
         "difficulty": 6,
         "topics": [
           "algorithms",
@@ -440,18 +603,30 @@
         "name": "Leap",
         "uuid": "193a0e19-462d-4d26-a117-124f07d5a3d7",
         "practices": [],
-        "prerequisites": ["numbers"],
+        "prerequisites": [
+          "numbers"
+        ],
         "difficulty": 1,
-        "topics": ["booleans", "integers", "logic"]
+        "topics": [
+          "booleans",
+          "integers",
+          "logic"
+        ]
       },
       {
         "slug": "reverse-string",
         "name": "Reverse String",
         "uuid": "e84c97eb-dbec-487c-b99f-ae9924e16293",
         "practices": [],
-        "prerequisites": ["strings", "array-transformation"],
+        "prerequisites": [
+          "strings",
+          "array-transformation"
+        ],
         "difficulty": 2,
-        "topics": ["loops", "strings"]
+        "topics": [
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "collatz-conjecture",
@@ -476,7 +651,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["conditionals", "loops", "exception_handling", "integers"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "exception_handling",
+          "integers"
+        ]
       },
       {
         "slug": "clock",
@@ -485,7 +665,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["dates", "globalization", "time"]
+        "topics": [
+          "dates",
+          "globalization",
+          "time"
+        ]
       },
       {
         "slug": "meetup",
@@ -510,7 +694,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["loops", "integers", "maps", "transforming"]
+        "topics": [
+          "loops",
+          "integers",
+          "maps",
+          "transforming"
+        ]
       },
       {
         "slug": "hamming",
@@ -519,7 +708,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["conditionals", "loops", "equality", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "equality",
+          "strings"
+        ]
       },
       {
         "slug": "raindrops",
@@ -528,7 +722,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["conditionals", "integers", "strings", "transforming"]
+        "topics": [
+          "conditionals",
+          "integers",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "nucleotide-count",
@@ -552,7 +751,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "maps", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "maps",
+          "strings"
+        ]
       },
       {
         "slug": "allergies",
@@ -561,7 +765,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": ["arrays", "bitwise_operations", "conditionals", "loops"]
+        "topics": [
+          "arrays",
+          "bitwise_operations",
+          "conditionals",
+          "loops"
+        ]
       },
       {
         "slug": "word-count",
@@ -570,7 +779,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["loops", "lists", "regular_expressions", "strings"]
+        "topics": [
+          "loops",
+          "lists",
+          "regular_expressions",
+          "strings"
+        ]
       },
       {
         "slug": "bank-account",
@@ -579,7 +793,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["classes", "conditionals"]
+        "topics": [
+          "classes",
+          "conditionals"
+        ]
       },
       {
         "slug": "difference-of-squares",
@@ -588,7 +805,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["algorithms", "loops", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "perfect-numbers",
@@ -597,7 +819,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["arrays", "conditionals", "loops", "integers", "math"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "complex-numbers",
@@ -606,7 +834,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["math"]
+        "topics": [
+          "math"
+        ]
       },
       {
         "slug": "luhn",
@@ -615,7 +845,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["conditionals", "loops", "integers", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "integers",
+          "strings"
+        ]
       },
       {
         "slug": "prime-factors",
@@ -624,7 +859,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "grains",
@@ -633,7 +874,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["loops", "integers"]
+        "topics": [
+          "loops",
+          "integers"
+        ]
       },
       {
         "slug": "pythagorean-triplet",
@@ -642,7 +886,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "palindrome-products",
@@ -667,7 +917,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["filtering", "strings"]
+        "topics": [
+          "filtering",
+          "strings"
+        ]
       },
       {
         "slug": "acronym",
@@ -676,7 +929,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["loops", "regular_expressions", "strings", "transforming"]
+        "topics": [
+          "loops",
+          "regular_expressions",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "high-scores",
@@ -685,7 +943,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["arrays"]
+        "topics": [
+          "arrays"
+        ]
       },
       {
         "slug": "isogram",
@@ -694,7 +954,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["filtering", "strings"]
+        "topics": [
+          "filtering",
+          "strings"
+        ]
       },
       {
         "slug": "matching-brackets",
@@ -718,7 +981,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["parsing", "transforming"]
+        "topics": [
+          "parsing",
+          "transforming"
+        ]
       },
       {
         "slug": "scale-generator",
@@ -727,7 +993,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["loops", "pattern_recognition", "strings", "arrays"]
+        "topics": [
+          "loops",
+          "pattern_recognition",
+          "strings",
+          "arrays"
+        ]
       },
       {
         "slug": "series",
@@ -736,7 +1007,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["loops", "exception_handling", "strings", "text_formatting"]
+        "topics": [
+          "loops",
+          "exception_handling",
+          "strings",
+          "text_formatting"
+        ]
       },
       {
         "slug": "largest-series-product",
@@ -778,7 +1054,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["files", "searching", "text_formatting"]
+        "topics": [
+          "files",
+          "searching",
+          "text_formatting"
+        ]
       },
       {
         "slug": "rectangles",
@@ -787,7 +1067,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "conditionals", "loops", "matrices", "strings"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "matrices",
+          "strings"
+        ]
       },
       {
         "slug": "spiral-matrix",
@@ -846,7 +1132,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": ["domain_specific_languages", "parsing", "stacks"]
+        "topics": [
+          "domain_specific_languages",
+          "parsing",
+          "stacks"
+        ]
       },
       {
         "slug": "food-chain",
@@ -855,7 +1145,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["algorithms", "text_formatting"]
+        "topics": [
+          "algorithms",
+          "text_formatting"
+        ]
       },
       {
         "slug": "house",
@@ -864,7 +1157,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "conditionals", "loops", "recursion", "strings"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "loops",
+          "recursion",
+          "strings"
+        ]
       },
       {
         "slug": "isbn-verifier",
@@ -936,7 +1235,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["promises", "error_handling", "higher_order_functions"]
+        "topics": [
+          "promises",
+          "error_handling",
+          "higher_order_functions"
+        ]
       },
       {
         "slug": "yacht",
@@ -945,7 +1248,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "conditionals", "filtering", "games"]
+        "topics": [
+          "arrays",
+          "conditionals",
+          "filtering",
+          "games"
+        ]
       },
       {
         "slug": "beer-song",
@@ -954,7 +1262,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "strings"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "resistor-color-trio",
@@ -963,7 +1275,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops"]
+        "topics": [
+          "conditionals",
+          "loops"
+        ]
       },
       {
         "slug": "dominoes",
@@ -972,7 +1287,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": ["graph_theory"]
+        "topics": [
+          "graph_theory"
+        ]
       },
       {
         "slug": "say",
@@ -1014,7 +1331,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "floating_point_numbers", "math"]
+        "topics": [
+          "algorithms",
+          "floating_point_numbers",
+          "math"
+        ]
       },
       {
         "slug": "sublist",
@@ -1023,7 +1344,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["arrays", "lists"]
+        "topics": [
+          "arrays",
+          "lists"
+        ]
       },
       {
         "slug": "binary-search-tree",
@@ -1032,7 +1356,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": ["algorithms", "conditionals", "loops", "recursion"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "recursion"
+        ]
       },
       {
         "slug": "custom-set",
@@ -1059,7 +1388,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["algorithms", "arrays", "conditionals", "loops", "recursion"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "conditionals",
+          "loops",
+          "recursion"
+        ]
       },
       {
         "slug": "circular-buffer",
@@ -1084,7 +1419,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": ["arrays", "data_structures", "lists"]
+        "topics": [
+          "arrays",
+          "data_structures",
+          "lists"
+        ]
       },
       {
         "slug": "word-search",
@@ -1110,7 +1449,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["bitwise_operations", "transforming"]
+        "topics": [
+          "bitwise_operations",
+          "transforming"
+        ]
       },
       {
         "slug": "two-bucket",
@@ -1136,7 +1478,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["algorithms", "games"]
+        "topics": [
+          "algorithms",
+          "games"
+        ]
       },
       {
         "slug": "connect",
@@ -1195,7 +1540,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "callbacks", "loops", "lists"]
+        "topics": [
+          "algorithms",
+          "callbacks",
+          "loops",
+          "lists"
+        ]
       },
       {
         "slug": "flatten-array",
@@ -1204,7 +1554,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["arrays", "recursion"]
+        "topics": [
+          "arrays",
+          "recursion"
+        ]
       },
       {
         "slug": "nth-prime",
@@ -1229,7 +1582,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "integers", "math", "recursion"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "integers",
+          "math",
+          "recursion"
+        ]
       },
       {
         "slug": "rotational-cipher",
@@ -1238,7 +1597,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["conditionals", "strings", "text_formatting", "transforming"]
+        "topics": [
+          "conditionals",
+          "strings",
+          "text_formatting",
+          "transforming"
+        ]
       },
       {
         "slug": "diffie-hellman",
@@ -1263,7 +1627,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["algorithms", "arrays", "filtering", "math"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "filtering",
+          "math"
+        ]
       },
       {
         "slug": "atbash-cipher",
@@ -1337,7 +1706,13 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["conditionals", "loops", "integers", "lists", "math"]
+        "topics": [
+          "conditionals",
+          "loops",
+          "integers",
+          "lists",
+          "math"
+        ]
       },
       {
         "slug": "change",
@@ -1346,7 +1721,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": ["algorithms", "performance", "searching"]
+        "topics": [
+          "algorithms",
+          "performance",
+          "searching"
+        ]
       },
       {
         "slug": "point-mutations",
@@ -1365,7 +1744,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["algorithms", "conditionals", "loops", "strings"]
+        "topics": [
+          "algorithms",
+          "conditionals",
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "armstrong-numbers",
@@ -1374,7 +1758,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["algorithms", "math"]
+        "topics": [
+          "algorithms",
+          "math"
+        ]
       },
       {
         "slug": "dnd-character",
@@ -1383,7 +1770,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["classes", "randomness"]
+        "topics": [
+          "classes",
+          "randomness"
+        ]
       },
       {
         "slug": "run-length-encoding",
@@ -1484,7 +1874,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["bitwise_operations", "algorithms", "loops", "math"]
+        "topics": [
+          "bitwise_operations",
+          "algorithms",
+          "loops",
+          "math"
+        ]
       },
       {
         "slug": "trinary",
@@ -1526,7 +1921,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": ["algorithms", "arrays", "games"]
+        "topics": [
+          "algorithms",
+          "arrays",
+          "games"
+        ]
       },
       {
         "slug": "queen-attack",
@@ -1552,7 +1951,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": ["algorithms", "events", "reactive_programming"]
+        "topics": [
+          "algorithms",
+          "events",
+          "reactive_programming"
+        ]
       },
       {
         "slug": "zipper",
@@ -1561,7 +1964,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": ["recursion", "searching", "trees"]
+        "topics": [
+          "recursion",
+          "searching",
+          "trees"
+        ]
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -21,18 +21,10 @@
   },
   "test_pattern": ".*[.]spec[.]js$",
   "files": {
-    "solution": [
-      "%{kebab_slug}.js"
-    ],
-    "test": [
-      "%{kebab_slug}.spec.js"
-    ],
-    "example": [
-      ".meta/proof.ci.js"
-    ],
-    "exemplar": [
-      ".meta/exemplar.js"
-    ]
+    "solution": ["%{kebab_slug}.js"],
+    "test": ["%{kebab_slug}.spec.js"],
+    "example": [".meta/proof.ci.js"],
+    "exemplar": [".meta/exemplar.js"]
   },
   "exercises": {
     "concept": [
@@ -40,9 +32,7 @@
         "slug": "lasagna",
         "name": "Lucian's Luscious Lasagna",
         "uuid": "97bf898a-36fc-47fc-b870-01fc0c7fe554",
-        "concepts": [
-          "basics"
-        ],
+        "concepts": ["basics"],
         "prerequisites": [],
         "status": "active"
       },
@@ -50,158 +40,95 @@
         "slug": "annalyns-infiltration",
         "name": "Annalyn's Infiltration",
         "uuid": "5acafcbb-20a0-45b9-b276-3d167e0de313",
-        "concepts": [
-          "booleans"
-        ],
-        "prerequisites": [
-          "basics"
-        ],
+        "concepts": ["booleans"],
+        "prerequisites": ["basics"],
         "status": "beta"
       },
       {
         "slug": "freelancer-rates",
         "name": "Freelancer Rates",
         "uuid": "0aff2fa7-55ea-47e9-af4a-78927d916baf",
-        "concepts": [
-          "numbers"
-        ],
-        "prerequisites": [
-          "basics"
-        ],
+        "concepts": ["numbers"],
+        "prerequisites": ["basics"],
         "status": "beta"
       },
       {
         "slug": "poetry-club-door-policy",
         "name": "Poetry Club Door Policy",
         "uuid": "39549583-1889-490a-bf98-ffb2e0aefe44",
-        "concepts": [
-          "strings"
-        ],
-        "prerequisites": [
-          "basics"
-        ],
+        "concepts": ["strings"],
+        "prerequisites": ["basics"],
         "status": "beta"
       },
       {
         "slug": "elyses-enchantments",
         "name": "Elyses Enchantments",
         "uuid": "25cb0707-44f8-4800-b993-3fcb2b6d9f61",
-        "concepts": [
-          "arrays"
-        ],
-        "prerequisites": [
-          "numbers"
-        ],
+        "concepts": ["arrays"],
+        "prerequisites": ["numbers"],
         "status": "beta"
       },
       {
         "slug": "vehicle-purchase",
         "name": "Vehicle Purchase",
         "uuid": "f75a7e2c-053a-411e-8b3d-f978a2c5100e",
-        "concepts": [
-          "comparison",
-          "conditionals"
-        ],
-        "prerequisites": [
-          "booleans",
-          "numbers",
-          "strings"
-        ],
+        "concepts": ["comparison", "conditionals"],
+        "prerequisites": ["booleans", "numbers", "strings"],
         "status": "beta"
       },
       {
         "slug": "bird-watcher",
         "name": "Bird Watcher",
         "uuid": "3e648aa0-9ce7-4041-93d2-2b95f3832824",
-        "concepts": [
-          "for-loops",
-          "increment-decrement"
-        ],
-        "prerequisites": [
-          "arrays",
-          "comparison",
-          "conditionals"
-        ],
+        "concepts": ["for-loops", "increment-decrement"],
+        "prerequisites": ["arrays", "comparison", "conditionals"],
         "status": "beta"
       },
       {
         "slug": "mixed-juices",
         "name": "Mixed Juices",
         "uuid": "81c3fb86-af86-4c56-a45f-e021403c4070",
-        "concepts": [
-          "while-loops",
-          "conditionals-switch"
-        ],
-        "prerequisites": [
-          "comparison",
-          "conditionals",
-          "arrays"
-        ],
+        "concepts": ["while-loops", "conditionals-switch"],
+        "prerequisites": ["comparison", "conditionals", "arrays"],
         "status": "beta"
       },
       {
         "slug": "lucky-numbers",
         "name": "Lucky Numbers",
         "uuid": "78bbd7d2-b660-4791-a404-af5bfed31849",
-        "concepts": [
-          "type-conversion"
-        ],
-        "prerequisites": [
-          "arrays",
-          "strings",
-          "numbers"
-        ],
+        "concepts": ["type-conversion"],
+        "prerequisites": ["arrays", "strings", "numbers"],
         "status": "wip"
       },
       {
         "slug": "elyses-analytic-enchantments",
         "name": "Elyses Analytic Enchantments",
         "uuid": "45d956db-d4ef-4468-b1d3-47021f172c15",
-        "concepts": [
-          "array-analysis"
-        ],
-        "prerequisites": [
-          "arrays",
-          "booleans",
-          "callbacks",
-          "numbers"
-        ],
+        "concepts": ["array-analysis"],
+        "prerequisites": ["arrays", "booleans", "callbacks", "numbers"],
         "status": "beta"
       },
       {
         "slug": "elyses-destructured-enchantments",
         "name": "Elyses Destructured Enchantments",
         "uuid": "d9b5cd13-2f2b-4034-a571-e66c847ed6f8",
-        "concepts": [
-          "array-destructuring",
-          "spread-operator",
-          "rest-elements"
-        ],
-        "prerequisites": [
-          "arrays"
-        ],
+        "concepts": ["array-destructuring", "spread-operator", "rest-elements"],
+        "prerequisites": ["arrays"],
         "status": "beta"
       },
       {
         "slug": "nullability",
         "name": "Employee Badges",
         "uuid": "19962010-7b8c-4db1-bdae-ffc857b268e5",
-        "concepts": [
-          "nullability"
-        ],
-        "prerequisites": [
-          "conditionals",
-          "strings"
-        ],
+        "concepts": ["nullability"],
+        "prerequisites": ["conditionals", "strings"],
         "status": "active"
       },
       {
         "slug": "recursion",
         "name": "Pizza Order",
         "uuid": "e9a9fa73-4497-43d5-a4ff-4eb319c98233",
-        "concepts": [
-          "recursion"
-        ],
+        "concepts": ["recursion"],
         "prerequisites": [
           "arrays",
           "array-destructuring",
@@ -214,22 +141,15 @@
         "slug": "closures",
         "name": "Coordinate Transformation",
         "uuid": "5aa39e89-c601-4a66-ab72-5d8512d69e02",
-        "concepts": [
-          "closures"
-        ],
-        "prerequisites": [
-          "arrays",
-          "booleans"
-        ],
+        "concepts": ["closures"],
+        "prerequisites": ["arrays", "booleans"],
         "status": "beta"
       },
       {
         "slug": "fruit-picker",
         "name": "Fruit Picker",
         "uuid": "a6348db8-cc2b-4c53-9f43-3c23248d66f0",
-        "concepts": [
-          "callbacks"
-        ],
+        "concepts": ["callbacks"],
         "prerequisites": [
           "booleans",
           "closures",
@@ -245,24 +165,15 @@
         "slug": "translation-service",
         "name": "Translation Service",
         "uuid": "4a967656-8615-474e-a009-5c0b09f4386f",
-        "concepts": [
-          "promises"
-        ],
-        "prerequisites": [
-          "arrays",
-          "callbacks",
-          "errors",
-          "recursion"
-        ],
+        "concepts": ["promises"],
+        "prerequisites": ["arrays", "callbacks", "errors", "recursion"],
         "status": "beta"
       },
       {
         "slug": "ozans-playlist",
         "name": "Ozan's Playlist",
         "uuid": "347692fb-7b0f-4ef0-9a02-2192b59bdf5d",
-        "concepts": [
-          "sets"
-        ],
+        "concepts": ["sets"],
         "prerequisites": [
           "array-destructuring",
           "array-loops",
@@ -300,95 +211,59 @@
           "optional-parameters"
         ],
         "difficulty": 1,
-        "topics": [
-          "optional_values",
-          "strings",
-          "text_formatting"
-        ]
+        "topics": ["optional_values", "strings", "text_formatting"]
       },
       {
         "slug": "resistor-color",
         "name": "Resistor Color",
         "uuid": "53be6837-c224-45f1-bff3-d7f74d6285ce",
         "practices": [],
-        "prerequisites": [
-          "arrays",
-          "array-analysis"
-        ],
+        "prerequisites": ["arrays", "array-analysis"],
         "difficulty": 1,
-        "topics": [
-          "arrays",
-          "strings"
-        ]
+        "topics": ["arrays", "strings"]
       },
       {
         "slug": "resistor-color-duo",
         "name": "Resistor Color Duo",
         "uuid": "de800041-3dcc-41b9-b101-7314ff685c93",
         "practices": [],
-        "prerequisites": [
-          "array-transformations"
-        ],
+        "prerequisites": ["array-transformations"],
         "difficulty": 2,
-        "topics": [
-          "strings",
-          "arrays"
-        ]
+        "topics": ["strings", "arrays"]
       },
       {
         "slug": "gigasecond",
         "name": "Gigasecond",
         "uuid": "fd7b62d4-266b-4e84-a526-bf3d47901216",
         "practices": [],
-        "prerequisites": [
-          "dates",
-          "immutability",
-          "type-conversion"
-        ],
+        "prerequisites": ["dates", "immutability", "type-conversion"],
         "difficulty": 1,
-        "topics": [
-          "time"
-        ]
+        "topics": ["time"]
       },
       {
         "slug": "rna-transcription",
         "name": "Rna Transcription",
         "uuid": "342974d6-9083-4754-a6c5-ed1e19e40ec5",
         "practices": [],
-        "prerequisites": [
-          "strings",
-          "array-transformations",
-          "objects"
-        ],
+        "prerequisites": ["strings", "array-transformations", "objects"],
         "difficulty": 2,
-        "topics": [
-          "strings",
-          "transforming"
-        ]
+        "topics": ["strings", "transforming"]
       },
       {
         "slug": "space-age",
         "name": "Space Age",
         "uuid": "d9d757ed-ebe6-4d4a-aa73-f6834221cd54",
         "practices": [],
-        "prerequisites": [
-          "objects",
-          "numbers"
-        ],
+        "prerequisites": ["objects", "numbers"],
         "difficulty": 2,
-        "topics": [
-          "floating_point_numbers"
-        ]
+        "topics": ["floating_point_numbers"]
       },
       {
         "slug": "pangram",
         "name": "Pangram",
         "uuid": "da5b2b34-a1a7-4970-81f9-4665d875398b",
         "practices": [],
-        "prerequisites": [
-          "strings",
-          "array-analysis"
-        ],
+        "prerequisites": ["strings", "array-analysis"],
         "difficulty": 2,
         "topics": [
           "algorithms",
@@ -425,11 +300,7 @@
         "name": "Bob",
         "uuid": "a5bf36f0-5d3c-41d4-8d54-e37e484e59cd",
         "practices": [],
-        "prerequisites": [
-          "strings",
-          "booleans",
-          "regular-expressions"
-        ],
+        "prerequisites": ["strings", "booleans", "regular-expressions"],
         "difficulty": 4,
         "topics": [
           "conditionals",
@@ -444,10 +315,7 @@
         "name": "Pascals Triangle",
         "uuid": "99493160-4673-402f-acda-62db5378148d",
         "practices": [],
-        "prerequisites": [
-          "arrays",
-          "for-loops"
-        ],
+        "prerequisites": ["arrays", "for-loops"],
         "difficulty": 4,
         "topics": [
           "conditionals",
@@ -462,10 +330,7 @@
         "name": "Linked List",
         "uuid": "ec60a578-8889-46a1-b7b8-306dbd8551d5",
         "practices": [],
-        "prerequisites": [
-          "classes",
-          "while-loops"
-        ],
+        "prerequisites": ["classes", "while-loops"],
         "difficulty": 5,
         "topics": [
           "algorithms",
@@ -482,36 +347,18 @@
         "name": "Grade School",
         "uuid": "64637322-33bc-401f-8cec-1f9810a41f75",
         "practices": [],
-        "prerequisites": [
-          "classes",
-          "objects",
-          "arrays",
-          "immutability"
-        ],
+        "prerequisites": ["classes", "objects", "arrays", "immutability"],
         "difficulty": 5,
-        "topics": [
-          "arrays",
-          "maps",
-          "sorting"
-        ]
+        "topics": ["arrays", "maps", "sorting"]
       },
       {
         "slug": "list-ops",
         "name": "List Ops",
         "uuid": "7d9db056-5398-41b6-af3b-9707f5eb0dbc",
         "practices": [],
-        "prerequisites": [
-          "classes",
-          "arrays",
-          "functions"
-        ],
+        "prerequisites": ["classes", "arrays", "functions"],
         "difficulty": 6,
-        "topics": [
-          "data_structures",
-          "loops",
-          "lists",
-          "recursion"
-        ]
+        "topics": ["data_structures", "loops", "lists", "recursion"]
       },
       {
         "slug": "robot-name",
@@ -563,11 +410,7 @@
         "name": "Wordy",
         "uuid": "9131bdb8-2e0f-4526-b113-8a77712e7216",
         "practices": [],
-        "prerequisites": [
-          "strings",
-          "regular-expressions",
-          "errors"
-        ],
+        "prerequisites": ["strings", "regular-expressions", "errors"],
         "difficulty": 7,
         "topics": [
           "conditionals",
@@ -584,10 +427,7 @@
         "name": "Secret Handshake",
         "uuid": "74bbc9e3-edc5-41e0-84d7-5b2d98dd8370",
         "practices": [],
-        "prerequisites": [
-          "bit-manipulation",
-          "array-analysis"
-        ],
+        "prerequisites": ["bit-manipulation", "array-analysis"],
         "difficulty": 6,
         "topics": [
           "algorithms",
@@ -603,30 +443,18 @@
         "name": "Leap",
         "uuid": "193a0e19-462d-4d26-a117-124f07d5a3d7",
         "practices": [],
-        "prerequisites": [
-          "numbers"
-        ],
+        "prerequisites": ["numbers"],
         "difficulty": 1,
-        "topics": [
-          "booleans",
-          "integers",
-          "logic"
-        ]
+        "topics": ["booleans", "integers", "logic"]
       },
       {
         "slug": "reverse-string",
         "name": "Reverse String",
         "uuid": "e84c97eb-dbec-487c-b99f-ae9924e16293",
         "practices": [],
-        "prerequisites": [
-          "strings",
-          "array-transformation"
-        ],
+        "prerequisites": ["strings", "array-transformation"],
         "difficulty": 2,
-        "topics": [
-          "loops",
-          "strings"
-        ]
+        "topics": ["loops", "strings"]
       },
       {
         "slug": "collatz-conjecture",
@@ -651,12 +479,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "conditionals",
-          "loops",
-          "exception_handling",
-          "integers"
-        ]
+        "topics": ["conditionals", "loops", "exception_handling", "integers"]
       },
       {
         "slug": "clock",
@@ -665,11 +488,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "dates",
-          "globalization",
-          "time"
-        ]
+        "topics": ["dates", "globalization", "time"]
       },
       {
         "slug": "meetup",
@@ -694,12 +513,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "loops",
-          "integers",
-          "maps",
-          "transforming"
-        ]
+        "topics": ["loops", "integers", "maps", "transforming"]
       },
       {
         "slug": "hamming",
@@ -708,12 +522,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "conditionals",
-          "loops",
-          "equality",
-          "strings"
-        ]
+        "topics": ["conditionals", "loops", "equality", "strings"]
       },
       {
         "slug": "raindrops",
@@ -722,12 +531,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "conditionals",
-          "integers",
-          "strings",
-          "transforming"
-        ]
+        "topics": ["conditionals", "integers", "strings", "transforming"]
       },
       {
         "slug": "nucleotide-count",
@@ -751,12 +555,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops",
-          "maps",
-          "strings"
-        ]
+        "topics": ["conditionals", "loops", "maps", "strings"]
       },
       {
         "slug": "allergies",
@@ -765,12 +564,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": [
-          "arrays",
-          "bitwise_operations",
-          "conditionals",
-          "loops"
-        ]
+        "topics": ["arrays", "bitwise_operations", "conditionals", "loops"]
       },
       {
         "slug": "word-count",
@@ -779,12 +573,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "loops",
-          "lists",
-          "regular_expressions",
-          "strings"
-        ]
+        "topics": ["loops", "lists", "regular_expressions", "strings"]
       },
       {
         "slug": "bank-account",
@@ -793,10 +582,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "classes",
-          "conditionals"
-        ]
+        "topics": ["classes", "conditionals"]
       },
       {
         "slug": "difference-of-squares",
@@ -805,12 +591,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "algorithms",
-          "loops",
-          "integers",
-          "math"
-        ]
+        "topics": ["algorithms", "loops", "integers", "math"]
       },
       {
         "slug": "perfect-numbers",
@@ -819,13 +600,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "arrays",
-          "conditionals",
-          "loops",
-          "integers",
-          "math"
-        ]
+        "topics": ["arrays", "conditionals", "loops", "integers", "math"]
       },
       {
         "slug": "complex-numbers",
@@ -834,9 +609,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "math"
-        ]
+        "topics": ["math"]
       },
       {
         "slug": "luhn",
@@ -845,12 +618,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "conditionals",
-          "loops",
-          "integers",
-          "strings"
-        ]
+        "topics": ["conditionals", "loops", "integers", "strings"]
       },
       {
         "slug": "prime-factors",
@@ -859,13 +627,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "integers",
-          "math"
-        ]
+        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
       },
       {
         "slug": "grains",
@@ -874,10 +636,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "loops",
-          "integers"
-        ]
+        "topics": ["loops", "integers"]
       },
       {
         "slug": "pythagorean-triplet",
@@ -886,13 +645,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "integers",
-          "math"
-        ]
+        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
       },
       {
         "slug": "palindrome-products",
@@ -917,10 +670,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "filtering",
-          "strings"
-        ]
+        "topics": ["filtering", "strings"]
       },
       {
         "slug": "acronym",
@@ -929,12 +679,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "loops",
-          "regular_expressions",
-          "strings",
-          "transforming"
-        ]
+        "topics": ["loops", "regular_expressions", "strings", "transforming"]
       },
       {
         "slug": "high-scores",
@@ -943,9 +688,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "arrays"
-        ]
+        "topics": ["arrays"]
       },
       {
         "slug": "isogram",
@@ -954,10 +697,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "filtering",
-          "strings"
-        ]
+        "topics": ["filtering", "strings"]
       },
       {
         "slug": "matching-brackets",
@@ -981,10 +721,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "parsing",
-          "transforming"
-        ]
+        "topics": ["parsing", "transforming"]
       },
       {
         "slug": "scale-generator",
@@ -993,12 +730,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "loops",
-          "pattern_recognition",
-          "strings",
-          "arrays"
-        ]
+        "topics": ["loops", "pattern_recognition", "strings", "arrays"]
       },
       {
         "slug": "series",
@@ -1007,12 +739,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "loops",
-          "exception_handling",
-          "strings",
-          "text_formatting"
-        ]
+        "topics": ["loops", "exception_handling", "strings", "text_formatting"]
       },
       {
         "slug": "largest-series-product",
@@ -1054,11 +781,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "files",
-          "searching",
-          "text_formatting"
-        ]
+        "topics": ["files", "searching", "text_formatting"]
       },
       {
         "slug": "rectangles",
@@ -1067,13 +790,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "arrays",
-          "conditionals",
-          "loops",
-          "matrices",
-          "strings"
-        ]
+        "topics": ["arrays", "conditionals", "loops", "matrices", "strings"]
       },
       {
         "slug": "spiral-matrix",
@@ -1132,11 +849,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": [
-          "domain_specific_languages",
-          "parsing",
-          "stacks"
-        ]
+        "topics": ["domain_specific_languages", "parsing", "stacks"]
       },
       {
         "slug": "food-chain",
@@ -1145,10 +858,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "text_formatting"
-        ]
+        "topics": ["algorithms", "text_formatting"]
       },
       {
         "slug": "house",
@@ -1157,13 +867,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "arrays",
-          "conditionals",
-          "loops",
-          "recursion",
-          "strings"
-        ]
+        "topics": ["arrays", "conditionals", "loops", "recursion", "strings"]
       },
       {
         "slug": "isbn-verifier",
@@ -1235,11 +939,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "promises",
-          "error_handling",
-          "higher_order_functions"
-        ]
+        "topics": ["promises", "error_handling", "higher_order_functions"]
       },
       {
         "slug": "yacht",
@@ -1248,12 +948,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "arrays",
-          "conditionals",
-          "filtering",
-          "games"
-        ]
+        "topics": ["arrays", "conditionals", "filtering", "games"]
       },
       {
         "slug": "beer-song",
@@ -1262,11 +957,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops",
-          "strings"
-        ]
+        "topics": ["conditionals", "loops", "strings"]
       },
       {
         "slug": "resistor-color-trio",
@@ -1275,10 +966,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops"
-        ]
+        "topics": ["conditionals", "loops"]
       },
       {
         "slug": "dominoes",
@@ -1287,9 +975,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": [
-          "graph_theory"
-        ]
+        "topics": ["graph_theory"]
       },
       {
         "slug": "say",
@@ -1331,11 +1017,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "floating_point_numbers",
-          "math"
-        ]
+        "topics": ["algorithms", "floating_point_numbers", "math"]
       },
       {
         "slug": "sublist",
@@ -1344,10 +1026,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "arrays",
-          "lists"
-        ]
+        "topics": ["arrays", "lists"]
       },
       {
         "slug": "binary-search-tree",
@@ -1356,12 +1035,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "recursion"
-        ]
+        "topics": ["algorithms", "conditionals", "loops", "recursion"]
       },
       {
         "slug": "custom-set",
@@ -1388,13 +1062,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": [
-          "algorithms",
-          "arrays",
-          "conditionals",
-          "loops",
-          "recursion"
-        ]
+        "topics": ["algorithms", "arrays", "conditionals", "loops", "recursion"]
       },
       {
         "slug": "circular-buffer",
@@ -1419,11 +1087,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": [
-          "arrays",
-          "data_structures",
-          "lists"
-        ]
+        "topics": ["arrays", "data_structures", "lists"]
       },
       {
         "slug": "word-search",
@@ -1449,10 +1113,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "bitwise_operations",
-          "transforming"
-        ]
+        "topics": ["bitwise_operations", "transforming"]
       },
       {
         "slug": "two-bucket",
@@ -1478,10 +1139,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": [
-          "algorithms",
-          "games"
-        ]
+        "topics": ["algorithms", "games"]
       },
       {
         "slug": "connect",
@@ -1540,12 +1198,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "callbacks",
-          "loops",
-          "lists"
-        ]
+        "topics": ["algorithms", "callbacks", "loops", "lists"]
       },
       {
         "slug": "flatten-array",
@@ -1554,10 +1207,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "arrays",
-          "recursion"
-        ]
+        "topics": ["arrays", "recursion"]
       },
       {
         "slug": "nth-prime",
@@ -1582,13 +1232,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops",
-          "integers",
-          "math",
-          "recursion"
-        ]
+        "topics": ["conditionals", "loops", "integers", "math", "recursion"]
       },
       {
         "slug": "rotational-cipher",
@@ -1597,12 +1241,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "conditionals",
-          "strings",
-          "text_formatting",
-          "transforming"
-        ]
+        "topics": ["conditionals", "strings", "text_formatting", "transforming"]
       },
       {
         "slug": "diffie-hellman",
@@ -1627,12 +1266,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "arrays",
-          "filtering",
-          "math"
-        ]
+        "topics": ["algorithms", "arrays", "filtering", "math"]
       },
       {
         "slug": "atbash-cipher",
@@ -1706,13 +1340,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "conditionals",
-          "loops",
-          "integers",
-          "lists",
-          "math"
-        ]
+        "topics": ["conditionals", "loops", "integers", "lists", "math"]
       },
       {
         "slug": "change",
@@ -1721,11 +1349,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": [
-          "algorithms",
-          "performance",
-          "searching"
-        ]
+        "topics": ["algorithms", "performance", "searching"]
       },
       {
         "slug": "point-mutations",
@@ -1744,12 +1368,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "strings"
-        ]
+        "topics": ["algorithms", "conditionals", "loops", "strings"]
       },
       {
         "slug": "armstrong-numbers",
@@ -1758,10 +1377,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "algorithms",
-          "math"
-        ]
+        "topics": ["algorithms", "math"]
       },
       {
         "slug": "dnd-character",
@@ -1770,10 +1386,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "classes",
-          "randomness"
-        ]
+        "topics": ["classes", "randomness"]
       },
       {
         "slug": "run-length-encoding",
@@ -1874,12 +1487,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "bitwise_operations",
-          "algorithms",
-          "loops",
-          "math"
-        ]
+        "topics": ["bitwise_operations", "algorithms", "loops", "math"]
       },
       {
         "slug": "trinary",
@@ -1921,11 +1529,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": [
-          "algorithms",
-          "arrays",
-          "games"
-        ]
+        "topics": ["algorithms", "arrays", "games"]
       },
       {
         "slug": "queen-attack",
@@ -1951,11 +1555,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": [
-          "algorithms",
-          "events",
-          "reactive_programming"
-        ]
+        "topics": ["algorithms", "events", "reactive_programming"]
       },
       {
         "slug": "zipper",
@@ -1964,11 +1564,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": [
-          "recursion",
-          "searching",
-          "trees"
-        ]
+        "topics": ["recursion", "searching", "trees"]
       }
     ]
   },


### PR DESCRIPTION
**We will auto-merge this PR shortly. No action is required**

---

This PR adds a new `test_runner.average_run_time` key to the `config.json` file. The purpose of this field is allow the website to show a progress bar while the test runner runs. The average run time is defined in seconds with one digit of precision.

For more information, see https://github.com/exercism/docs/pull/130

We've pre-populated the average run time value by timing the execution time of the test runner in Docker on the example solution of the `leap` exercise, repeating that 4 more times, and then averaging the execution times. Clearly, the actual average execution time will differ between exercises and solutions, so this should be seen as very general indicator.

*This is mostly a stop-gap solution for now. We'll revisit this in 6 months time or so.* 

## Tracking

https://github.com/exercism/v3-launch/issues/35
