### PR TITLE
Add missing [concept-arrays] tag in Functions concept instruction file

### DIFF
--- a/concepts/functions/about.md
+++ b/concepts/functions/about.md
@@ -107,7 +107,7 @@ noReturn(1);
 ```
 
 In JavaScript, you can only return exactly one value.
-If you want to pass more information, you need to combine it into one entity first, usually into an [object][concept-objects], or an [array][concept-arrays]..
+If you want to pass more information, you need to combine it into one entity first, usually into an [object][concept-objects], or an [array][concept-arrays].
 
 ```javascript
 function divide(a, b) {
@@ -155,6 +155,7 @@ Have a look at [closures][concept-closures] to learn more about variable scope i
 [concept-null-undefined]: /tracks/javascript/concepts/null-undefined
 [concept-rest-and-spread]: /tracks/javascript/concepts/rest-and-spread
 [concept-objects]: /tracks/javascript/concepts/objects
+[concept-arrays]: /tracks/javascript/concepts/arrays
 [concept-callbacks]: /tracks/javascript/concepts/callbacks
 [mdn-arguments-object]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments
 [mdn-primitives]: https://developer.mozilla.org/en-US/docs/Glossary/Primitive

--- a/concepts/functions/introduction.md
+++ b/concepts/functions/introduction.md
@@ -81,7 +81,7 @@ noReturn(1);
 ```
 
 In JavaScript, you can only return exactly one value.
-If you want to pass more information, you need to combine it into one entity first, usually into an [object][concept-objects], or an [array][concept-arrays]..
+If you want to pass more information, you need to combine it into one entity first, usually into an [object][concept-objects], or an [array][concept-arrays].
 
 ```javascript
 function divide(a, b) {

--- a/exercises/concept/lasagna-master/.docs/introduction.md
+++ b/exercises/concept/lasagna-master/.docs/introduction.md
@@ -81,7 +81,7 @@ noReturn(1);
 ```
 
 In JavaScript, you can only return exactly one value.
-If you want to pass more information, you need to combine it into one entity first, usually into an [object][concept-objects], or an [array][concept-arrays]..
+If you want to pass more information, you need to combine it into one entity first, usually into an [object][concept-objects], or an [array][concept-arrays].
 
 ```javascript
 function divide(a, b) {
@@ -118,5 +118,6 @@ const obj = {
 [concept-arrow-functions]: /tracks/javascript/concepts/arrow-functions
 [concept-null-undefined]: /tracks/javascript/concepts/null-undefined
 [concept-objects]: /tracks/javascript/concepts/objects
+[concept-arrays]: /tracks/javascript/concepts/arrays
 [concept-callbacks]: /tracks/javascript/concepts/callbacks
 [mdn-primitives]: https://developer.mozilla.org/en-US/docs/Glossary/Primitive


### PR DESCRIPTION
The instruction file for the *"Functions"* concept was missing a tag for the link to the *"Arrays"* concept page.