### PR TITLE
Fix project/product names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,14 +166,14 @@ You may improve these files by making the required changes and opening a new Pul
 
 ## Tools
 
-You'll need LTS or higher NodeJS in order to contribute to the _code_ in this repository.
+You'll need LTS or higher Node.js in order to contribute to the _code_ in this repository.
 Run `npm install` in the root in order to be able to run the scripts as listed below.
 We use the following dependencies:
 
 - `shelljs` in order to provide shell interface to scripts
 - `eslint` for linting all code in the stub, test file and example file
 - `jest` to run all the test files on all example implementations
-- `babel` to transpile everything so it works _regardless of your version of NodeJS_.
+- `babel` to transpile everything so it works _regardless of your version of Node.js_.
 
 We also use `prettier` to format the files.
 **Prettier is installed when using `npm install`**.
@@ -183,7 +183,7 @@ If you want to auto-format using your editor, install via `npm install` and it w
 ### Fetch configlet
 
 If you'd like to download [configlet][configlet], you can use the [`fetch-configlet`][bin-fetch-configlet] binary.
-It will run on Linux, Mac OSX and Windows, and download `configlet` to your local drive.
+It will run on Linux, macOS and Windows, and download `configlet` to your local drive.
 Find more information about [configlet][configlet] [here][configlet].
 
 > If a track implements an exercise for which test data exists, the exercise _must_ contain a `.meta/tests.toml` file.
