### PR TITLE
Use consistent "skip test" label

### DIFF
--- a/exercises/practice/palindrome-products/palindrome-products.spec.js
+++ b/exercises/practice/palindrome-products/palindrome-products.spec.js
@@ -79,7 +79,7 @@ describe('Palindromes', () => {
     expect(sortFactors(smallest.factors)).toEqual(expected.factors);
   });
 
-  test.skip('largest palindrome from four digit factors', () => {
+  xtest('largest palindrome from four digit factors', () => {
     const palindromes = Palindromes.generate({
       maxFactor: 9999,
       minFactor: 1000,


### PR DESCRIPTION
This seems to consistently fail in the online test runner... (but it's not skipped)... is there a reason for this discrepancy or is this a bug?
<img width="710" alt="Screen Shot 2021-09-23 at 10 47 33 PM" src="https://user-images.githubusercontent.com/6473/134610605-efe1ddb3-e008-4c71-8795-98f6e1dc7bcc.png">


