### PR TITLE
Fixed markdown issues & the link to `expo` in ABOUT.md

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,7 +1,6 @@
-
 # About
 
-JavaScript is a programming language that allows web pages to be dynamic. It is an interpreted language, which means that it doesn't need to be compiled: instead the interpreter (such as a web browser) will parse the code and turn it into code that their machine can run - suitable for creating dynamic websites that can run on any browser *on any computer*!
+JavaScript is a programming language that allows web pages to be dynamic. It is an interpreted language, which means that it doesn't need to be compiled: instead the interpreter (such as a web browser) will parse the code and turn it into code that their machine can run - suitable for creating dynamic websites that can run on any browser _on any computer_!
 
 JavaScript is not only for use in the browser. JavaScript runtimes, such as [NodeJS][web-nodejs] and [deno][web-deno] allow you to write, launch and serve requests on webservers.
 Other frameworks, such as [Electron][web-electron] use JavaScript to write _cross platform applications_ for Windows, Linux and Mac OS.
@@ -26,7 +25,7 @@ This means you don't need to worry about what is and isn't supported.
 
 ---
 
-*There is a [small number of browsers][wiki-javascript-support] that doesn't ship with a JavaScript runtime, or that has disabled JavaScript execution by default.*
+_There is a [small number of browsers][wiki-javascript-support] that doesn't ship with a JavaScript runtime, or that has disabled JavaScript execution by default._
 
 [wiki-javascript-support]: https://en.wikipedia.org/wiki/Comparison_of_web_browsers#JavaScript_support
 [wiki-transpilation]: https://en.wikipedia.org/wiki/Source-to-source_compiler

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,6 +1,6 @@
 # About
 
-JavaScript is a programming language that allows web pages to be dynamic. It is an interpreted language, which means that it doesn't need to be compiled: instead the interpreter (such as a web browser) will parse the code and turn it into code that their machine can run - suitable for creating dynamic websites that can run on any browser\* on any computer\*!
+JavaScript is a programming language that allows web pages to be dynamic. It is an interpreted language, which means that it doesn't need to be compiled: instead the interpreter (such as a web browser) will parse the code and turn it into code that their machine can run - suitable for creating dynamic websites that can run on any browser\ *on any computer\*!
 
 JavaScript is not only for use in the browser. JavaScript runtimes, such as [NodeJS][web-nodejs] and [deno][web-deno] allow you to write, launch and serve requests on webservers.
 Other frameworks, such as [Electron][web-electron] use JavaScript to write _cross platform applications_ for Windows, Linux and Mac OS.

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,6 +1,6 @@
 # About
 
-JavaScript is a programming language that allows web pages to be dynamic. It is an interpreted language, which means that it doesn't need to be compiled: instead the interpreter (such as a web browser) will parse the code and turn it into code that their machine can run - suitable for creating dynamic websites that can run on any browser *on any computer*!
+JavaScript is a programming language that allows web pages to be dynamic. It is an interpreted language, which means that it doesn't need to be compiled: instead the interpreter (such as a web browser) will parse the code and turn it into code that their machine can run - suitable for creating dynamic websites that can run on any browser **on any computer**!
 
 JavaScript is not only for use in the browser. JavaScript runtimes, such as [NodeJS][web-nodejs] and [deno][web-deno] allow you to write, launch and serve requests on webservers.
 Other frameworks, such as [Electron][web-electron] use JavaScript to write _cross platform applications_ for Windows, Linux and Mac OS.

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,6 +1,7 @@
+
 # About
 
-JavaScript is a programming language that allows web pages to be dynamic. It is an interpreted language, which means that it doesn't need to be compiled: instead the interpreter (such as a web browser) will parse the code and turn it into code that their machine can run - suitable for creating dynamic websites that can run on any browser **on any computer**!
+JavaScript is a programming language that allows web pages to be dynamic. It is an interpreted language, which means that it doesn't need to be compiled: instead the interpreter (such as a web browser) will parse the code and turn it into code that their machine can run - suitable for creating dynamic websites that can run on any browser *on any computer*!
 
 JavaScript is not only for use in the browser. JavaScript runtimes, such as [NodeJS][web-nodejs] and [deno][web-deno] allow you to write, launch and serve requests on webservers.
 Other frameworks, such as [Electron][web-electron] use JavaScript to write _cross platform applications_ for Windows, Linux and Mac OS.
@@ -25,7 +26,7 @@ This means you don't need to worry about what is and isn't supported.
 
 ---
 
-\* There is a [small number of browsers][wiki-javascript-support] that doesn't ship with a JavaScript runtime, or that has disabled JavaScript execution by default.
+*There is a [small number of browsers][wiki-javascript-support] that doesn't ship with a JavaScript runtime, or that has disabled JavaScript execution by default.*
 
 [wiki-javascript-support]: https://en.wikipedia.org/wiki/Comparison_of_web_browsers#JavaScript_support
 [wiki-transpilation]: https://en.wikipedia.org/wiki/Source-to-source_compiler
@@ -35,7 +36,7 @@ This means you don't need to worry about what is and isn't supported.
 [web-deno]: https://deno.land/
 [web-electron]: https://electronjs.org/
 [web-react-native]: https://facebook.github.io/react-native/
-[web-expo]: https://expo.io/
+[web-expo]: https://expo.dev/
 [web-ionic]: https://ionicframework.com/
 [web-compat-browsers]: https://kangax.github.io/compat-table/esnext/
 [web-compat-node]: https://node.green/#ESNEXT

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,6 +1,6 @@
 # About
 
-JavaScript is a programming language that allows web pages to be dynamic. It is an interpreted language, which means that it doesn't need to be compiled: instead the interpreter (such as a web browser) will parse the code and turn it into code that their machine can run - suitable for creating dynamic websites that can run on any browser\ *on any computer\*!
+JavaScript is a programming language that allows web pages to be dynamic. It is an interpreted language, which means that it doesn't need to be compiled: instead the interpreter (such as a web browser) will parse the code and turn it into code that their machine can run - suitable for creating dynamic websites that can run on any browser *on any computer*!
 
 JavaScript is not only for use in the browser. JavaScript runtimes, such as [NodeJS][web-nodejs] and [deno][web-deno] allow you to write, launch and serve requests on webservers.
 Other frameworks, such as [Electron][web-electron] use JavaScript to write _cross platform applications_ for Windows, Linux and Mac OS.


### PR DESCRIPTION
This PR just fixes some Markdown issues that I saw while I was browsing through the About section of JavaScript track. Also the link to expo is fixed as it is `expo.dev` now.