### PR TITLE
Update introduction.md

### DIFF
--- a/concepts/arrays/about.md
+++ b/concepts/arrays/about.md
@@ -146,7 +146,7 @@ Read [this article][instanceof-vs-array-is-array] for more information.
 
 ## Array Methods
 
-Some of the [methods][array_methods] that are available on `Array.prototype` can be used to add or remove from the array.
+Some of the [methods][array_methods] that are available on every Array[^0] object can be used to add or remove from the array.
 Here are a few of them:
 
 ### push
@@ -209,6 +209,7 @@ names;
 
 ---
 
+[^0]: `Array`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array> (referenced November 5, 2021)
 [^1]: `push`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push> (referenced September 29, 2021)
 [^2]: `pop`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop> (referenced September 29, 2021)
 [^3]: `shift`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift> (referenced September 29, 2021)

--- a/concepts/arrays/about.md
+++ b/concepts/arrays/about.md
@@ -146,7 +146,7 @@ Read [this article][instanceof-vs-array-is-array] for more information.
 
 ## Array Methods
 
-Some of the [methods][array_methods] that are available on every Array[^0] object can be used to add or remove from the array.
+Some of the [methods][array_methods] that are available on every Array object can be used to add or remove from the array.
 Here are a few of them:
 
 ### push
@@ -209,7 +209,6 @@ names;
 
 ---
 
-[^0]: `Array`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array> (referenced November 5, 2021)
 [^1]: `push`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push> (referenced September 29, 2021)
 [^2]: `pop`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop> (referenced September 29, 2021)
 [^3]: `shift`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift> (referenced September 29, 2021)

--- a/concepts/arrays/introduction.md
+++ b/concepts/arrays/introduction.md
@@ -33,7 +33,7 @@ numbers;
 
 ## Methods
 
-Some of the [methods][array_methods] that are available on `Array.prototype`[^0] can be used to add or remove from the array.
+Some of the [methods][array_methods] that are available on every Array[^0] object can be used to add or remove from the array.
 
 ### push
 
@@ -94,7 +94,7 @@ numbers;
 
 ---
 
-[^0]: `Array.prototype` is undefined.  Please add reference.
+[^0]: `Array`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array> (referenced November 5, 2021)
 [^1]: `push`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push> (referenced September 29, 2021)
 [^2]: `pop`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop> (referenced September 29, 2021)
 [^3]: `shift`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift> (referenced September 29, 2021)

--- a/concepts/arrays/introduction.md
+++ b/concepts/arrays/introduction.md
@@ -33,7 +33,7 @@ numbers;
 
 ## Methods
 
-Some of the [methods][array_methods] that are available on every Array[^0] object can be used to add or remove from the array.
+Some of the [methods][array_methods] that are available on every Array object can be used to add or remove from the array.
 
 ### push
 
@@ -94,7 +94,6 @@ numbers;
 
 ---
 
-[^0]: `Array`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array> (referenced November 5, 2021)
 [^1]: `push`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push> (referenced September 29, 2021)
 [^2]: `pop`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop> (referenced September 29, 2021)
 [^3]: `shift`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift> (referenced September 29, 2021)

--- a/concepts/arrays/introduction.md
+++ b/concepts/arrays/introduction.md
@@ -33,7 +33,7 @@ numbers;
 
 ## Methods
 
-Some of the [methods][array_methods] that are available on `Array.prototype` can be used to add or remove from the array.
+Some of the [methods][array_methods] that are available on `Array.prototype`[^0] can be used to add or remove from the array.
 
 ### push
 
@@ -94,6 +94,7 @@ numbers;
 
 ---
 
+[^0]: `Array.prototype` is undefined.  Please add reference.
 [^1]: `push`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push> (referenced September 29, 2021)
 [^2]: `pop`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop> (referenced September 29, 2021)
 [^3]: `shift`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift> (referenced September 29, 2021)

--- a/exercises/concept/elyses-enchantments/.docs/introduction.md
+++ b/exercises/concept/elyses-enchantments/.docs/introduction.md
@@ -33,7 +33,7 @@ numbers;
 
 ## Methods
 
-Some of the [methods][array_methods] that are available on every Array[^0] object can be used to add or remove from the array.
+Some of the [methods][array_methods] that are available on every Array object can be used to add or remove from the array.
 Here are a few to consider when working on this exercise:
 
 ### push
@@ -96,7 +96,6 @@ numbers;
 
 ---
 
-[^0]: `Array`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array> (referenced November 5, 2021)
 [^1]: `push`, MDN. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push (referenced September 29, 2021)
 [^2]: `pop`, MDN. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop (referenced September 29, 2021)
 [^3]: `shift`, MDN. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift (referenced September 29, 2021)

--- a/exercises/concept/elyses-enchantments/.docs/introduction.md
+++ b/exercises/concept/elyses-enchantments/.docs/introduction.md
@@ -33,7 +33,7 @@ numbers;
 
 ## Methods
 
-Some of the [methods][array_methods] that are available on `Array.prototype` can be used to add or remove from the array.
+Some of the [methods][array_methods] that are available on every Array[^0] object can be used to add or remove from the array.
 Here are a few to consider when working on this exercise:
 
 ### push
@@ -96,6 +96,7 @@ numbers;
 
 ---
 
+[^0]: `Array`, MDN. <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array> (referenced November 5, 2021)
 [^1]: `push`, MDN. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push (referenced September 29, 2021)
 [^2]: `pop`, MDN. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop (referenced September 29, 2021)
 [^3]: `shift`, MDN. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift (referenced September 29, 2021)


### PR DESCRIPTION
This document uses the term "Array.prototype" without defining it.   This is quite confusing and should be fixed.