### PR TITLE
Elyses Transformative Enchantments exercise typos

### DIFF
--- a/exercises/concept/elyses-transformative-enchantments/.meta/exemplar.js
+++ b/exercises/concept/elyses-transformative-enchantments/.meta/exemplar.js
@@ -41,7 +41,7 @@ export function middleTwo(deck) {
 /**
  * Moves the outside two cards to the middle.
  *
- * @param {number[]} deck with 10 cards
+ * @param {number[]} deck with even number of cards
  * @returns {number[]} transformed deck
  */
 

--- a/exercises/concept/elyses-transformative-enchantments/enchantments.js
+++ b/exercises/concept/elyses-transformative-enchantments/enchantments.js
@@ -37,7 +37,7 @@ export function middleTwo(deck) {
 /**
  * Moves the outside two cards to the middle.
  *
- * @param {number[]} deck with 10 cards
+ * @param {number[]} deck with even number of cards
  *
  * @returns {number[]} transformed deck
  */


### PR DESCRIPTION
Tests and hints use array with even amount of cards, yet `sandwichTrick` function phpdoc says _deck with 10 cards_ . Probably a copypaste typo