### PR TITLE
Update high-score-board.spec.js with expected value

### DIFF
--- a/exercises/concept/high-score-board/high-score-board.spec.js
+++ b/exercises/concept/high-score-board/high-score-board.spec.js
@@ -91,7 +91,7 @@ describe('updateScore', () => {
     };
 
     updateScore(scoreBoard, 'Min-seo Shin', 1999);
-    const actual = updateScore(scoreBoard, 'Jesse Johnson', 1337);
+    const actual = updateScore(scoreBoard, 'Jesse Johnson', 2674);
     expect(actual).toEqual(expected);
 
     // This checks that the same object that was passed in is returned.


### PR DESCRIPTION
We expect `2674` on: 
https://github.com/exercism/javascript/blob/main/exercises/concept/high-score-board/high-score-board.spec.js#L90
but update the value to `1337` on:
https://github.com/exercism/javascript/blob/main/exercises/concept/high-score-board/high-score-board.spec.js#L94
that leads to a failing test on the main track. No way around via online editor. The only option is to update the test and submit from local. 

Updating the function to `updateScore` with expected values.