### PR TITLE
word-search: sync (#903)

### DIFF
--- a/exercises/practice/word-search/.meta/tests.toml
+++ b/exercises/practice/word-search/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [b4057815-0d01-41f0-9119-6a91f54b2a0a]
 description = "Should accept an initial game grid and a target search word"
@@ -58,3 +65,6 @@ description = "Should locate words written bottom left to top right"
 
 [69e1d994-a6d7-4e24-9b5a-db76751c2ef8]
 description = "Should locate words written top right to bottom left"
+
+[695531db-69eb-463f-8bad-8de3bf5ef198]
+description = "Should fail to locate a word that is not in the puzzle"

--- a/exercises/practice/word-search/word-search.spec.js
+++ b/exercises/practice/word-search/word-search.spec.js
@@ -541,7 +541,7 @@ describe('vertical directions', () => {
     ).toEqual(expectedResults);
   });
 
-  describe('word doesn\'t exist', () => {
+  describe("word doesn't exist", () => {
     xtest('should fail to locate a word that is not in the puzzle', () => {
       const grid = [
         'jefblpepre',
@@ -555,17 +555,13 @@ describe('vertical directions', () => {
         'jalaycalmp',
         'clojurermt',
       ];
-  
+
       const expectedResults = {
-        fail: undefined
+        fail: undefined,
       };
       const wordSearch = new WordSearch(grid);
-  
-      expect(
-        wordSearch.find([
-          'fail',
-        ])
-      ).toEqual(expectedResults);
-    });    
+
+      expect(wordSearch.find(['fail'])).toEqual(expectedResults);
+    });
   });
 });

--- a/exercises/practice/word-search/word-search.spec.js
+++ b/exercises/practice/word-search/word-search.spec.js
@@ -540,4 +540,32 @@ describe('vertical directions', () => {
       ])
     ).toEqual(expectedResults);
   });
+
+  describe('word doesn\'t exist', () => {
+    xtest('should fail to locate a word that is not in the puzzle', () => {
+      const grid = [
+        'jefblpepre',
+        'camdcimgtc',
+        'oivokprjsm',
+        'pbwasqroua',
+        'rixilelhrs',
+        'wolcqlirpc',
+        'screeaumgr',
+        'alxhpburyi',
+        'jalaycalmp',
+        'clojurermt',
+      ];
+  
+      const expectedResults = {
+        fail: undefined
+      };
+      const wordSearch = new WordSearch(grid);
+  
+      expect(
+        wordSearch.find([
+          'fail',
+        ])
+      ).toEqual(expectedResults);
+    });    
+  });
 });


### PR DESCRIPTION
1. Added the missing case `"695531db-69eb-463f-8bad-8de3bf5ef198"` in tests.toml by running `configlet sync`.
2. Implemented the missing case in word-search.spec.js.
3. Made sure the tests still pass against .meta/proof.ci.js by running `npx babel-node scripts/ci`.