### PR TITLE
Tests for empty promise array and no arguments.

### DIFF
--- a/exercises/practice/promises/.meta/proof.ci.js
+++ b/exercises/practice/promises/.meta/proof.ci.js
@@ -5,30 +5,42 @@ export const promisify =
       fn(...args, (err, result) => (err ? reject(err) : resolve(result)));
     });
 
-export const all = (promises) =>
-  promises.reduce(
+export const all = (promises) => {
+  if (!promises) return Promise.resolve();
+  if (promises.length === 0) return Promise.resolve([]);
+  return promises.reduce(
     async (acc, promise) => (await acc).concat(await promise),
     Promise.resolve([])
   );
+};
 
-export const allSettled = (promises) =>
-  promises.reduce(
+export const allSettled = (promises) => {
+  if (!promises) return Promise.resolve();
+  if (promises.length === 0) return Promise.resolve([]);
+  return promises.reduce(
     async (acc, promise) =>
       (await acc).concat(await promise.catch((err) => err)),
     Promise.resolve([])
   );
+};
 
-export const race = (promises) =>
-  new Promise((resolve, reject) => {
+export const race = (promises) => {
+  if (!promises) return Promise.resolve();
+  if (promises.length === 0) return Promise.resolve([]);
+  return new Promise((resolve, reject) => {
     promises.forEach((promise) => {
       promise.then(resolve, reject);
     });
   });
+};
 
-export const any = (promises) =>
-  new Promise((resolve, reject) => {
+export const any = (promises) => {
+  if (!promises) return Promise.resolve();
+  if (promises.length === 0) return Promise.resolve([]);
+  return new Promise((resolve, reject) => {
     promises.forEach((promise) => {
       promise.then(resolve).catch(() => null);
     });
     allSettled(promises).then(reject);
   });
+};

--- a/exercises/practice/promises/promises.spec.js
+++ b/exercises/practice/promises/promises.spec.js
@@ -47,6 +47,14 @@ describe('promises', () => {
       expect(all([])).toBeInstanceOf(Promise);
     });
 
+    xtest('resolves when given no promises', () => {
+      return expect(all([])).resolves.toEqual([]);
+    });
+
+    xtest('resolves when given no arguments', () => {
+      return expect(all()).resolves.toBeUndefined();
+    });
+
     xtest('resolved values appear in the order they are passed in', () => {
       const FIRST = 'FIRST';
       const SECOND = 'SECOND';
@@ -75,6 +83,14 @@ describe('promises', () => {
 
     xtest('returns a Promise', () => {
       expect(allSettled([])).toBeInstanceOf(Promise);
+    });
+
+    xtest('resolves when given no promises', () => {
+      return expect(allSettled([])).resolves.toEqual([]);
+    });
+
+    xtest('resolves when given no arguments', () => {
+      return expect(allSettled()).resolves.toBeUndefined();
     });
 
     xtest('resolved values appear in the order they are passed in', () => {
@@ -106,6 +122,14 @@ describe('promises', () => {
 
     xtest('returns a Promise', () => {
       expect(race([])).toBeInstanceOf(Promise);
+    });
+
+    xtest('resolves when given no promises', () => {
+      return expect(race([])).resolves.toEqual([]);
+    });
+
+    xtest('resolves when given no arguments', () => {
+      return expect(race()).resolves.toBeUndefined();
     });
 
     xtest('resolves with value of the fastest successful promise', () => {
@@ -143,6 +167,14 @@ describe('promises', () => {
 
     xtest('returns a Promise', () => {
       expect(any([]).catch(() => null)).toBeInstanceOf(Promise);
+    });
+
+    xtest('resolves when given no promises', () => {
+      return expect(race([])).resolves.toEqual([]);
+    });
+
+    xtest('resolves when given no arguments', () => {
+      return expect(race()).resolves.toBeUndefined();
     });
 
     xtest('resolves with value of fastest successful promise', () => {


### PR DESCRIPTION
Without these tests it's possible, easy even, to write promises that never resolve or reject when passed an empty array or no array.

fixes #1400 