@@ -215,17 +215,17 @@ We have various `scripts` for you in order to aid with maintaining and contribut
 > SyntaxError: Unexpected token 'export'
 > ```
 >
-> It's because your local node version does **not** support es6
+> It's because your local Node.js version does **not** support es6
 > `import` and `export` statements in regular `.js` files, or
 > files without extension. This is one of the reasons why these
-> scripts are meant to be ran through node:
+> scripts are meant to be ran through Node.js:
 >
 > ```shell
 > npx babel-node scripts/the-script
 > ```
 >
 > Additionally, this ensures that the code written in the scripts
-> and their dependencies can be executed by your current node
+> and their dependencies can be executed by your current Node.js
 > version, which may be different than the maintainer or
 > contributor who contributed to the script.
 

--- a/config/exercise-readme-insert.md
+++ b/config/exercise-readme-insert.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Go through the setup instructions for Javascript to install the necessary
+Go through the setup instructions for JavaScript to install the necessary
 dependencies:
 
 [https://exercism.org/docs/tracks/javascript/installation](https://exercism.org/docs/tracks/javascript/installation)

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -2,11 +2,11 @@
 
 JavaScript is a programming language that allows web pages to be dynamic. It is an interpreted language, which means that it doesn't need to be compiled: instead the interpreter (such as a web browser) will parse the code and turn it into code that their machine can run - suitable for creating dynamic websites that can run on any browser _on any computer_!
 
-JavaScript is not only used in the browser. JavaScript runtimes, such as [NodeJS][web-nodejs] and [deno][web-deno] allow you to write, launch and serve requests on webservers.
-Other frameworks, such as [Electron][web-electron] use JavaScript to write _cross-platform applications_ for Windows, Linux and Mac OS.
-Mobile app development is also a possibility, utilising [react-native][web-react-native], [ionic][web-ionic] and various others, with [expo][web-expo] now allowing to target Android, iOS and the web, all at once.
+JavaScript is not only used in the browser. JavaScript runtimes, such as [Node.js][web-nodejs] and [Deno][web-deno] allow you to write, launch and serve requests on webservers.
+Other frameworks, such as [Electron][web-electron] use JavaScript to write _cross-platform applications_ for Windows, Linux and macOS.
+Mobile app development is also a possibility, utilising [React Native][web-react-native], [Ionic][web-ionic] and various others, with [Expo][web-expo] now allowing to target Android, iOS and the web, all at once.
 
-ECMAScript is the [standard][web-ecma] that defines Javascript.
+ECMAScript is the [standard][web-ecma] that defines JavaScript.
 
 > "ECMAScript has grown to be one of the world’s most widely used general-purpose programming languages.
 > It is best known as the language embedded in web browsers but has also been widely adopted for server and embedded applications."
@@ -15,12 +15,12 @@ ECMAScript is the [standard][web-ecma] that defines Javascript.
 Starting with the 6th edition (commonly known as ES2015 or ES6) in 2015, a new edition of the standard will be released each year.
 The 6th edition was a major update that brought many enhancements over ES5, including notably template strings, expressive arrow function syntax, and cleaner syntax for defining classes.
 
-But because new syntax and features are coming to JavaScript _each year_, support for these changes is often incomplete in [current browsers][web-compat-browsers] and [the latest node][web-compat-node].
+But because new syntax and features are coming to JavaScript _each year_, support for these changes is often incomplete in [current browsers][web-compat-browsers] and [the latest Node.js][web-compat-node].
 This doesn't mean we can't use it.
 Tools such as [Babel][web-babel] offer [transpilation][wiki-transpilation] for most features, allowing us to _write_ as if it's the future.
 
 **Note**: This track supports the latest ECMAScript syntax via Babel and the [@babel/preset-env][web-babel-preset-env] plugin, and new experimental features are enabled with each update of that plugin, matching the release of the specifications.
-It automatically adapts to _your local node_ installation.
+It automatically adapts to _your local Node.js_ installation.
 This means you don't need to worry about what is and isn't supported.
 
 ---

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,43 +1,43 @@
 # Installation
 
-This track relies on [NodeJS][web-nodejs] throughout to provide a runtime for JavaScript.
-This means that we assume all execution of JavaScript on your computer will happen using [NodeJS][web-nodejs].
+This track relies on [Node.js][web-nodejs] throughout to provide a runtime for JavaScript.
+This means that we assume all execution of JavaScript on your computer will happen using [Node.js][web-nodejs].
 
 # Track Requirements
 
-Many machines come pre-installed with [NodeJS][web-nodejs] or might have been installed previously, or as a dependency.
+Many machines come pre-installed with [Node.js][web-nodejs] or might have been installed previously, or as a dependency.
 So before we do anything, we should check if it's already installed:
 
 1. Open up a _terminal_ (`Terminal`, `cmd`, `Powershell`, `bash`, ...)
 1. `node -v`
 
-If [NodeJS][web-nodejs] is installed, a version is displayed.
+If [Node.js][web-nodejs] is installed, a version is displayed.
 Write this version down.
-If [NodeJS][web-nodejs] is _not_ installed, an error will be written out.
+If [Node.js][web-nodejs] is _not_ installed, an error will be written out.
 Usually, something along the lines of `'node' is not recognised`.
 
-## NodeJS
+## Node.js
 
-### If node is pre-installed
+### If Node.js is pre-installed
 
-Browse to [the NodeJS website][web-nodejs].
+Browse to [the Node.js website][web-nodejs].
 It will display _two_ versions (if it detects your OS. Otherwise, select your OS first).
 If your `node -v` version matches one of these, you're good.
-If it doesn't, we recommend that you use Node LTS.
+If it doesn't, we recommend that you use Node.js LTS.
 If you're worried upgrading might break something on your system, you can continue as if everything is fine;
 we might not be able to provide support when something unexpected happens.
 
-### If node is not installed
+### If Node.js is not installed
 
-There are a couple of ways to install [NodeJS][web-nodejs]:
+There are a couple of ways to install [Node.js][web-nodejs]:
 
 - via an [Installer or Binary][web-nodejs-download]
 - via a [package manager][web-nodejs-package]
 
-Both options support Windows, MacOS, and Linux. If you don't know what to do, using an installer is the easiest.
+Both options support Windows, macOS, and Linux. If you don't know what to do, using an installer is the easiest.
 
-- We recommend using the **LTS** version. This is also indicated as _recommended_ on the [NodeJS][web-nodejs] website "for most users".
-- Follow the instructions on the webpage and/or during the installer and install [NodeJS][web-nodejs].
+- We recommend using the **LTS** version. This is also indicated as _recommended_ on the [Node.js][web-nodejs] website "for most users".
+- Follow the instructions on the webpage and/or during the installer and install [Node.js][web-nodejs].
 
 ### Testing the installation
 
@@ -56,7 +56,7 @@ This means that the open terminals don't know that a new program was installed.
 >
 > If you've used the official installer, your `PATH` should have been automatically configured, but if your shell has trouble locating your globally installed modules &mdash; or if you build Node.js from source &mdash; update your `PATH` to include the `npm` binaries.
 >
-> On MacOS and Linux you may accomplish this by adding the following to either `~/.bash_profile` or `~/.zshrc`:
+> On macOS and Linux you may accomplish this by adding the following to either `~/.bash_profile` or `~/.zshrc`:
 >
 > ```bash
 > $ export PATH=/usr/local/share/npm/bin:$PATH
@@ -93,7 +93,7 @@ In this case, run `pnpm install` instead of `npm install`, and everything should
 >
 > You don't need this information to complete the JavaScript track, but if you're eager to understand what just happened, the following paragraphs are for you:
 >
-> This works because `npm` is a package manager that comes bundled with `NodeJS`, which has been installed per the steps above.
+> This works because `npm` is a package manager that comes bundled with Node.js, which has been installed per the steps above.
 > The `npm` command looks for a `package.json` file, which is present in _each_ assignment folder.
 > This file lists the `"dependencies"` above, which are then downloaded by `npm` and placed into the `node_modules` folder.
 >

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,8 +1,8 @@
 # Learning
 
