### PR TITLE
Made instructions clearer in Resistor Color docs

### DIFF
--- a/exercises/practice/resistor-color/.docs/instructions.md
+++ b/exercises/practice/resistor-color/.docs/instructions.md
@@ -31,6 +31,6 @@ The goal of this exercise is to create a way:
 - to look up the numerical value associated with a particular color band
 - to list the different band colors
 
-Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array: Better Be Right Or Your Great Big Values Go Wrong.
+Store the colors is an array, such that their index maps to the numerical value they are associated with: Better Be Right Or Your Great Big Values Go Wrong. Then create a function that outputs the corresponding value as you put in a color.
 
 More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article](https://en.wikipedia.org/wiki/Electronic_color_code)


### PR DESCRIPTION
Used simpler vocabulary and mentioned what to do more specifically. I had personally found the instructions confusing when attempting the exercise.