### PR TITLE
Add missing commas between major and minor scale names

### DIFF
--- a/exercises/practice/scale-generator/.docs/instructions.md
+++ b/exercises/practice/scale-generator/.docs/instructions.md
@@ -21,15 +21,15 @@ The collection of notes in these scales is written with either sharps or
 flats, depending on the tonic. Here is a list of which are which:
 
 No Sharps or Flats:
-C major
+C major,
 a minor
 
 Use Sharps:
-G, D, A, E, B, F# major
+G, D, A, E, B, F# major,
 e, b, f#, c#, g#, d# minor
 
 Use Flats:
-F, Bb, Eb, Ab, Db, Gb major
+F, Bb, Eb, Ab, Db, Gb major,
 d, g, c, f, bb, eb minor
 
 The diatonic scales, and all other scales that derive from the


### PR DESCRIPTION
All scale names are rendered on the same line. The comma may not make sense in the markdown file but improves readability on the rendered page.