### PR TITLE
reduced pythagorean-triplet's time complexity from cubic to quadratic 

### DIFF
--- a/exercises/practice/pythagorean-triplet/.meta/proof.ci.js
+++ b/exercises/practice/pythagorean-triplet/.meta/proof.ci.js
@@ -27,12 +27,17 @@ export function triplets({ minFactor, maxFactor, sum }) {
   };
 
   const result = [];
+  const squared_map = {};
+
+  for (let a = min; a < max; a += 1) {
+    squared_map[a*a] = a;
+  }
 
   for (let a = min; a < max - 1; a += 1) {
     for (let b = a + 1; b < max; b += 1) {
-      for (let c = b + 1; c <= max; c += 1) {
-        const triplet = new Triplet(a, b, c);
-
+      const c = (a*a) + (b*b);
+      if (squared_map[c]) {
+        const triplet = new Triplet(a, b, squared_map[c]);
         if (isDesired(triplet)) {
           result.push(triplet);
         }

--- a/exercises/practice/pythagorean-triplet/.meta/proof.ci.js
+++ b/exercises/practice/pythagorean-triplet/.meta/proof.ci.js
@@ -30,12 +30,12 @@ export function triplets({ minFactor, maxFactor, sum }) {
   const squared_map = {};
 
   for (let a = min; a < max; a += 1) {
-    squared_map[a*a] = a;
+    squared_map[a * a] = a;
   }
 
   for (let a = min; a < max - 1; a += 1) {
     for (let b = a + 1; b < max; b += 1) {
-      const c = (a*a) + (b*b);
+      const c = a * a + b * b;
       if (squared_map[c]) {
         const triplet = new Triplet(a, b, squared_map[c]);
         if (isDesired(triplet)) {

--- a/exercises/practice/pythagorean-triplet/pythagorean-triplet.spec.js
+++ b/exercises/practice/pythagorean-triplet/pythagorean-triplet.spec.js
@@ -58,7 +58,7 @@ describe('Triplet', () => {
     ]);
   });
 
-  test.skip('triplets for large number', () => {
+  xtest('triplets for large number', () => {
     expect(tripletsWithSum(30000)).toEqual([
       [1200, 14375, 14425],
       [1875, 14000, 14125],

--- a/exercises/practice/pythagorean-triplet/pythagorean-triplet.spec.js
+++ b/exercises/practice/pythagorean-triplet/pythagorean-triplet.spec.js
@@ -58,7 +58,7 @@ describe('Triplet', () => {
     ]);
   });
 
-  xtest('triplets for large number', () => {
+  test.skip('triplets for large number', () => {
     expect(tripletsWithSum(30000)).toEqual([
       [1200, 14375, 14425],
       [1875, 14000, 14125],


### PR DESCRIPTION
In the previous implementation the triplets function had a time complexity of O(n^3). This commit reduces it to O(n^2). I believe the current best known optimal solution for this type of problem is [O(n^2(log log n)/log ^2n)](https://en.wikipedia.org/wiki/3SUM) but in order to achieve that result we would need to make changes to this solution which would negatively impact readability/understandability. The final test still takes a long time (~16s) but I don't think that can be significantly improved for an input of that size. 

