### PR TITLE
Add link to Math object in Freelancer Rates intro

### DIFF
--- a/exercises/concept/freelancer-rates/.docs/introduction.md
+++ b/exercises/concept/freelancer-rates/.docs/introduction.md
@@ -12,6 +12,10 @@ Many programming languages have specific numeric types to represent different ty
 If you require arbitrary precision or work with extremely large numbers, use the `bigint` type.
 Otherwise, the `number` type is likely the better option.
 
+### Built-in Objects
+
+[`Math`][built-in-math]: is a built-in object that's useful when dealing with numbers. It contains properties and methods for mathematical constants and functions, does **not** work with `BigInt`.
+
 ## Arithmetic Operators
 
 JavaScript provides 6 different operators to perform basic arithmetic operations on numbers.
@@ -71,4 +75,5 @@ let y = 31;
 y %= 3; // y is now 1
 ```
 
+[built-in-math]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math
 [mdn-operator-precedence]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#table


### PR DESCRIPTION
Since the exercise used for Numbers and Arithmetic Operators is combined, if the user were to come into it from Arithmetic Operations without reading the Numbers concept, they would not be introduced to the Math object, which is necessary to complete the exercise. It's mentioned in the hints, but I don't think it's enough for someone new to JS.

I tried to use the phrasing and structure of the related docs, but let me know if there's a better way to do it.