### PR TITLE
Improve concept exercise Coordinate Transformation

### DIFF
--- a/exercises/concept/coordinate-transformation/coordinate-transformation.spec.js
+++ b/exercises/concept/coordinate-transformation/coordinate-transformation.spec.js
@@ -108,6 +108,12 @@ describe('memoizeTransform', () => {
     expect(memoizedTranslate(2, 2)).toEqual([4, 4]);
   });
 
+  test('should return different results for different input', () => {
+    const memoizedTranslate = memoizeTransform(translate2d(1, 2));
+    expect(memoizedTranslate(2, 2)).toEqual([3, 4]);
+    expect(memoizedTranslate(6, 6)).toEqual([7, 8]);
+  });
+
   test('should not call the memoized function if the input is the same', () => {
     const memoizedTransform = memoizeTransform(fakeTransform());
     expect(memoizedTransform(5, 5)).toEqual([1, 1]);

--- a/exercises/concept/coordinate-transformation/coordinate-transformation.spec.js
+++ b/exercises/concept/coordinate-transformation/coordinate-transformation.spec.js
@@ -108,7 +108,7 @@ describe('memoizeTransform', () => {
     expect(memoizedTranslate(2, 2)).toEqual([4, 4]);
   });
 
-  test('should return different results for different input', () => {
+  test('should return different results for different inputs', () => {
     const memoizedTranslate = memoizeTransform(translate2d(1, 2));
     expect(memoizedTranslate(2, 2)).toEqual([3, 4]);
     expect(memoizedTranslate(6, 6)).toEqual([7, 8]);


### PR DESCRIPTION
The current specs allow a solution, where the memoization only
works once, i.e. for the first pair of arguments.
This CL adds specs to test if memoization respects the arguments.

Example:

```javascript
function memoizeTransform(f) {
  let res;

  return function (x, y) {
    res = res ?? f(x, y);
    return res;
  }
}
```

The additional test case covers this and fails with the above
solution.