### PR TITLE
Fix typo in door policy comment

### DIFF
--- a/exercises/concept/poetry-club-door-policy/.meta/exemplar.js
+++ b/exercises/concept/poetry-club-door-policy/.meta/exemplar.js
@@ -35,7 +35,7 @@ export function backDoorResponse(line) {
 }
 
 /**
- * Format the password for the front-door, given the response
+ * Format the password for the back door, given the response
  * letters.
  *
  * @param {string} word the letters you responded with before

--- a/exercises/concept/poetry-club-door-policy/door-policy.js
+++ b/exercises/concept/poetry-club-door-policy/door-policy.js
@@ -53,7 +53,7 @@ export function backDoorResponse(line) {
 }
 
 /**
- * Format the password for the front-door, given the response
+ * Format the password for the back door, given the response
  * letters.
  *
  * @param {string} word the letters you responded with before


### PR DESCRIPTION
Update the `backDoorResponse` comment to say 'back door'.