### PR TITLE
Adds a test case that can be solved using `hasOwnProperty` to the High Score Board exercise

### DIFF
--- a/exercises/concept/high-score-board/.docs/instructions.md
+++ b/exercises/concept/high-score-board/.docs/instructions.md
@@ -110,3 +110,20 @@ const params = { score: 400, normalizeFunction: normalize };
 normalizeScore(params);
 // => 810
 ```
+
+## 7. Confirm player is on score board
+
+Players want to know if they are on the score board.
+
+Write a function `hasPlayer`.
+The function takes a scoreboard, and a name of a player. It should return a boolean indicating if that player is on the score board.
+
+```javascript
+const scoreBoard = {
+  'Amil Pastorius': 99373,
+  'Min-seo Shin': 0,
+};
+
+hasPlayer(scoreBoard, "Min-seo Shin");
+// => true
+```

--- a/exercises/concept/high-score-board/high-score-board.js
+++ b/exercises/concept/high-score-board/high-score-board.js
@@ -64,3 +64,14 @@ export function applyMondayBonus(scoreBoard) {
 export function normalizeScore(params) {
   throw new Error('Please implement the normalizeScore function');
 }
+
+/**
+ * Confirms player is in the scoreboard.
+ *
+ * @param {Record<string, number>} scoreBoard parameters for performing the confirmation
+ * @param {string} player player name to check 
+ * @returns {boolean} 
+ */
+export function hasPlayer(scoreBoard, player) {
+  throw new Error('Please implement the hasPlayer function');
+}

--- a/exercises/concept/high-score-board/high-score-board.spec.js
+++ b/exercises/concept/high-score-board/high-score-board.spec.js
@@ -5,6 +5,7 @@ import {
   updateScore,
   applyMondayBonus,
   normalizeScore,
+  hasPlayer,
 } from './high-score-board';
 
 describe('createScoreBoard', () => {
@@ -153,3 +154,23 @@ describe('normalizeScore', () => {
     expect(normalizeScore(params)).toEqual(1150);
   });
 });
+
+describe("hasPlayer", () => {
+  test("confirms player is in scoreboard", () => {
+    const scoreBoard = {
+      'Amil Pastorius': 99373,
+      'Min-seo Shin': 0,
+    };
+
+    expect(hasPlayer(scoreBoard, "Amil Pastorius")).toEqual(true);
+  });
+
+  test("confirms player is not in scoreboard", () => {
+    const scoreBoard = {
+      'Amil Pastorius': 99373,
+      'Min-seo Shin': 0,
+    };
+
+    expect(hasPlayer(scoreBoard, "John Cena")).toEqual(false);
+  });
+}); 


### PR DESCRIPTION
The `README.md` in the High Score Board exercise mentions `hasOwnProperty`, but it was never used in the rest of the exercise, so I added a test case that can be solved using `hasOwnProperty`. 

This is my first PR to this repository, so if I'm missing something, let me know. I'm not clear about what may or may not need to be updated on the problem-specifications repository, or in the hidden directories (like `.meta`).