### PR TITLE
Lasagna Master: Check that original recipe is not modified

### DIFF
--- a/exercises/concept/lasagna-master/lasagna-master.spec.js
+++ b/exercises/concept/lasagna-master/lasagna-master.spec.js
@@ -223,6 +223,21 @@ describe('scaleRecipe', () => {
   test('works for an empty recipe', () => {
     expect(scaleRecipe({})).toEqual({});
   });
+
+  test('does not modify the original recipe', () => {
+    const recipe = {
+      sauce: 1,
+      noodles: 250,
+      meat: 150,
+      tomatoes: 3,
+      onion: 2,
+    };
+
+    const copy = { ...recipe };
+
+    scaleRecipe(recipe, 4);
+    expect(recipe).toEqual(copy);
+  });
 });
 
 /**


### PR DESCRIPTION
This adds a check that, for a number of people not equal to 2, the original object is deeply equal to a clone of itself made earlier. This I think is more accurate than simply checking that the original recipe and the resulting object are not equal by reference since it is possible to modify the original without returning it at the end. This check also allows them to mess with the original object but end up with the same values at the end which is functionally equivalent to leaving it unmodified.

Closes #1496