### PR TITLE
Add icons for key features

### DIFF
--- a/config.json
+++ b/config.json
@@ -1706,32 +1706,32 @@
   ],
   "key_features": [
     {
-      "icon": "features-cross-platform",
+      "icon": "cross-platform",
       "title": "Runs almost everywhere",
       "content": "Build web-pages, write backend, create database scripts, make mobile apps, design CLI-s, and more."
     },
     {
-      "icon": "features-multi-paradigm",
+      "icon": "multi-paradigm",
       "title": "Use any programming style",
       "content": "Use prototype-based, object-oriented, functional, or declarative programming styles, and more."
     },
     {
-      "icon": "features-weakly-typed",
+      "icon": "dynamically-typed",
       "title": "No types required",
       "content": "Dynamically and weakly typed by default, gain typed confidence using Flow, JSDoc, or TypeScript."
     },
     {
-      "icon": "features-concurrency",
+      "icon": "concurrency",
       "title": "Concurrency is safe",
       "content": "Async/await, dedicated workers, or state sync in shared workers. No deadlocks or race conditions."
     },
     {
-      "icon": "features-packages",
+      "icon": "tooling",
       "title": "Largest package registry",
       "content": "No need to reinvent the wheel. Build on top of > 1.3 million packages (April, 2020)."
     },
     {
-      "icon": "features-designed",
+      "icon": "community",
       "title": "Designed by a comity",
       "content": "Frequent updates, following ECMAScript, a general purpose, cross platform, vendor-neutral standard."
     }

--- a/config.json
+++ b/config.json
@@ -1732,7 +1732,7 @@
     },
     {
       "icon": "community",
-      "title": "Designed by a comity",
+      "title": "Designed by a committee",
       "content": "Frequent updates, following ECMAScript, a general purpose, cross platform, vendor-neutral standard."
     }
   ],


### PR DESCRIPTION
My proposal, feel free to change 🙂:

- ![](https://d31gpyts0tlbet.cloudfront.net/key-features/cross-platform.svg) Run almost anywhere
- ![](https://d31gpyts0tlbet.cloudfront.net/key-features/multi-paradigm.svg) Use any programming style
- ![](https://d31gpyts0tlbet.cloudfront.net/key-features/dynamically-typed.svg) No types required
- ![](https://d31gpyts0tlbet.cloudfront.net/key-features/concurrency.svg) Concurrency is safe
- ![](https://d31gpyts0tlbet.cloudfront.net/key-features/tooling.svg) Largest package repository
- ![](https://d31gpyts0tlbet.cloudfront.net/key-features/community.svg) Designed by a committee

I'm assuming that "comity" was a typo because it's a law term according to wiki (https://en.wikipedia.org/wiki/Comity)