### PR TITLE
exercises/concept/translation-service imports and a minor typo

### DIFF
--- a/exercises/concept/translation-service/.docs/instructions.md
+++ b/exercises/concept/translation-service/.docs/instructions.md
@@ -99,7 +99,7 @@ service.request("jIyajbe'");
 
 ## 4. Fetch a translation, inspect the quality, or request it
 
-Implement the function `premium(text, quality)` for premium users, which fetches a translation, request it if it's not available, and only returns it if it meets a certain threshold.
+Implement the function `premium(text, quality)` for premium users, which fetches a translation, requests it if it's not available, and only returns it if it meets a certain threshold.
 
 - If `api.fetch` resolves, check the quality before resolving
 - If `api.fetch` rejects with `NotAvailable`, _request_ the translation instead

--- a/exercises/concept/translation-service/service.js
+++ b/exercises/concept/translation-service/service.js
@@ -8,6 +8,8 @@
 //
 // In your own projects, files, and code, you can play with @ts-check as well.
 
+import { NotAvailable, Untranslatable } from './errors';
+
 export class TranslationService {
   /**
    * Creates a new service


### PR DESCRIPTION
Without those imports, the tests will always fail if you attempt to catch those errors by their type (without string comparisons). On the JavaScript track, the concept of importing is not introduced before this exercise, so it makes sense to add those imports into the JS template for less confusion.

Also a minor typo in the instructions.