### PR TITLE
fix: Simpler core.js version check

### DIFF
--- a/bin/check_corejs_version.sh
+++ b/bin/check_corejs_version.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
 
-babel_version="$(sed -n "s/.*corejs: '\([^\\']*\)'.*/\1/p" babel.config.js)"
-package_version="$(sed -n 's/.*"core-js": "\^\?\([^\"]*\)".*/\1/p' package.json)"
+babel_version="$(sed -n "s/.*corejs: '\([0-9]\+\)\.\([0-9]\+\).*/\1.\2/p" babel.config.js)"
+package_version="$(sed -n 's/.*"core-js": "^\?\([0-9]\+\)\.\([0-9]\+\).*/\1.\2/p' package.json)"
 
-IFS='.' read -r -a babel_arr <<< "$babel_version"
-IFS='.' read -r -a package_arr <<< "$package_version"
-
-if [ ${babel_arr[0]} != ${package_arr[0]} ] || [ ${babel_arr[1]} != ${package_arr[1]} ]; then
-  echo "core-js version in package.json does not match the version in babel.config.js!"
+if [ ${babel_version} != ${package_version} ]; then
+  echo "core-js version (major.minor) in package.json does not match the version in babel.config.js!"
   echo "babel.config.js version: ${babel_version}"
   echo "package.json version: ${package_version}"
   exit 1

--- a/bin/check_corejs_version.sh
+++ b/bin/check_corejs_version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-babel_version="$(sed -n "s/.*corejs: '\([0-9]\+\)\.\([0-9]\+\).*/\1.\2/p" babel.config.js)"
-package_version="$(sed -n 's/.*"core-js": "^\?\([0-9]\+\)\.\([0-9]\+\).*/\1.\2/p' package.json)"
+babel_version="$(sed -n "s/.*corejs: '\([0-9]\+\.[0-9]\+\).*/\1/p" babel.config.js)"
+package_version="$(sed -n 's/.*"core-js": "^\?\([0-9]\+\.[0-9]\+\).*/\1/p' package.json)"
 
 if [ ${babel_version} != ${package_version} ]; then
   echo "core-js version (major.minor) in package.json does not match the version in babel.config.js!"


### PR DESCRIPTION
I thought of an easier version to check the core.js version with pure regex :)
Follow-up to https://github.com/exercism/javascript/pull/1313.