### PR TITLE
Translation Service: remove instructions as steps

### DIFF
--- a/exercises/concept/translation-service/.docs/instructions.md
+++ b/exercises/concept/translation-service/.docs/instructions.md
@@ -4,11 +4,11 @@ In this exercise you'll be providing a `TranslationService` where paid members h
 
 You have found an out-of-space translation API that is able to fulfill any translation _request_ in a reasonable amount of time, and you want to capitalize on this.
 
-## The API interface
+**The API interface**
 
 The API has a very minimal interface:
 
-### Fetching a translation
+**Fetching a translation**
 
 `api.fetch(text)` fetches the translation of `text`, returning two values:
 
@@ -23,7 +23,7 @@ api.fetch('jIyaj');
 // => Promise({ resolved: 'I understand' })
 ```
 
-### Requesting a translation
+**Requesting a translation**
 
 Some translations are known in the future.
 The API knows about these.
@@ -39,7 +39,7 @@ api.request('majQa’');
 // => Promise({ resolved: undefined })
 ```
 
-### ⚠ Warning! ⚠
+**⚠ Warning! ⚠**
 
 ```exercism/caution
 The API works its magic by teleporting in the various translators when a `request` comes in.
@@ -117,7 +117,7 @@ service.premium("'arlogh Qoylu'pu'?", 40);
 // => Promise<...> resolves "What time is it?"
 ```
 
-## N.B.
+**N.B.**
 
 ```exercism/note
 The correct translation of `'arlogh Qoylu'pu'?` is **How many times has it been heard?**.


### PR DESCRIPTION
While doing the translation service exercise I was really confused because it seemed that the first few instructions about the api interface were reading as steps:

![image](https://user-images.githubusercontent.com/30577427/144481993-94d660bb-1976-412f-ac90-66a38a4b1297.png)

As this is already a concept that can be hard to grasp, I thought if we removed them as headers and kept them as part of the instructions (as I assume they are?) it will be easier to do this exercise. 

Maybe there is another way to make this happen that is semantically more correct? But right now it appears that a h3 or h2 will turn into a step?
