### PR TITLE
Add a test to check that only the last result is remembered

### DIFF
--- a/exercises/concept/coordinate-transformation/coordinate-transformation.spec.js
+++ b/exercises/concept/coordinate-transformation/coordinate-transformation.spec.js
@@ -119,4 +119,13 @@ describe('memoizeTransform', () => {
     expect(memoizedTransform(5, 5)).toEqual([1, 1]);
     expect(memoizedTransform(5, 5)).toEqual([1, 1]);
   });
+
+  test('should only remember the last result', () => {
+    const mockFunction = jest.fn((x, y) => [x * 2, y * 2]);
+    const memoizedTransform = memoizeTransform(mockFunction);
+    expect(memoizedTransform(1, 1)).toEqual([2, 2]);
+    expect(memoizedTransform(2, 2)).toEqual([4, 4]);
+    expect(memoizedTransform(1, 1)).toEqual([2, 2]);
+    expect(mockFunction).toBeCalledTimes(3);
+  });
 });


### PR DESCRIPTION
I added a test that makes sure the student's code isn't remembering all the results and only the last one. It calls the student's function with some input, different input, and then the first input again. This should require the underlying function to be called 3 times if the student's code is implemented to only remember the last result.

Fixes #1373.