### PR TITLE
Fix minor inconsistency with default Error

### DIFF
--- a/exercises/concept/high-score-board/high-score-board.js
+++ b/exercises/concept/high-score-board/high-score-board.js
@@ -42,7 +42,7 @@ export function removePlayer(scoreBoard, player) {
  * @returns {Record<string, number>} updated score board
  */
 export function updateScore(scoreBoard, player, points) {
-  throw new Error('Please implement the addToScore function');
+  throw new Error('Please implement the updateScore function');
 }
 
 /**


### PR DESCRIPTION
The name of the function is `updateScore` rather than `addToScore` - this update changes the thrown error to match the function name.