-Exercism itself has a nice [learning path for Javascript](https://exercism.org/tracks/javascript/concepts).
+Exercism itself has a nice [learning path for JavaScript](https://exercism.org/tracks/javascript/concepts).
 But in case you need more, here are some resources:
 
-- [Learn Javascript on MDN](https://developer.mozilla.org/en-US/docs/Learn/JavaScript)
+- [Learn JavaScript on MDN](https://developer.mozilla.org/en-US/docs/Learn/JavaScript)
 - [ES6 Katas](http://es6katas.org)
 - [Babel docs](https://babeljs.io/docs/en/learn/)

--- a/reference/keywords/export.md
+++ b/reference/keywords/export.md
@@ -36,7 +36,7 @@ One caveat about re-exporting is that `default` exports are ignored by this synt
 
 ## Transpilation
 
-To make `export`s work, we use transpilers like [babel][babel] or [tsc][tsc] that take those modules and convert them into a dedicated file (or multiple). Babel also has the benefit of another form of `export`s, the so-called `synthetic default export`:
+To make `export`s work, we use transpilers like [Babel][babel] or the [TypeScript compiler (tsc)][tsc] that take those modules and convert them into a dedicated file (or multiple). Babel also has the benefit of another form of `export`s, the so-called `synthetic default export`:
 
 ```js
 exports = class XYZ {};
@@ -46,7 +46,7 @@ Which will be translated like the first mentioned example (`export default class
 
 ## ECMAScript 6 modules vs CommonJS modules
 
-There are different kinds of [modules][concept-module], each with a different way to export. The examples above are all [ECMAScript 6 modules][es6-modules] and are mostly available through preprocessors like [babel][babel]. In [Node.js][node-js] environments however [CommonJS modules][cjs-modules] are used. They usually take the following form (note that there is no `default` export):
+There are different kinds of [modules][concept-module], each with a different way to export. The examples above are all [ECMAScript 6 modules][es6-modules] and are mostly available through preprocessors like [Babel][babel]. In [Node.js][node-js] environments however [CommonJS modules][cjs-modules] are used. They usually take the following form (note that there is no `default` export):
 
 ```js
 var foo = 42;
@@ -61,7 +61,7 @@ module.exports = {
 
 ## Where to use
 
-The `export` keyword, just like `import`, can only be used in a module, which means it has to be run in [Node.js][node-js], transpiled by [babel][babel] or similar, or be used in a [file included in the browser directly][es-modules-in-browser] using `<script type="module" src="…">`.
+The `export` keyword, just like `import`, can only be used in a module, which means it has to be run in [Node.js][node-js], transpiled by [Babel][babel] or similar, or be used in a [file included in the browser directly][es-modules-in-browser] using `<script type="module" src="…">`.
 
 ## Further reading
 

--- a/reference/keywords/import.md
+++ b/reference/keywords/import.md
@@ -12,7 +12,7 @@ import { myExport as expert } from 'module-name'; // Only imports the myExport b
 import { default as namedDefault, myExport } from 'module-name'; // Imports the default export as namedDefault, and myExport
 ```
 
-Typically, the module name can be either a [NPM][npm]-installed package – which reside in the `node_modules/` directory – or a relative link, such as `./myFile.js`. There are also JavaScript interpreters where modules can be URLs, like in [deno][deno].
+Typically, the module name can be either a [npm][npm]-installed package – which reside in the `node_modules/` directory – or a relative link, such as `./myFile.js`. There are also JavaScript interpreters where modules can be URLs, like in [Deno][deno].
 
 ## ECMAScript 6 modules vs CommonJS modules
 
@@ -26,7 +26,7 @@ This was the primary way of importing modules in Node.js, but current versions a
 
 ## Where to use
 
-The `import` keyword, just like `export`, can only be used in a module, which means it has to be run in [Node.js][node-js], transpiled by [babel][babel] or similar, or be used in a [file included in the browser directly][es-modules-in-browser] using `<script type="module" src="…">`.
+The `import` keyword, just like `export`, can only be used in a module, which means it has to be run in [Node.js][node-js], transpiled by [Babel][babel] or similar, or be used in a [file included in the browser directly][es-modules-in-browser] using `<script type="module" src="…">`.
 
 ## Further reading
 


### PR DESCRIPTION
#### Change

Use names as presented on their respective sites. ie. copy the capitalisation and punctuation.

#### Consequences

Being consistent when referring to these projects will avoid confusion and reduce the burden on the reader.