### PR TITLE
Prevent changes to the lock file by the format action

### DIFF
--- a/.github/workflows/action-format.yml
+++ b/.github/workflows/action-format.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           node-version: '16'
       - name: Install project development dependencies
-        run: npm i
+        run: npm install --no-save
       - name: 'Format code'
         run: ./bin/format.sh
 


### PR DESCRIPTION
According to this https://github.com/npm/npm/issues/17761 `--no-save` prevents the edit of the lock file.

Fixes https://github.com/exercism/javascript/pull/1579#discussion_r776326023

cc @JaPatGitHub 