### PR TITLE
Add comment for "same object" assertions

### DIFF
--- a/exercises/concept/amusement-park/amusement-park.spec.js
+++ b/exercises/concept/amusement-park/amusement-park.spec.js
@@ -29,7 +29,7 @@ describe('revokeTicket', () => {
   test('returns the same object that was passed in', () => {
     const visitor = { name: 'Anatoli Traverse', age: 34, ticketId: 'AA5AA01D' };
 
-    // this follows the suggestion from the Jest docs to avoid a confusing test report
+    // This checks that the same object that was passed in is returned.
     // https://jestjs.io/docs/expect#tobevalue
     expect(Object.is(revokeTicket(visitor), visitor)).toBe(true);
   });
@@ -39,6 +39,7 @@ describe('revokeTicket', () => {
     const actual = revokeTicket(visitor);
 
     expect(actual).toEqual(visitor);
+    // This checks that the same object that was passed in is returned.
     expect(Object.is(actual, visitor)).toBe(true);
   });
 });

--- a/exercises/concept/bird-watcher/bird-watcher.spec.js
+++ b/exercises/concept/bird-watcher/bird-watcher.spec.js
@@ -56,7 +56,7 @@ describe('bird watcher', () => {
     test('does not create a new array', () => {
       const birdsPerDay = [2, 0, 1, 4, 1, 3, 0];
 
-      // this follows the suggestion from the Jest docs to avoid a confusing test report
+      // This checks that the same object that was passed in is returned.
       // https://jestjs.io/docs/expect#tobevalue
       expect(Object.is(fixBirdCountLog(birdsPerDay), birdsPerDay)).toBe(true);
     });

--- a/exercises/concept/high-score-board/high-score-board.spec.js
+++ b/exercises/concept/high-score-board/high-score-board.spec.js
@@ -34,7 +34,8 @@ describe('addPlayer', () => {
   test('returns the existing score board', () => {
     const scoreBoard = {};
     const actual = addPlayer(scoreBoard, 'Jesse Johnson', 1337);
-    // This follows the suggestion from the Jest docs to avoid a confusing test report
+
+    // This checks that the same object that was passed in is returned.
     // https://jestjs.io/docs/expect#tobevalue
     expect(Object.is(actual, scoreBoard)).toBe(true);
   });
@@ -55,6 +56,8 @@ describe('removePlayer', () => {
 
     const actual = removePlayer(scoreBoard, 'Jesse Johnson');
     expect(actual).toEqual(expected);
+
+    // This checks that the same object that was passed in is returned.
     expect(Object.is(actual, scoreBoard)).toBe(true);
   });
 
@@ -67,6 +70,8 @@ describe('removePlayer', () => {
 
     const actual = removePlayer(scoreBoard, 'Bruno Santangelo');
     expect(actual).toEqual(scoreBoard);
+
+    // This checks that the same object that was passed in is returned.
     expect(Object.is(actual, scoreBoard)).toBe(true);
   });
 });
@@ -88,6 +93,8 @@ describe('updateScore', () => {
     updateScore(scoreBoard, 'Min-seo Shin', 1999);
     const actual = updateScore(scoreBoard, 'Jesse Johnson', 1337);
     expect(actual).toEqual(expected);
+
+    // This checks that the same object that was passed in is returned.
     expect(Object.is(actual, scoreBoard)).toBe(true);
   });
 });
@@ -108,6 +115,8 @@ describe('applyMondayBonus', () => {
 
     const actual = applyMondayBonus(scoreBoard);
     expect(actual).toEqual(expected);
+
+    // This checks that the same object that was passed in is returned.
     expect(Object.is(actual, scoreBoard)).toBe(true);
   });
 
@@ -115,6 +124,8 @@ describe('applyMondayBonus', () => {
     const scoreBoard = {};
     const actual = applyMondayBonus(scoreBoard);
     expect(actual).toEqual({});
+
+    // This checks that the same object that was passed in is returned.
     expect(Object.is(actual, scoreBoard)).toBe(true);
   });
 });


### PR DESCRIPTION
The editor bug reports revealed that some people were struggling to understand the test cases that check that the same object that is passed in as parameter is also returned. Students did not return the same object but then did not understand what the test failure meant.

Unfortunately, Jest does not support custom messages for assertions. Different options were discussed and I decided adding a comment would be the easiest quick fix for now.

I had trouble finding a concise sentence for this, if someone has a better idea, I am happy to apply that instead.

(The link to jest is included only once per file as it is only as reference for the contributors/maintainers, not for the students.)