### PR TITLE
Possible simplification of Translation Service exemplar

### DIFF
--- a/exercises/concept/translation-service/.meta/exemplar.js
+++ b/exercises/concept/translation-service/.meta/exemplar.js
@@ -51,9 +51,9 @@ export class TranslationService {
    */
   request(text) {
     const api = this.api;
-    function requestAsPromise(text) {
+    function requestAsPromise(txt) {
       return new Promise((resolve, reject) => {
-        api.request(text, (err) => (err ? reject(err) : resolve()));
+        api.request(txt, (err) => (err ? reject(err) : resolve()));
       });
     }
 


### PR DESCRIPTION
By using `.catch()` and by wrapping `this.api.request()` as a promise some of the logic can be simplified.

Also suggest removing the `.bind(this)` as complex at this stage of the learning.