### PR TITLE
Make roadmap available on the website

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,16 +47,16 @@ This document provides an overview of the main topics that contributors and main
 - `recursion`
 - `closures`
 - `sets`
+- `randomness`
+- `regular-expressions`
+- `dates`
+- `async-await`
+- `type-checking`
 
 ### Potential Future Concepts
 
-- `type-checking`
-- `maps` (should be added to the Sets exercise, WeakSet/WeakMap could be in about as first iteration)
-- `dates`
-- `async-await`
+- `maps` (could be added to the Sets exercise, WeakSet/WeakMap could be in about as first iteration)
 - `JSON`
-- `randomness`
-- `regular-expressions`
 - `math`
 - getters/setters, flags, descriptors
 - `proxy`

--- a/docs/config.json
+++ b/docs/config.json
@@ -27,6 +27,13 @@
       "path": "docs/RESOURCES.md",
       "title": "Useful JavaScript resources",
       "blurb": "A collection of useful resources to help you master JavaScript"
+    },
+    {
+      "uuid": "eef6eca6-6ee8-4ab5-a97a-3e8eb7785c7e",
+      "slug": "roadmap",
+      "path": "docs/ROADMAP.md",
+      "title": "Roadmap & Concept List",
+      "blurb": "Priorities for future development of the JavaScript track"
     }
   ]
 }


### PR DESCRIPTION
Bethany pointed out that by adding the roadmap to the docs folder and setting the right config, we can make it available on the website in the track-specific contribution guideline section. https://exercism.org/docs/tracks/javascript

This PR also includes some minor updates for the concept list to reflect the issues that have been created.