### PR TITLE
Update scale-generator.spec.js

### DIFF
--- a/exercises/practice/scale-generator/scale-generator.spec.js
+++ b/exercises/practice/scale-generator/scale-generator.spec.js
@@ -15,7 +15,7 @@ describe('ScaleGenerator', () => {
         'G#',
         'A',
         'A#',
-        'B',
+        'B'
       ];
       expect(new Scale('C').chromatic()).toEqual(expected);
     });
@@ -33,7 +33,7 @@ describe('ScaleGenerator', () => {
         'Db',
         'D',
         'Eb',
-        'E',
+        'E'
       ];
       expect(new Scale('F').chromatic()).toEqual(expected);
     });


### PR DESCRIPTION
Removed the redundant comma in the expected array variable for both the below test cases: 
- 'Chromatic scale with sharps'
- 'Chromatic scale with flats'