### PR TITLE
Add custom flags to config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,6 @@
 /.github/workflows/sync-labels.yml
 exercises/**/README.md
 !/README.md
+
+# These are formatted via configlet and will not match prettier
+exercises/**/.meta/config.json

--- a/exercises/concept/amusement-park/.meta/config.json
+++ b/exercises/concept/amusement-park/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["amusement-park.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": ["ruby/amusement-park"]
+  "forked_from": ["ruby/amusement-park"],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/amusement-park/.meta/config.json
+++ b/exercises/concept/amusement-park/.meta/config.json
@@ -1,13 +1,22 @@
 {
-  "blurb": "Learn about undefined and null by managing visitors and tickets at an amusement park.",
-  "authors": ["junedev"],
-  "contributors": [],
+  "authors": [
+    "junedev"
+  ],
   "files": {
-    "solution": ["amusement-park.js"],
-    "test": ["amusement-park.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "amusement-park.js"
+    ],
+    "test": [
+      "amusement-park.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": ["ruby/amusement-park"],
+  "forked_from": [
+    "ruby/amusement-park"
+  ],
+  "blurb": "Learn about undefined and null by managing visitors and tickets at an amusement park.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["annalyns-infiltration.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": []
+  "forked_from": [],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -1,13 +1,23 @@
 {
-  "blurb": "Help Annalyn free her best friend using boolean logic in JavaScript",
-  "authors": ["ovidiu141"],
-  "contributors": ["rishiosaur", "SleeplessByte"],
+  "authors": [
+    "ovidiu141"
+  ],
+  "contributors": [
+    "rishiosaur",
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["annalyns-infiltration.js"],
-    "test": ["annalyns-infiltration.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "annalyns-infiltration.js"
+    ],
+    "test": [
+      "annalyns-infiltration.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": [],
+  "blurb": "Help Annalyn free her best friend using boolean logic in JavaScript",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/annalyns-infiltration/annalyns-infiltration.spec.js
+++ b/exercises/concept/annalyns-infiltration/annalyns-infiltration.spec.js
@@ -5,407 +5,405 @@ import {
   canFreePrisoner,
 } from './annalyns-infiltration';
 
-describe("Annalyn's infiltration", () => {
-  describe('can execute fast attack', () => {
-    test('when the knight is awake', () => {
-      const knightIsAwake = true;
-      const expected = false;
+describe('can execute fast attack', () => {
+  test('when the knight is awake', () => {
+    const knightIsAwake = true;
+    const expected = false;
 
-      expect(canExecuteFastAttack(knightIsAwake)).toBe(expected);
-    });
-
-    test('when the knight is asleep', () => {
-      const knightIsAwake = false;
-      const expected = true;
-
-      expect(canExecuteFastAttack(knightIsAwake)).toBe(expected);
-    });
+    expect(canExecuteFastAttack(knightIsAwake)).toBe(expected);
   });
 
-  describe('can spy', () => {
-    test('when everyone is asleep', () => {
-      const knightIsAwake = false;
-      const archerIsAwake = false;
-      const prisonerIsAwake = false;
-      const expected = false;
+  test('when the knight is asleep', () => {
+    const knightIsAwake = false;
+    const expected = true;
 
-      expect(canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).toBe(
-        expected
-      );
-    });
+    expect(canExecuteFastAttack(knightIsAwake)).toBe(expected);
+  });
+});
 
-    test('when only the prisoner is awake', () => {
-      const knightIsAwake = false;
-      const archerIsAwake = false;
-      const prisonerIsAwake = true;
-      const expected = true;
+describe('can spy', () => {
+  test('when everyone is asleep', () => {
+    const knightIsAwake = false;
+    const archerIsAwake = false;
+    const prisonerIsAwake = false;
+    const expected = false;
 
-      expect(canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).toBe(
-        expected
-      );
-    });
-
-    test('when only the archer is awake', () => {
-      const knightIsAwake = false;
-      const archerIsAwake = true;
-      const prisonerIsAwake = false;
-      const expected = true;
-
-      expect(canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).toBe(
-        expected
-      );
-    });
-
-    test('when only the knight is asleep', () => {
-      const knightIsAwake = false;
-      const archerIsAwake = true;
-      const prisonerIsAwake = true;
-      const expected = true;
-
-      expect(canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).toBe(
-        expected
-      );
-    });
-
-    test('when only the knight is awake', () => {
-      const knightIsAwake = true;
-      const archerIsAwake = false;
-      const prisonerIsAwake = false;
-      const expected = true;
-
-      expect(canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).toBe(
-        expected
-      );
-    });
-
-    test('when only the archer is asleep', () => {
-      const knightIsAwake = true;
-      const archerIsAwake = false;
-      const prisonerIsAwake = true;
-      const expected = true;
-
-      expect(canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).toBe(
-        expected
-      );
-    });
-
-    test('when everyone is awake', () => {
-      const knightIsAwake = true;
-      const archerIsAwake = true;
-      const prisonerIsAwake = true;
-      const expected = true;
-
-      expect(canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).toBe(
-        expected
-      );
-    });
+    expect(canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).toBe(
+      expected
+    );
   });
 
-  describe('can signal prisoner', () => {
-    test('when everyone is asleep', () => {
-      const archerIsAwake = false;
-      const prisonerIsAwake = false;
-      const expected = false;
+  test('when only the prisoner is awake', () => {
+    const knightIsAwake = false;
+    const archerIsAwake = false;
+    const prisonerIsAwake = true;
+    const expected = true;
 
-      expect(canSignalPrisoner(archerIsAwake, prisonerIsAwake)).toBe(expected);
-    });
-
-    test('when only the prisoner is awake', () => {
-      const archerIsAwake = false;
-      const prisonerIsAwake = true;
-      const expected = true;
-
-      expect(canSignalPrisoner(archerIsAwake, prisonerIsAwake)).toBe(expected);
-    });
-
-    test('when only the archer is awake', () => {
-      const archerIsAwake = true;
-      const prisonerIsAwake = false;
-      const expected = false;
-
-      expect(canSignalPrisoner(archerIsAwake, prisonerIsAwake)).toBe(expected);
-    });
-
-    test('when everyone is awake', () => {
-      const archerIsAwake = true;
-      const prisonerIsAwake = true;
-      const expected = false;
-
-      expect(canSignalPrisoner(archerIsAwake, prisonerIsAwake)).toBe(expected);
-    });
+    expect(canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).toBe(
+      expected
+    );
   });
 
-  describe('can free prisoner', () => {
-    test('when everyone is asleep and pet dog is not present', () => {
-      const knightIsAwake = false;
-      const archerIsAwake = false;
-      const prisonerIsAwake = false;
-      const petDogIsPresent = false;
-      const expected = false;
+  test('when only the archer is awake', () => {
+    const knightIsAwake = false;
+    const archerIsAwake = true;
+    const prisonerIsAwake = false;
+    const expected = true;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).toBe(
+      expected
+    );
+  });
 
-    test('when everyone is asleep and pet dog is present', () => {
-      const knightIsAwake = false;
-      const archerIsAwake = false;
-      const prisonerIsAwake = false;
-      const petDogIsPresent = true;
-      const expected = true;
+  test('when only the knight is asleep', () => {
+    const knightIsAwake = false;
+    const archerIsAwake = true;
+    const prisonerIsAwake = true;
+    const expected = true;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).toBe(
+      expected
+    );
+  });
 
-    test('when only the prisoner is awake and pet dog is not present', () => {
-      const knightIsAwake = false;
-      const archerIsAwake = false;
-      const prisonerIsAwake = true;
-      const petDogIsPresent = false;
-      const expected = true;
+  test('when only the knight is awake', () => {
+    const knightIsAwake = true;
+    const archerIsAwake = false;
+    const prisonerIsAwake = false;
+    const expected = true;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).toBe(
+      expected
+    );
+  });
 
-    test('when only the prisoner is awake and pet dog is present', () => {
-      const knightIsAwake = false;
-      const archerIsAwake = false;
-      const prisonerIsAwake = true;
-      const petDogIsPresent = true;
-      const expected = true;
+  test('when only the archer is asleep', () => {
+    const knightIsAwake = true;
+    const archerIsAwake = false;
+    const prisonerIsAwake = true;
+    const expected = true;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).toBe(
+      expected
+    );
+  });
 
-    test('when only the archer is awake and pet dog is not present', () => {
-      const knightIsAwake = false;
-      const archerIsAwake = true;
-      const prisonerIsAwake = false;
-      const petDogIsPresent = false;
-      const expected = false;
+  test('when everyone is awake', () => {
+    const knightIsAwake = true;
+    const archerIsAwake = true;
+    const prisonerIsAwake = true;
+    const expected = true;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(canSpy(knightIsAwake, archerIsAwake, prisonerIsAwake)).toBe(
+      expected
+    );
+  });
+});
 
-    test('when only the archer is awake and pet dog is present', () => {
-      const knightIsAwake = false;
-      const archerIsAwake = true;
-      const prisonerIsAwake = false;
-      const petDogIsPresent = true;
-      const expected = false;
+describe('can signal prisoner', () => {
+  test('when everyone is asleep', () => {
+    const archerIsAwake = false;
+    const prisonerIsAwake = false;
+    const expected = false;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(canSignalPrisoner(archerIsAwake, prisonerIsAwake)).toBe(expected);
+  });
 
-    test('when only the knight is asleep and pet dog is not present', () => {
-      const knightIsAwake = false;
-      const archerIsAwake = true;
-      const prisonerIsAwake = true;
-      const petDogIsPresent = false;
-      const expected = false;
+  test('when only the prisoner is awake', () => {
+    const archerIsAwake = false;
+    const prisonerIsAwake = true;
+    const expected = true;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(canSignalPrisoner(archerIsAwake, prisonerIsAwake)).toBe(expected);
+  });
 
-    test('when only the knight is asleep and pet dog is present', () => {
-      const knightIsAwake = false;
-      const archerIsAwake = true;
-      const prisonerIsAwake = true;
-      const petDogIsPresent = true;
-      const expected = false;
+  test('when only the archer is awake', () => {
+    const archerIsAwake = true;
+    const prisonerIsAwake = false;
+    const expected = false;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(canSignalPrisoner(archerIsAwake, prisonerIsAwake)).toBe(expected);
+  });
 
-    test('when only the knight is awake and pet dog is not present', () => {
-      const knightIsAwake = true;
-      const archerIsAwake = false;
-      const prisonerIsAwake = false;
-      const petDogIsPresent = false;
-      const expected = false;
+  test('when everyone is awake', () => {
+    const archerIsAwake = true;
+    const prisonerIsAwake = true;
+    const expected = false;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(canSignalPrisoner(archerIsAwake, prisonerIsAwake)).toBe(expected);
+  });
+});
 
-    test('when only the knight is awake and pet dog is present', () => {
-      const knightIsAwake = true;
-      const archerIsAwake = false;
-      const prisonerIsAwake = false;
-      const petDogIsPresent = true;
-      const expected = true;
+describe('can free prisoner', () => {
+  test('when everyone is asleep and pet dog is not present', () => {
+    const knightIsAwake = false;
+    const archerIsAwake = false;
+    const prisonerIsAwake = false;
+    const petDogIsPresent = false;
+    const expected = false;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
+  });
 
-    test('when only the archer is asleep and pet dog is not present', () => {
-      const knightIsAwake = true;
-      const archerIsAwake = false;
-      const prisonerIsAwake = true;
-      const petDogIsPresent = false;
-      const expected = false;
+  test('when everyone is asleep and pet dog is present', () => {
+    const knightIsAwake = false;
+    const archerIsAwake = false;
+    const prisonerIsAwake = false;
+    const petDogIsPresent = true;
+    const expected = true;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
+  });
 
-    test('when only the archer is asleep and pet dog is present', () => {
-      const knightIsAwake = true;
-      const archerIsAwake = false;
-      const prisonerIsAwake = true;
-      const petDogIsPresent = true;
-      const expected = true;
+  test('when only the prisoner is awake and pet dog is not present', () => {
+    const knightIsAwake = false;
+    const archerIsAwake = false;
+    const prisonerIsAwake = true;
+    const petDogIsPresent = false;
+    const expected = true;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
+  });
 
-    test('when only the prisoner is asleep and pet dog is not present', () => {
-      const knightIsAwake = true;
-      const archerIsAwake = true;
-      const prisonerIsAwake = false;
-      const petDogIsPresent = false;
-      const expected = false;
+  test('when only the prisoner is awake and pet dog is present', () => {
+    const knightIsAwake = false;
+    const archerIsAwake = false;
+    const prisonerIsAwake = true;
+    const petDogIsPresent = true;
+    const expected = true;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
+  });
 
-    test('when only the prisoner is asleep and pet dog is present', () => {
-      const knightIsAwake = true;
-      const archerIsAwake = true;
-      const prisonerIsAwake = false;
-      const petDogIsPresent = true;
-      const expected = false;
+  test('when only the archer is awake and pet dog is not present', () => {
+    const knightIsAwake = false;
+    const archerIsAwake = true;
+    const prisonerIsAwake = false;
+    const petDogIsPresent = false;
+    const expected = false;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
+  });
 
-    test('when everyone is awake and pet dog is not present', () => {
-      const knightIsAwake = true;
-      const archerIsAwake = true;
-      const prisonerIsAwake = true;
-      const petDogIsPresent = false;
-      const expected = false;
+  test('when only the archer is awake and pet dog is present', () => {
+    const knightIsAwake = false;
+    const archerIsAwake = true;
+    const prisonerIsAwake = false;
+    const petDogIsPresent = true;
+    const expected = false;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
+  });
 
-    test('when everyone is awake and pet dog is present', () => {
-      const knightIsAwake = true;
-      const archerIsAwake = true;
-      const prisonerIsAwake = true;
-      const petDogIsPresent = true;
-      const expected = false;
+  test('when only the knight is asleep and pet dog is not present', () => {
+    const knightIsAwake = false;
+    const archerIsAwake = true;
+    const prisonerIsAwake = true;
+    const petDogIsPresent = false;
+    const expected = false;
 
-      expect(
-        canFreePrisoner(
-          knightIsAwake,
-          archerIsAwake,
-          prisonerIsAwake,
-          petDogIsPresent
-        )
-      ).toBe(expected);
-    });
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
+  });
+
+  test('when only the knight is asleep and pet dog is present', () => {
+    const knightIsAwake = false;
+    const archerIsAwake = true;
+    const prisonerIsAwake = true;
+    const petDogIsPresent = true;
+    const expected = false;
+
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
+  });
+
+  test('when only the knight is awake and pet dog is not present', () => {
+    const knightIsAwake = true;
+    const archerIsAwake = false;
+    const prisonerIsAwake = false;
+    const petDogIsPresent = false;
+    const expected = false;
+
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
+  });
+
+  test('when only the knight is awake and pet dog is present', () => {
+    const knightIsAwake = true;
+    const archerIsAwake = false;
+    const prisonerIsAwake = false;
+    const petDogIsPresent = true;
+    const expected = true;
+
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
+  });
+
+  test('when only the archer is asleep and pet dog is not present', () => {
+    const knightIsAwake = true;
+    const archerIsAwake = false;
+    const prisonerIsAwake = true;
+    const petDogIsPresent = false;
+    const expected = false;
+
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
+  });
+
+  test('when only the archer is asleep and pet dog is present', () => {
+    const knightIsAwake = true;
+    const archerIsAwake = false;
+    const prisonerIsAwake = true;
+    const petDogIsPresent = true;
+    const expected = true;
+
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
+  });
+
+  test('when only the prisoner is asleep and pet dog is not present', () => {
+    const knightIsAwake = true;
+    const archerIsAwake = true;
+    const prisonerIsAwake = false;
+    const petDogIsPresent = false;
+    const expected = false;
+
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
+  });
+
+  test('when only the prisoner is asleep and pet dog is present', () => {
+    const knightIsAwake = true;
+    const archerIsAwake = true;
+    const prisonerIsAwake = false;
+    const petDogIsPresent = true;
+    const expected = false;
+
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
+  });
+
+  test('when everyone is awake and pet dog is not present', () => {
+    const knightIsAwake = true;
+    const archerIsAwake = true;
+    const prisonerIsAwake = true;
+    const petDogIsPresent = false;
+    const expected = false;
+
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
+  });
+
+  test('when everyone is awake and pet dog is present', () => {
+    const knightIsAwake = true;
+    const archerIsAwake = true;
+    const prisonerIsAwake = true;
+    const petDogIsPresent = true;
+    const expected = false;
+
+    expect(
+      canFreePrisoner(
+        knightIsAwake,
+        archerIsAwake,
+        prisonerIsAwake,
+        petDogIsPresent
+      )
+    ).toBe(expected);
   });
 });

--- a/exercises/concept/bird-watcher/.meta/config.json
+++ b/exercises/concept/bird-watcher/.meta/config.json
@@ -1,13 +1,22 @@
 {
-  "blurb": "Professionalize counting the birds in your garden with for loops and increment/decrement operators",
-  "authors": ["junedev"],
-  "contributors": [],
+  "authors": [
+    "junedev"
+  ],
   "files": {
-    "solution": ["bird-watcher.js"],
-    "test": ["bird-watcher.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "bird-watcher.js"
+    ],
+    "test": [
+      "bird-watcher.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": ["csharp/bird-watcher"],
+  "forked_from": [
+    "csharp/bird-watcher"
+  ],
+  "blurb": "Professionalize counting the birds in your garden with for loops and increment/decrement operators",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/bird-watcher/.meta/config.json
+++ b/exercises/concept/bird-watcher/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["bird-watcher.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": ["csharp/bird-watcher"]
+  "forked_from": ["csharp/bird-watcher"],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/bird-watcher/bird-watcher.spec.js
+++ b/exercises/concept/bird-watcher/bird-watcher.spec.js
@@ -1,77 +1,75 @@
 import { totalBirdCount, birdsInWeek, fixBirdCountLog } from './bird-watcher';
 
-describe('bird watcher', () => {
-  describe('totalBirdCount', () => {
-    test('calculates the correct total number of birds', () => {
-      const birdsPerDay = [9, 0, 8, 4, 5, 1, 3];
-      expect(totalBirdCount(birdsPerDay)).toBe(30);
-    });
-
-    test('works for a short bird count list', () => {
-      const birdsPerDay = [2];
-      expect(totalBirdCount(birdsPerDay)).toBe(2);
-    });
-
-    test('works for a long bird count list', () => {
-      // prettier-ignore
-      const birdsPerDay = [2, 8, 4, 1, 3, 5, 0, 4, 1, 6, 0, 3, 0, 1, 5, 4, 1, 1, 2, 6];
-      expect(totalBirdCount(birdsPerDay)).toBe(57);
-    });
+describe('totalBirdCount', () => {
+  test('calculates the correct total number of birds', () => {
+    const birdsPerDay = [9, 0, 8, 4, 5, 1, 3];
+    expect(totalBirdCount(birdsPerDay)).toBe(30);
   });
 
-  describe('birdsInWeek', () => {
-    test('calculates the number of birds in the first week', () => {
-      const birdsPerDay = [3, 0, 5, 1, 0, 4, 1, 0, 3, 4, 3, 0, 8, 0];
-      expect(birdsInWeek(birdsPerDay, 1)).toBe(14);
-    });
-
-    test('calculates the number of birds for a week in the middle of the log', () => {
-      // prettier-ignore
-      const birdsPerDay = [4, 7, 3, 2, 1, 1, 2, 0, 2, 3, 2, 7, 1, 3, 0, 6, 5, 3, 7, 2, 3];
-      expect(birdsInWeek(birdsPerDay, 2)).toBe(18);
-    });
-
-    test('works when there is only one week', () => {
-      const birdsPerDay = [3, 0, 3, 3, 2, 1, 0];
-      expect(birdsInWeek(birdsPerDay, 1)).toBe(12);
-    });
-
-    test('works for a long bird count list', () => {
-      const week21 = [2, 0, 1, 4, 1, 3, 0];
-      const birdsPerDay = randomArray(20 * 7)
-        .concat(week21)
-        .concat(randomArray(10 * 7));
-
-      expect(birdsInWeek(birdsPerDay, 21)).toBe(11);
-    });
+  test('works for a short bird count list', () => {
+    const birdsPerDay = [2];
+    expect(totalBirdCount(birdsPerDay)).toBe(2);
   });
 
-  describe('fixBirdCountLog', () => {
-    test('returns a bird count list with the corrected values', () => {
-      const birdsPerDay = [3, 0, 5, 1, 0, 4, 1, 0, 3, 4, 3, 0];
-      const expected = [4, 0, 6, 1, 1, 4, 2, 0, 4, 4, 4, 0];
-      expect(fixBirdCountLog(birdsPerDay)).toEqual(expected);
-    });
+  test('works for a long bird count list', () => {
+    // prettier-ignore
+    const birdsPerDay = [2, 8, 4, 1, 3, 5, 0, 4, 1, 6, 0, 3, 0, 1, 5, 4, 1, 1, 2, 6];
+    expect(totalBirdCount(birdsPerDay)).toBe(57);
+  });
+});
 
-    test('does not create a new array', () => {
-      const birdsPerDay = [2, 0, 1, 4, 1, 3, 0];
+describe('birdsInWeek', () => {
+  test('calculates the number of birds in the first week', () => {
+    const birdsPerDay = [3, 0, 5, 1, 0, 4, 1, 0, 3, 4, 3, 0, 8, 0];
+    expect(birdsInWeek(birdsPerDay, 1)).toBe(14);
+  });
 
-      // This checks that the same object that was passed in is returned.
-      // https://jestjs.io/docs/expect#tobevalue
-      expect(Object.is(fixBirdCountLog(birdsPerDay), birdsPerDay)).toBe(true);
-    });
+  test('calculates the number of birds for a week in the middle of the log', () => {
+    // prettier-ignore
+    const birdsPerDay = [4, 7, 3, 2, 1, 1, 2, 0, 2, 3, 2, 7, 1, 3, 0, 6, 5, 3, 7, 2, 3];
+    expect(birdsInWeek(birdsPerDay, 2)).toBe(18);
+  });
 
-    test('works for a short bird count list', () => {
-      expect(fixBirdCountLog([4, 2])).toEqual([5, 2]);
-    });
+  test('works when there is only one week', () => {
+    const birdsPerDay = [3, 0, 3, 3, 2, 1, 0];
+    expect(birdsInWeek(birdsPerDay, 1)).toBe(12);
+  });
 
-    test('works for a long bird count list', () => {
-      // prettier-ignore
-      const birdsPerDay = [2, 8, 4, 1, 3, 5, 0, 4, 1, 6, 0, 3, 0, 1, 5, 4, 1, 1, 2, 6];
-      // prettier-ignore
-      const expected = [3, 8, 5, 1, 4, 5, 1, 4, 2, 6, 1, 3, 1, 1, 6, 4, 2, 1, 3, 6];
-      expect(fixBirdCountLog(birdsPerDay)).toEqual(expected);
-    });
+  test('works for a long bird count list', () => {
+    const week21 = [2, 0, 1, 4, 1, 3, 0];
+    const birdsPerDay = randomArray(20 * 7)
+      .concat(week21)
+      .concat(randomArray(10 * 7));
+
+    expect(birdsInWeek(birdsPerDay, 21)).toBe(11);
+  });
+});
+
+describe('fixBirdCountLog', () => {
+  test('returns a bird count list with the corrected values', () => {
+    const birdsPerDay = [3, 0, 5, 1, 0, 4, 1, 0, 3, 4, 3, 0];
+    const expected = [4, 0, 6, 1, 1, 4, 2, 0, 4, 4, 4, 0];
+    expect(fixBirdCountLog(birdsPerDay)).toEqual(expected);
+  });
+
+  test('does not create a new array', () => {
+    const birdsPerDay = [2, 0, 1, 4, 1, 3, 0];
+
+    // This checks that the same object that was passed in is returned.
+    // https://jestjs.io/docs/expect#tobevalue
+    expect(Object.is(fixBirdCountLog(birdsPerDay), birdsPerDay)).toBe(true);
+  });
+
+  test('works for a short bird count list', () => {
+    expect(fixBirdCountLog([4, 2])).toEqual([5, 2]);
+  });
+
+  test('works for a long bird count list', () => {
+    // prettier-ignore
+    const birdsPerDay = [2, 8, 4, 1, 3, 5, 0, 4, 1, 6, 0, 3, 0, 1, 5, 4, 1, 1, 2, 6];
+    // prettier-ignore
+    const expected = [3, 8, 5, 1, 4, 5, 1, 4, 2, 6, 1, 3, 1, 1, 6, 4, 2, 1, 3, 6];
+    expect(fixBirdCountLog(birdsPerDay)).toEqual(expected);
   });
 });
 

--- a/exercises/concept/coordinate-transformation/.meta/config.json
+++ b/exercises/concept/coordinate-transformation/.meta/config.json
@@ -1,13 +1,22 @@
 {
-  "blurb": "Practice your knowledge of closures by implementing various coordinate transformations.",
-  "authors": ["neenjaw"],
-  "contributors": ["SleeplessByte"],
+  "authors": [
+    "neenjaw"
+  ],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["coordinate-transformation.js"],
-    "test": ["coordinate-transformation.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "coordinate-transformation.js"
+    ],
+    "test": [
+      "coordinate-transformation.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": [],
+  "blurb": "Practice your knowledge of closures by implementing various coordinate transformations.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/coordinate-transformation/.meta/config.json
+++ b/exercises/concept/coordinate-transformation/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["coordinate-transformation.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": []
+  "forked_from": [],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/custom-signs/.meta/config.json
+++ b/exercises/concept/custom-signs/.meta/config.json
@@ -1,13 +1,22 @@
 {
-  "blurb": "Learn about template strings and the ternary operator ...",
-  "authors": ["pertrai1"],
-  "contributors": [],
+  "authors": [
+    "pertrai1"
+  ],
   "files": {
-    "solution": ["custom-signs.js"],
-    "test": ["custom-signs.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "custom-signs.js"
+    ],
+    "test": [
+      "custom-signs.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": ["swift/custom-signs"],
+  "forked_from": [
+    "swift/custom-signs"
+  ],
+  "blurb": "Learn about template strings and the ternary operator ...",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/custom-signs/.meta/config.json
+++ b/exercises/concept/custom-signs/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["custom-signs.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": ["swift/custom-signs"]
+  "forked_from": ["swift/custom-signs"],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/elyses-analytic-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-analytic-enchantments/.meta/config.json
@@ -1,13 +1,23 @@
 {
-  "blurb": "Elyse's magic training continues, teaching you about useful built-in methods to analyse arrays.",
-  "authors": ["peterchu999", "SleeplessByte"],
-  "contributors": ["pertrai1"],
+  "authors": [
+    "peterchu999",
+    "SleeplessByte"
+  ],
+  "contributors": [
+    "pertrai1"
+  ],
   "files": {
-    "solution": ["enchantments.js"],
-    "test": ["enchantments.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "enchantments.js"
+    ],
+    "test": [
+      "enchantments.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": [],
+  "blurb": "Elyse's magic training continues, teaching you about useful built-in methods to analyse arrays.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/elyses-analytic-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-analytic-enchantments/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["enchantments.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": []
+  "forked_from": [],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/elyses-destructured-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-destructured-enchantments/.meta/config.json
@@ -1,14 +1,24 @@
 {
-  "blurb": "Elyse's magic training continues, teaching you about array destructing and the rest/spread operator.",
-  "icon": "elyses-enchantments",
-  "authors": ["kristinaborn"],
-  "contributors": ["SleeplessByte", "angelikatyborska"],
+  "authors": [
+    "kristinaborn"
+  ],
+  "contributors": [
+    "SleeplessByte",
+    "angelikatyborska"
+  ],
   "files": {
-    "solution": ["enchantments.js"],
-    "test": ["enchantments.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "enchantments.js"
+    ],
+    "test": [
+      "enchantments.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": [],
+  "icon": "elyses-enchantments",
+  "blurb": "Elyse's magic training continues, teaching you about array destructing and the rest/spread operator.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/elyses-destructured-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-destructured-enchantments/.meta/config.json
@@ -8,5 +8,11 @@
     "test": ["enchantments.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": []
+  "forked_from": [],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/elyses-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-enchantments/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["enchantments.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": ["go/card-tricks"]
+  "forked_from": ["go/card-tricks"],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/elyses-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-enchantments/.meta/config.json
@@ -1,13 +1,28 @@
 {
-  "blurb": "Help Elyse with her Enchantments and learn about arrays in the process.",
-  "authors": ["ovidiu141", "SleeplessByte"],
-  "contributors": ["peterchu999", "pertrai1", "nasch"],
+  "authors": [
+    "ovidiu141",
+    "SleeplessByte"
+  ],
+  "contributors": [
+    "peterchu999",
+    "pertrai1",
+    "nasch"
+  ],
   "files": {
-    "solution": ["enchantments.js"],
-    "test": ["enchantments.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "enchantments.js"
+    ],
+    "test": [
+      "enchantments.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": ["go/card-tricks"],
+  "forked_from": [
+    "go/card-tricks"
+  ],
+  "blurb": "Help Elyse with her Enchantments and learn about arrays in the process.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/elyses-enchantments/enchantments.spec.js
+++ b/exercises/concept/elyses-enchantments/enchantments.spec.js
@@ -11,273 +11,275 @@ import {
   checkSizeOfStack,
 } from './enchantments';
 
-describe('Elyses enchantments', () => {
-  describe('pick a card', () => {
-    test('get the first card', () => {
-      const stack = [1, 2, 3];
-      const expected = 1;
+describe('pick a card', () => {
+  test('get the first card', () => {
+    const stack = [1, 2, 3];
+    const expected = 1;
 
-      expect(getItem(stack, 0)).toBe(expected);
-    });
+    expect(getItem(stack, 0)).toBe(expected);
+  });
 
-    test('get the middle card', () => {
-      const stack = [4, 5, 6];
-      const expected = 5;
+  test('get the middle card', () => {
+    const stack = [4, 5, 6];
+    const expected = 5;
 
-      expect(getItem(stack, 1)).toBe(expected);
-    });
+    expect(getItem(stack, 1)).toBe(expected);
+  });
 
-    test('get the last card', () => {
-      const stack = [9, 8, 7];
-      const expected = 7;
+  test('get the last card', () => {
+    const stack = [9, 8, 7];
+    const expected = 7;
 
-      expect(getItem(stack, 2)).toBe(expected);
+    expect(getItem(stack, 2)).toBe(expected);
+  });
+});
+
+describe('sleight of hand', () => {
+  test('replace the first card with a 7', () => {
+    const stack = [1, 2, 3];
+    const position = 0;
+    const replacement = 7;
+
+    const expected = [7, 2, 3];
+    expect(setItem(stack, position, replacement)).toStrictEqual(expected);
+  });
+
+  test('replace the middle card with a 5', () => {
+    const stack = [2, 2, 2];
+    const position = 1;
+    const replacement = 5;
+
+    const expected = [2, 5, 2];
+    expect(setItem(stack, position, replacement)).toStrictEqual(expected);
+  });
+
+  test('replace the last card with a 7', () => {
+    const stack = [7, 7, 6];
+    const position = 2;
+    const replacement = 7;
+
+    const expected = [7, 7, 7];
+    expect(setItem(stack, position, replacement)).toStrictEqual(expected);
+  });
+});
+
+describe('make cards appear at the top', () => {
+  test('adding a second card at the top', () => {
+    const stack = [1];
+    const newCard = 5;
+
+    const expected = [1, 5];
+    expect(insertItemAtTop(stack, newCard)).toStrictEqual(expected);
+  });
+
+  test('adding a third card at the top', () => {
+    const stack = [1, 5];
+    const newCard = 9;
+
+    const expected = [1, 5, 9];
+    expect(insertItemAtTop(stack, newCard)).toStrictEqual(expected);
+  });
+
+  test('adding a fourth card at the top', () => {
+    const stack = [1, 5, 9];
+    const newCard = 2;
+
+    const expected = [1, 5, 9, 2];
+    expect(insertItemAtTop(stack, newCard)).toStrictEqual(expected);
+  });
+
+  test('adding a different fourth card at the top', () => {
+    const stack = [1, 5, 9];
+    const newCard = 8;
+
+    const expected = [1, 5, 9, 8];
+    expect(insertItemAtTop(stack, newCard)).toStrictEqual(expected);
+  });
+
+  test('adding multiple cards to the stack at the top', () => {
+    const stack = [1];
+
+    insertItemAtTop(stack, 5);
+    insertItemAtTop(stack, 9);
+
+    const expected = [1, 5, 9];
+    expect(stack).toStrictEqual(expected);
+  });
+});
+
+describe('make cards disappear', () => {
+  test('remove the card at the bottom', () => {
+    const stack = [1, 2, 3, 4];
+    const position = 0;
+
+    const expected = [2, 3, 4];
+
+    if (stack[0] === undefined) {
+      // eslint-disable-next-line no-undef
+      fail(
+        new Error(
+          'The card has disappeared, but the stack has not changed in size. This magic trick has turned into actual magic. Perhaps a different method of removing the card will result in a stack that Elyse can work with...'
+        )
+      );
+    }
+
+    expect(removeItem(stack, position)).toStrictEqual(expected);
+  });
+
+  test('remove the card at the top', () => {
+    const stack = [1, 2, 3, 4];
+    const position = 3;
+
+    const expected = [1, 2, 3];
+    expect(removeItem(stack, position)).toStrictEqual(expected);
+  });
+
+  test('remove the second card', () => {
+    const stack = [1, 2, 3, 4];
+    const position = 1;
+
+    const expected = [1, 3, 4];
+    expect(removeItem(stack, position)).toStrictEqual(expected);
+  });
+
+  test('remove the middle two cards', () => {
+    const stack = [1, 2, 3, 4];
+
+    removeItem(stack, 1);
+    removeItem(stack, 1);
+
+    const expected = [1, 4];
+    expect(expected).toStrictEqual(expected);
+  });
+});
+
+describe('make the top card disappear', () => {
+  test('remove the only card from the top', () => {
+    const stack = [1];
+    const expected = [];
+    expect(removeItemFromTop(stack)).toStrictEqual(expected);
+  });
+
+  test('remove the card from the top', () => {
+    const stack = [1, 2, 3];
+    const expected = [1, 2];
+    expect(removeItemFromTop(stack)).toStrictEqual(expected);
+  });
+
+  test('remove two cards from the top', () => {
+    const stack = [1, 2, 3];
+
+    removeItemFromTop(stack);
+    removeItemFromTop(stack);
+
+    const expected = [1];
+    expect(expected).toStrictEqual(expected);
+  });
+
+  test('remove the only card from the bottom', () => {
+    const stack = [1];
+    const expected = [];
+    expect(removeItemAtBottom(stack)).toStrictEqual(expected);
+  });
+
+  test('remove the card from the bottom', () => {
+    const stack = [1, 2, 3];
+    const expected = [2, 3];
+    expect(removeItemAtBottom(stack)).toStrictEqual(expected);
+  });
+
+  test('remove two cards from the bottom', () => {
+    const stack = [1, 2, 3];
+
+    removeItemFromTop(stack);
+    removeItemFromTop(stack);
+
+    const expected = [3];
+    expect(expected).toStrictEqual(expected);
+  });
+});
+
+describe('make cards appear at the bottom', () => {
+  test('adding a second card to the bottom', () => {
+    const stack = [1];
+    const newCard = 5;
+
+    const expected = [5, 1];
+    expect(insertItemAtBottom(stack, newCard)).toStrictEqual(expected);
+  });
+
+  test('adding a third card to the bottom', () => {
+    const stack = [5, 1];
+    const newCard = 9;
+
+    const expected = [9, 5, 1];
+    expect(insertItemAtBottom(stack, newCard)).toStrictEqual(expected);
+  });
+
+  test('adding a fourth card to the bottom', () => {
+    const stack = [9, 5, 1];
+    const newCard = 2;
+
+    const expected = [2, 9, 5, 1];
+    expect(insertItemAtBottom(stack, newCard)).toStrictEqual(expected);
+  });
+
+  test('adding a different fourth card to the bottom', () => {
+    const stack = [9, 5, 1];
+    const newCard = 8;
+
+    const expected = [8, 9, 5, 1];
+    expect(insertItemAtBottom(stack, newCard)).toStrictEqual(expected);
+  });
+
+  test('adding multiple cards to the stack to the bottom', () => {
+    const stack = [1];
+
+    insertItemAtBottom(stack, 5);
+    insertItemAtBottom(stack, 9);
+
+    const expected = [9, 5, 1];
+    expect(stack).toStrictEqual(expected);
+  });
+});
+
+describe('check your work', () => {
+  describe('an empty stack of cards', () => {
+    test('has 0 cards', () => {
+      const stack = [];
+
+      expect(checkSizeOfStack(stack, 0)).toBe(true);
+      expect(checkSizeOfStack(stack, 1)).toBe(false);
     });
   });
 
-  describe('sleight of hand', () => {
-    test('replace the first card with a 7', () => {
-      const stack = [1, 2, 3];
-      const position = 0;
-      const replacement = 7;
+  describe('a stack with a single card', () => {
+    test('has exactly 1 card', () => {
+      const stack = [7];
 
-      const expected = [7, 2, 3];
-      expect(setItem(stack, position, replacement)).toStrictEqual(expected);
-    });
-
-    test('replace the middle card with a 5', () => {
-      const stack = [2, 2, 2];
-      const position = 1;
-      const replacement = 5;
-
-      const expected = [2, 5, 2];
-      expect(setItem(stack, position, replacement)).toStrictEqual(expected);
-    });
-
-    test('replace the last card with a 7', () => {
-      const stack = [7, 7, 6];
-      const position = 2;
-      const replacement = 7;
-
-      const expected = [7, 7, 7];
-      expect(setItem(stack, position, replacement)).toStrictEqual(expected);
+      expect(checkSizeOfStack(stack, 0)).toBe(false);
+      expect(checkSizeOfStack(stack, 1)).toBe(true);
+      expect(checkSizeOfStack(stack, 2)).toBe(false);
     });
   });
 
-  describe('make cards appear', () => {
-    test('adding a second card at the top', () => {
-      const stack = [1];
-      const newCard = 5;
+  describe('a stack with the even cards', () => {
+    test('has exactly 4 cards', () => {
+      const stack = [2, 4, 6, 8];
 
-      const expected = [1, 5];
-      expect(insertItemAtTop(stack, newCard)).toStrictEqual(expected);
-    });
-
-    test('adding a third card at the top', () => {
-      const stack = [1, 5];
-      const newCard = 9;
-
-      const expected = [1, 5, 9];
-      expect(insertItemAtTop(stack, newCard)).toStrictEqual(expected);
-    });
-
-    test('adding a fourth card at the top', () => {
-      const stack = [1, 5, 9];
-      const newCard = 2;
-
-      const expected = [1, 5, 9, 2];
-      expect(insertItemAtTop(stack, newCard)).toStrictEqual(expected);
-    });
-
-    test('adding a different fourth card at the top', () => {
-      const stack = [1, 5, 9];
-      const newCard = 8;
-
-      const expected = [1, 5, 9, 8];
-      expect(insertItemAtTop(stack, newCard)).toStrictEqual(expected);
-    });
-
-    test('adding multiple cards to the stack at the top', () => {
-      const stack = [1];
-
-      insertItemAtTop(stack, 5);
-      insertItemAtTop(stack, 9);
-
-      const expected = [1, 5, 9];
-      expect(stack).toStrictEqual(expected);
-    });
-
-    test('adding a second card to the bottom', () => {
-      const stack = [1];
-      const newCard = 5;
-
-      const expected = [5, 1];
-      expect(insertItemAtBottom(stack, newCard)).toStrictEqual(expected);
-    });
-
-    test('adding a third card to the bottom', () => {
-      const stack = [5, 1];
-      const newCard = 9;
-
-      const expected = [9, 5, 1];
-      expect(insertItemAtBottom(stack, newCard)).toStrictEqual(expected);
-    });
-
-    test('adding a fourth card to the bottom', () => {
-      const stack = [9, 5, 1];
-      const newCard = 2;
-
-      const expected = [2, 9, 5, 1];
-      expect(insertItemAtBottom(stack, newCard)).toStrictEqual(expected);
-    });
-
-    test('adding a different fourth card to the bottom', () => {
-      const stack = [9, 5, 1];
-      const newCard = 8;
-
-      const expected = [8, 9, 5, 1];
-      expect(insertItemAtBottom(stack, newCard)).toStrictEqual(expected);
-    });
-
-    test('adding multiple cards to the stack to the bottom', () => {
-      const stack = [1];
-
-      insertItemAtBottom(stack, 5);
-      insertItemAtBottom(stack, 9);
-
-      const expected = [9, 5, 1];
-      expect(stack).toStrictEqual(expected);
+      expect(checkSizeOfStack(stack, 3)).toBe(false);
+      expect(checkSizeOfStack(stack, 4)).toBe(true);
+      expect(checkSizeOfStack(stack, 5)).toBe(false);
     });
   });
 
-  describe('make cards disappear', () => {
-    test('remove the card at the bottom', () => {
-      const stack = [1, 2, 3, 4];
-      const position = 0;
+  describe('a stack with the odd cards', () => {
+    test('has exactly 5 cards', () => {
+      const stack = [1, 3, 5, 7, 9];
 
-      const expected = [2, 3, 4];
-
-      if (stack[0] === undefined) {
-        // eslint-disable-next-line no-undef
-        fail(
-          new Error(
-            'The card has disappeared, but the stack has not changed in size. This magic trick has turned into actual magic. Perhaps a different method of removing the card will result in a stack that Elyse can work with...'
-          )
-        );
-      }
-
-      expect(removeItem(stack, position)).toStrictEqual(expected);
-    });
-
-    test('remove the card at the top', () => {
-      const stack = [1, 2, 3, 4];
-      const position = 3;
-
-      const expected = [1, 2, 3];
-      expect(removeItem(stack, position)).toStrictEqual(expected);
-    });
-
-    test('remove the second card', () => {
-      const stack = [1, 2, 3, 4];
-      const position = 1;
-
-      const expected = [1, 3, 4];
-      expect(removeItem(stack, position)).toStrictEqual(expected);
-    });
-
-    test('remove the middle two cards', () => {
-      const stack = [1, 2, 3, 4];
-
-      removeItem(stack, 1);
-      removeItem(stack, 1);
-
-      const expected = [1, 4];
-      expect(expected).toStrictEqual(expected);
-    });
-
-    test('remove the only card from the top', () => {
-      const stack = [1];
-      const expected = [];
-      expect(removeItemFromTop(stack)).toStrictEqual(expected);
-    });
-
-    test('remove the card from the top', () => {
-      const stack = [1, 2, 3];
-      const expected = [1, 2];
-      expect(removeItemFromTop(stack)).toStrictEqual(expected);
-    });
-
-    test('remove two cards from the top', () => {
-      const stack = [1, 2, 3];
-
-      removeItemFromTop(stack);
-      removeItemFromTop(stack);
-
-      const expected = [1];
-      expect(expected).toStrictEqual(expected);
-    });
-
-    test('remove the only card from the bottom', () => {
-      const stack = [1];
-      const expected = [];
-      expect(removeItemAtBottom(stack)).toStrictEqual(expected);
-    });
-
-    test('remove the card from the bottom', () => {
-      const stack = [1, 2, 3];
-      const expected = [2, 3];
-      expect(removeItemAtBottom(stack)).toStrictEqual(expected);
-    });
-
-    test('remove two cards from the bottom', () => {
-      const stack = [1, 2, 3];
-
-      removeItemFromTop(stack);
-      removeItemFromTop(stack);
-
-      const expected = [3];
-      expect(expected).toStrictEqual(expected);
-    });
-  });
-
-  describe('check your work', () => {
-    describe('an empty stack of cards', () => {
-      test('has 0 cards', () => {
-        const stack = [];
-
-        expect(checkSizeOfStack(stack, 0)).toBe(true);
-        expect(checkSizeOfStack(stack, 1)).toBe(false);
-      });
-    });
-
-    describe('a stack with a single card', () => {
-      test('has exactly 1 card', () => {
-        const stack = [7];
-
-        expect(checkSizeOfStack(stack, 0)).toBe(false);
-        expect(checkSizeOfStack(stack, 1)).toBe(true);
-        expect(checkSizeOfStack(stack, 2)).toBe(false);
-      });
-    });
-
-    describe('a stack with the even cards', () => {
-      test('has exactly 4 cards', () => {
-        const stack = [2, 4, 6, 8];
-
-        expect(checkSizeOfStack(stack, 3)).toBe(false);
-        expect(checkSizeOfStack(stack, 4)).toBe(true);
-        expect(checkSizeOfStack(stack, 5)).toBe(false);
-      });
-    });
-
-    describe('a stack with the odd cards', () => {
-      test('has exactly 5 cards', () => {
-        const stack = [1, 3, 5, 7, 9];
-
-        expect(checkSizeOfStack(stack, 3)).toBe(false);
-        expect(checkSizeOfStack(stack, 4)).toBe(false);
-        expect(checkSizeOfStack(stack, 5)).toBe(true);
-      });
+      expect(checkSizeOfStack(stack, 3)).toBe(false);
+      expect(checkSizeOfStack(stack, 4)).toBe(false);
+      expect(checkSizeOfStack(stack, 5)).toBe(true);
     });
   });
 });

--- a/exercises/concept/elyses-looping-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-looping-enchantments/.meta/config.json
@@ -1,14 +1,24 @@
 {
-  "blurb": "Sift through Elyse's array of cards using various looping methods.",
-  "icon": "elyses-enchantments",
-  "authors": ["rishiosaur", "SleeplessByte"],
-  "contributors": ["junedev"],
+  "authors": [
+    "rishiosaur",
+    "SleeplessByte"
+  ],
+  "contributors": [
+    "junedev"
+  ],
   "files": {
-    "solution": ["enchantments.js"],
-    "test": ["enchantments.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "enchantments.js"
+    ],
+    "test": [
+      "enchantments.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": [],
+  "icon": "elyses-enchantments",
+  "blurb": "Sift through Elyse's array of cards using various looping methods.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/elyses-looping-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-looping-enchantments/.meta/config.json
@@ -8,5 +8,11 @@
     "test": ["enchantments.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": []
+  "forked_from": [],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/elyses-transformative-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-transformative-enchantments/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["enchantments.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": []
+  "forked_from": [],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/elyses-transformative-enchantments/.meta/config.json
+++ b/exercises/concept/elyses-transformative-enchantments/.meta/config.json
@@ -1,13 +1,23 @@
 {
-  "blurb": "Elyse has grown her magical powers and attempts some really cool tricks now while you learn about transforming arrays.",
-  "authors": ["yyyc514"],
-  "contributors": ["SleeplessByte", "junedev"],
+  "authors": [
+    "yyyc514"
+  ],
+  "contributors": [
+    "SleeplessByte",
+    "junedev"
+  ],
   "files": {
-    "solution": ["enchantments.js"],
-    "test": ["enchantments.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "enchantments.js"
+    ],
+    "test": [
+      "enchantments.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": [],
+  "blurb": "Elyse has grown her magical powers and attempts some really cool tricks now while you learn about transforming arrays.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/factory-sensors/.meta/config.json
+++ b/exercises/concept/factory-sensors/.meta/config.json
@@ -1,12 +1,23 @@
 {
-  "blurb": "Learn how to handle errors by creating a piece of software for a newspaper factory.",
-  "authors": ["TomPradat"],
-  "contributors": ["SleeplessByte", "junedev"],
+  "authors": [
+    "TomPradat"
+  ],
+  "contributors": [
+    "SleeplessByte",
+    "junedev"
+  ],
   "files": {
-    "solution": ["factory-sensors.js"],
-    "test": ["factory-sensors.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "factory-sensors.js"
+    ],
+    "test": [
+      "factory-sensors.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
+  "blurb": "Learn how to handle errors by creating a piece of software for a newspaper factory.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/factory-sensors/.meta/config.json
+++ b/exercises/concept/factory-sensors/.meta/config.json
@@ -6,5 +6,11 @@
     "solution": ["factory-sensors.js"],
     "test": ["factory-sensors.spec.js"],
     "exemplar": [".meta/exemplar.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/concept/freelancer-rates/.meta/config.json
+++ b/exercises/concept/freelancer-rates/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["freelancer-rates.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": []
+  "forked_from": [],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/freelancer-rates/.meta/config.json
+++ b/exercises/concept/freelancer-rates/.meta/config.json
@@ -1,13 +1,23 @@
 {
-  "blurb": "Learn about numbers whilst helping a freelancer communicate with a project manager about day- and month rates.",
-  "authors": ["SleeplessByte", "JaPatGitHub"],
-  "contributors": ["junedev"],
+  "authors": [
+    "SleeplessByte",
+    "JaPatGitHub"
+  ],
+  "contributors": [
+    "junedev"
+  ],
   "files": {
-    "solution": ["freelancer-rates.js"],
-    "test": ["freelancer-rates.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "freelancer-rates.js"
+    ],
+    "test": [
+      "freelancer-rates.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": [],
+  "blurb": "Learn about numbers whilst helping a freelancer communicate with a project manager about day- and month rates.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/freelancer-rates/freelancer-rates.spec.js
+++ b/exercises/concept/freelancer-rates/freelancer-rates.spec.js
@@ -8,87 +8,85 @@ import {
 
 const DIFFERENCE_PRECISION_IN_DIGITS = 6;
 
-describe('freelancer rates', () => {
-  describe('day rate', () => {
+describe('day rate', () => {
+  test('at 16/hour', () => {
+    const actual = dayRate(16);
+    expect(actual).toBe(128);
+  });
+
+  test('at 25/hour', () => {
+    const actual = dayRate(25);
+    expect(actual).toBe(200);
+  });
+
+  test('at 31.40/hour', () => {
+    const actual = dayRate(31.4);
+    expect(actual).toBeCloseTo(251.2, DIFFERENCE_PRECISION_IN_DIGITS);
+  });
+
+  test('at 89.89/hour', () => {
+    const actual = dayRate(89.89);
+    expect(actual).toBeCloseTo(719.12, DIFFERENCE_PRECISION_IN_DIGITS);
+  });
+
+  test('at 97.654321/hour', () => {
+    const actual = dayRate(97.654321);
+    expect(actual).toBeCloseTo(781.234568, DIFFERENCE_PRECISION_IN_DIGITS);
+  });
+});
+
+describe('days in budget', () => {
+  describe('with a budget of 1280', () => {
     test('at 16/hour', () => {
-      const actual = dayRate(16);
-      expect(actual).toBe(128);
+      const actual = daysInBudget(1280, 16);
+      const expected = 10;
+
+      expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
     });
 
     test('at 25/hour', () => {
-      const actual = dayRate(25);
-      expect(actual).toBe(200);
+      const actual = daysInBudget(1280, 25);
+      const expected = 6;
+
+      expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
     });
 
-    test('at 31.40/hour', () => {
-      const actual = dayRate(31.4);
-      expect(actual).toBeCloseTo(251.2, DIFFERENCE_PRECISION_IN_DIGITS);
-    });
-
-    test('at 89.89/hour', () => {
-      const actual = dayRate(89.89);
-      expect(actual).toBeCloseTo(719.12, DIFFERENCE_PRECISION_IN_DIGITS);
-    });
-
-    test('at 97.654321/hour', () => {
-      const actual = dayRate(97.654321);
-      expect(actual).toBeCloseTo(781.234568, DIFFERENCE_PRECISION_IN_DIGITS);
-    });
-  });
-
-  describe('days in budget', () => {
-    describe('with a budget of 1280', () => {
-      test('at 16/hour', () => {
-        const actual = daysInBudget(1280, 16);
-        const expected = 10;
+    describe('with a budget of 835', () => {
+      test('at 12/hour', () => {
+        const actual = daysInBudget(835, 12);
+        const expected = 8;
 
         expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
-      });
-
-      test('at 25/hour', () => {
-        const actual = daysInBudget(1280, 25);
-        const expected = 6;
-
-        expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
-      });
-
-      describe('with a budget of 835', () => {
-        test('at 12/hour', () => {
-          const actual = daysInBudget(835, 12);
-          const expected = 8;
-
-          expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
-        });
       });
     });
   });
+});
 
-  describe('cost with monthly discount', () => {
-    describe('at 16/hour', () => {
-      test('for 70 days', () => {
-        const actual = priceWithMonthlyDiscount(16, 70, 0);
-        const expected = 8960;
-        expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
-      });
-
-      test('for 130 days with 15% discount', () => {
-        const actual = priceWithMonthlyDiscount(16, 130, 0.15);
-        const expected = 14528;
-        expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
-      });
+describe('cost with monthly discount', () => {
+  describe('at 16/hour', () => {
+    test('for 70 days', () => {
+      const actual = priceWithMonthlyDiscount(16, 70, 0);
+      const expected = 8960;
+      expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
     });
-    describe('at 29.654321/hour', () => {
-      test('for 220 days with 11.2%', () => {
-        const actual = priceWithMonthlyDiscount(29.654321, 220, 0.112);
-        const expected = 46347;
-        expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
-      });
 
-      test('for 155 days with 25.47% discount', () => {
-        const actual = priceWithMonthlyDiscount(29.654321, 155, 0.2547);
-        const expected = 27467;
-        expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
-      });
+    test('for 130 days with 15% discount', () => {
+      const actual = priceWithMonthlyDiscount(16, 130, 0.15);
+      const expected = 14528;
+      expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
+    });
+  });
+  describe('at 29.654321/hour', () => {
+    test('for 220 days with 11.2%', () => {
+      const actual = priceWithMonthlyDiscount(29.654321, 220, 0.112);
+      const expected = 46347;
+      expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
+    });
+
+    test('for 155 days with 25.47% discount', () => {
+      const actual = priceWithMonthlyDiscount(29.654321, 155, 0.2547);
+      const expected = 27467;
+      expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
     });
   });
 });

--- a/exercises/concept/fruit-picker/.meta/config.json
+++ b/exercises/concept/fruit-picker/.meta/config.json
@@ -1,13 +1,25 @@
 {
-  "blurb": "Learn about callbacks picking fruit from the grocer",
-  "authors": ["neenjaw"],
-  "contributors": ["SleeplessByte"],
+  "authors": [
+    "neenjaw"
+  ],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["fruit-picker.js"],
-    "editor": ["grocer.js"],
-    "test": ["fruit-picker.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "fruit-picker.js"
+    ],
+    "test": [
+      "fruit-picker.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ],
+    "editor": [
+      "grocer.js"
+    ]
   },
+  "blurb": "Learn about callbacks picking fruit from the grocer",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/fruit-picker/.meta/config.json
+++ b/exercises/concept/fruit-picker/.meta/config.json
@@ -7,5 +7,11 @@
     "editor": ["grocer.js"],
     "test": ["fruit-picker.spec.js"],
     "exemplar": [".meta/exemplar.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/concept/high-score-board/.meta/config.json
+++ b/exercises/concept/high-score-board/.meta/config.json
@@ -1,13 +1,23 @@
 {
-  "blurb": "Practice JavaScript objects by tracking high scores of an arcade game.",
-  "authors": ["junedev"],
-  "contributors": [],
+  "authors": [
+    "junedev"
+  ],
   "files": {
-    "solution": ["high-score-board.js"],
-    "test": ["high-score-board.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "high-score-board.js"
+    ],
+    "test": [
+      "high-score-board.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": ["elixir/high-score", "swift/high-score-board"],
+  "forked_from": [
+    "elixir/high-score",
+    "swift/high-score-board"
+  ],
+  "blurb": "Practice JavaScript objects by tracking high scores of an arcade game.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/high-score-board/.meta/config.json
+++ b/exercises/concept/high-score-board/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["high-score-board.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": ["elixir/high-score", "swift/high-score-board"]
+  "forked_from": ["elixir/high-score", "swift/high-score-board"],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/lasagna-master/.meta/config.json
+++ b/exercises/concept/lasagna-master/.meta/config.json
@@ -8,5 +8,11 @@
     "exemplar": [".meta/exemplar.js"]
   },
   "source": "Inspired by the Lasagna Master exercise in the Swift track",
-  "source_url": "https://github.com/exercism/swift/blob/main/exercises/concept/lasagna-master/.docs/instructions.md"
+  "source_url": "https://github.com/exercism/swift/blob/main/exercises/concept/lasagna-master/.docs/instructions.md",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/lasagna-master/.meta/config.json
+++ b/exercises/concept/lasagna-master/.meta/config.json
@@ -1,12 +1,19 @@
 {
-  "blurb": "Dive deeper into JavaScript functions while preparing to cook the perfect lasagna.",
-  "authors": ["junedev"],
-  "contributors": [],
+  "authors": [
+    "junedev"
+  ],
   "files": {
-    "solution": ["lasagna-master.js"],
-    "test": ["lasagna-master.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "lasagna-master.js"
+    ],
+    "test": [
+      "lasagna-master.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
+  "blurb": "Dive deeper into JavaScript functions while preparing to cook the perfect lasagna.",
   "source": "Inspired by the Lasagna Master exercise in the Swift track",
   "source_url": "https://github.com/exercism/swift/blob/main/exercises/concept/lasagna-master/.docs/instructions.md",
   "custom": {

--- a/exercises/concept/lasagna/.meta/config.json
+++ b/exercises/concept/lasagna/.meta/config.json
@@ -1,13 +1,25 @@
 {
-  "blurb": "Learn the basics of JavaScript cooking a brilliant lasagna from your favorite cooking book.",
-  "authors": ["SleeplessByte"],
-  "contributors": ["junedev"],
+  "authors": [
+    "SleeplessByte"
+  ],
+  "contributors": [
+    "junedev"
+  ],
   "files": {
-    "solution": ["lasagna.js"],
-    "test": ["lasagna.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "lasagna.js"
+    ],
+    "test": [
+      "lasagna.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": ["csharp/lasagna"],
+  "forked_from": [
+    "csharp/lasagna"
+  ],
+  "blurb": "Learn the basics of JavaScript cooking a brilliant lasagna from your favorite cooking book.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/lasagna/.meta/config.json
+++ b/exercises/concept/lasagna/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["lasagna.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": ["csharp/lasagna"]
+  "forked_from": ["csharp/lasagna"],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/lucky-numbers/.meta/config.json
+++ b/exercises/concept/lucky-numbers/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["lucky-numbers.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": []
+  "forked_from": [],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/lucky-numbers/.meta/config.json
+++ b/exercises/concept/lucky-numbers/.meta/config.json
@@ -1,13 +1,24 @@
 {
-  "blurb": "Practice type conversion while helping your friend Kojo with his website www.fun-with-numbers.com.",
-  "authors": ["shubhsk88", "junedev"],
-  "contributors": ["neenjaw", "SleeplessByte"],
+  "authors": [
+    "shubhsk88",
+    "junedev"
+  ],
+  "contributors": [
+    "neenjaw",
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["lucky-numbers.js"],
-    "test": ["lucky-numbers.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "lucky-numbers.js"
+    ],
+    "test": [
+      "lucky-numbers.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": [],
+  "blurb": "Practice type conversion while helping your friend Kojo with his website www.fun-with-numbers.com.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/mixed-juices/.meta/config.json
+++ b/exercises/concept/mixed-juices/.meta/config.json
@@ -1,13 +1,22 @@
 {
-  "blurb": "Help your friend Li Mei run her juice bar with your knowledge of while loops and switch statements.",
-  "authors": ["junedev"],
-  "contributors": [],
+  "authors": [
+    "junedev"
+  ],
   "files": {
-    "solution": ["mixed-juices.js"],
-    "test": ["mixed-juices.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "mixed-juices.js"
+    ],
+    "test": [
+      "mixed-juices.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": ["swift/master-mixologist"],
+  "forked_from": [
+    "swift/master-mixologist"
+  ],
+  "blurb": "Help your friend Li Mei run her juice bar with your knowledge of while loops and switch statements.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/mixed-juices/.meta/config.json
+++ b/exercises/concept/mixed-juices/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["mixed-juices.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": ["swift/master-mixologist"]
+  "forked_from": ["swift/master-mixologist"],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/nullability/.docs/instructions.md
+++ b/exercises/concept/nullability/.docs/instructions.md
@@ -4,7 +4,7 @@ While working for a factory, a need arises to create the printed message on empl
 
 A badge requires the `id` of the employee, the `name` of the employee, as well as the department in which they are working.
 
-## 1. Create the badge text.
+## 1. Create the badge text
 
 Implement a function named `printBadge` that returns the text to print on the badge.
 

--- a/exercises/concept/nullability/.meta/config.json
+++ b/exercises/concept/nullability/.meta/config.json
@@ -1,13 +1,23 @@
 {
-  "blurb": "TODO: add blurb for nullability exercise",
-  "authors": ["SleeplessByte", "Jlamon"],
-  "contributors": [],
+  "authors": [
+    "SleeplessByte",
+    "Jlamon"
+  ],
   "files": {
-    "solution": ["nullability.js"],
-    "test": ["nullability.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "nullability.js"
+    ],
+    "test": [
+      "nullability.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": ["csharp/tim-from-marketing"],
+  "forked_from": [
+    "csharp/tim-from-marketing"
+  ],
+  "blurb": "TODO: add blurb for nullability exercise",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/nullability/.meta/config.json
+++ b/exercises/concept/nullability/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["nullability.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": ["csharp/tim-from-marketing"]
+  "forked_from": ["csharp/tim-from-marketing"],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/ozans-playlist/.meta/config.json
+++ b/exercises/concept/ozans-playlist/.meta/config.json
@@ -1,12 +1,22 @@
 {
-  "blurb": "Use sets to avoid repeating tracks in a playlist",
-  "authors": ["kristinaborn"],
-  "contributors": ["SleeplessByte"],
+  "authors": [
+    "kristinaborn"
+  ],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["ozans-playlist.js"],
-    "test": ["ozans-playlist.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "ozans-playlist.js"
+    ],
+    "test": [
+      "ozans-playlist.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
+  "blurb": "Use sets to avoid repeating tracks in a playlist",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/ozans-playlist/.meta/config.json
+++ b/exercises/concept/ozans-playlist/.meta/config.json
@@ -1,10 +1,16 @@
 {
   "blurb": "Use sets to avoid repeating tracks in a playlist",
   "authors": ["kristinaborn"],
-  "contributors": [],
+  "contributors": ["SleeplessByte"],
   "files": {
     "solution": ["ozans-playlist.js"],
     "test": ["ozans-playlist.spec.js"],
     "exemplar": [".meta/exemplar.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/concept/ozans-playlist/ozans-playlist.spec.js
+++ b/exercises/concept/ozans-playlist/ozans-playlist.spec.js
@@ -6,95 +6,93 @@ import {
   removeDuplicates,
 } from './ozans-playlist';
 
-describe("Ozan's playlist", () => {
-  describe('removeDuplicates', () => {
-    test('works for an empty playlist', () => {
-      const playlist = [];
+describe('removeDuplicates', () => {
+  test('works for an empty playlist', () => {
+    const playlist = [];
 
-      expect(removeDuplicates(playlist)).toEqual([]);
-    });
-
-    test('works for a non-empty playlist', () => {
-      const TRACK_1 = 'Two Paintings and a Drum - Carl Cox';
-      const TRACK_2 = 'Leash Called Love - The Sugarcubes';
-      const playlist = [TRACK_1, TRACK_2, TRACK_1];
-      const expected = [TRACK_1, TRACK_2];
-
-      expect(removeDuplicates(playlist)).toEqual(expected);
-    });
+    expect(removeDuplicates(playlist)).toEqual([]);
   });
 
-  describe('hasTrack', () => {
-    const TRACK_1 = 'Big Science - Laurie Anderson';
-    const TRACK_2 = 'Tightrope - Laurie Anderson';
+  test('works for a non-empty playlist', () => {
+    const TRACK_1 = 'Two Paintings and a Drum - Carl Cox';
+    const TRACK_2 = 'Leash Called Love - The Sugarcubes';
+    const playlist = [TRACK_1, TRACK_2, TRACK_1];
+    const expected = [TRACK_1, TRACK_2];
 
-    test('returns true when the track is in the playlist', () => {
-      const playlist = [TRACK_1, TRACK_2];
+    expect(removeDuplicates(playlist)).toEqual(expected);
+  });
+});
 
-      expect(hasTrack(playlist, TRACK_1)).toBe(true);
-    });
+describe('hasTrack', () => {
+  const TRACK_1 = 'Big Science - Laurie Anderson';
+  const TRACK_2 = 'Tightrope - Laurie Anderson';
 
-    test('returns false when the track is not in the playlist', () => {
-      const playlist = [TRACK_2];
+  test('returns true when the track is in the playlist', () => {
+    const playlist = [TRACK_1, TRACK_2];
 
-      expect(hasTrack(playlist, TRACK_1)).toBe(false);
-    });
+    expect(hasTrack(playlist, TRACK_1)).toBe(true);
   });
 
-  describe('addTrack', () => {
-    const TRACK_1 = 'Jigsaw Feeling - Siouxsie and the Banshees';
-    const TRACK_2 = 'Feeling Good - Nina Simone';
+  test('returns false when the track is not in the playlist', () => {
+    const playlist = [TRACK_2];
 
-    test('adds a track that is not already in the playlist', () => {
-      const playlist = [];
-      const expected = [TRACK_1];
+    expect(hasTrack(playlist, TRACK_1)).toBe(false);
+  });
+});
 
-      expect(addTrack(playlist, TRACK_1)).toEqual(expected);
-    });
+describe('addTrack', () => {
+  const TRACK_1 = 'Jigsaw Feeling - Siouxsie and the Banshees';
+  const TRACK_2 = 'Feeling Good - Nina Simone';
 
-    test('does not add a track that is already in the playlist', () => {
-      const playlist = [TRACK_1, TRACK_2];
-      const expected = [TRACK_1, TRACK_2];
+  test('adds a track that is not already in the playlist', () => {
+    const playlist = [];
+    const expected = [TRACK_1];
 
-      expect(addTrack(playlist, TRACK_1)).toEqual(expected);
-    });
+    expect(addTrack(playlist, TRACK_1)).toEqual(expected);
   });
 
-  describe('deleteTrack', () => {
-    const TRACK_1 = 'Ancestors - Tanya Tagaq';
-    const TRACK_2 = 'Take This Hammer - Lead Belly';
+  test('does not add a track that is already in the playlist', () => {
+    const playlist = [TRACK_1, TRACK_2];
+    const expected = [TRACK_1, TRACK_2];
 
-    test('works if the track is present in the playlist', () => {
-      const playlist = [TRACK_1, TRACK_2];
-      const expected = [TRACK_2];
+    expect(addTrack(playlist, TRACK_1)).toEqual(expected);
+  });
+});
 
-      expect(deleteTrack(playlist, TRACK_1)).toEqual(expected);
-    });
+describe('deleteTrack', () => {
+  const TRACK_1 = 'Ancestors - Tanya Tagaq';
+  const TRACK_2 = 'Take This Hammer - Lead Belly';
 
-    test('works if the track is not present in the playlist', () => {
-      const playlist = [TRACK_2];
-      const expected = [TRACK_2];
+  test('works if the track is present in the playlist', () => {
+    const playlist = [TRACK_1, TRACK_2];
+    const expected = [TRACK_2];
 
-      expect(deleteTrack(playlist, TRACK_1)).toEqual(expected);
-    });
+    expect(deleteTrack(playlist, TRACK_1)).toEqual(expected);
   });
 
-  describe('listArtists', () => {
-    test('works for an empty playlist', () => {
-      const playlist = [];
+  test('works if the track is not present in the playlist', () => {
+    const playlist = [TRACK_2];
+    const expected = [TRACK_2];
 
-      expect(listArtists(playlist)).toEqual([]);
-    });
+    expect(deleteTrack(playlist, TRACK_1)).toEqual(expected);
+  });
+});
 
-    test('works for a non-empty playlist', () => {
-      const playlist = [
-        'Onu Alma Beni Al - Sezen Aksu',
-        'Famous Blue Raincoat - Leonard Cohen',
-        'Rakkas - Sezen Aksu',
-      ];
-      const expected = ['Sezen Aksu', 'Leonard Cohen'];
+describe('listArtists', () => {
+  test('works for an empty playlist', () => {
+    const playlist = [];
 
-      expect(listArtists(playlist)).toEqual(expected);
-    });
+    expect(listArtists(playlist)).toEqual([]);
+  });
+
+  test('works for a non-empty playlist', () => {
+    const playlist = [
+      'Onu Alma Beni Al - Sezen Aksu',
+      'Famous Blue Raincoat - Leonard Cohen',
+      'Rakkas - Sezen Aksu',
+    ];
+    const expected = ['Sezen Aksu', 'Leonard Cohen'];
+
+    expect(listArtists(playlist)).toEqual(expected);
   });
 });

--- a/exercises/concept/pizza-order/.meta/config.json
+++ b/exercises/concept/pizza-order/.meta/config.json
@@ -1,13 +1,22 @@
 {
-  "blurb": "TODO: add blurb for recursion exercise",
-  "authors": ["SleeplessByte"],
-  "contributors": [],
+  "authors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["pizza-order.js"],
-    "test": ["pizza-order.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "pizza-order.js"
+    ],
+    "test": [
+      "pizza-order.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": ["fsharp/pizza-pricing"],
+  "forked_from": [
+    "fsharp/pizza-pricing"
+  ],
+  "blurb": "TODO: add blurb for recursion exercise",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/concept/pizza-order/.meta/config.json
+++ b/exercises/concept/pizza-order/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["pizza-order.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": ["fsharp/pizza-pricing"]
+  "forked_from": ["fsharp/pizza-pricing"],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": true,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/poetry-club-door-policy/.meta/config.json
+++ b/exercises/concept/poetry-club-door-policy/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["door-policy.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": []
+  "forked_from": [],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/poetry-club-door-policy/.meta/config.json
+++ b/exercises/concept/poetry-club-door-policy/.meta/config.json
@@ -1,13 +1,24 @@
 {
-  "blurb": "Learn about strings using poems to get into the poetry club.",
-  "authors": ["SleeplessByte"],
-  "contributors": ["hayashi-ay", "junedev", "mmmmmrob"],
+  "authors": [
+    "SleeplessByte"
+  ],
+  "contributors": [
+    "hayashi-ay",
+    "junedev",
+    "mmmmmrob"
+  ],
   "files": {
-    "solution": ["door-policy.js"],
-    "test": ["door-policy.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "door-policy.js"
+    ],
+    "test": [
+      "door-policy.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": [],
+  "blurb": "Learn about strings using poems to get into the poetry club.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/translation-service/.meta/config.json
+++ b/exercises/concept/translation-service/.meta/config.json
@@ -1,14 +1,27 @@
 {
-  "blurb": "Connect to the Klingon Translation Service and learn about promises.",
-  "authors": ["SleeplessByte"],
-  "contributors": ["AndrewLawendy"],
+  "authors": [
+    "SleeplessByte"
+  ],
+  "contributors": [
+    "AndrewLawendy"
+  ],
   "files": {
-    "solution": ["service.js"],
-    "test": ["service.spec.js"],
-    "exemplar": [".meta/exemplar.js"],
-    "editor": ["api.js", "errors.js", "global.d.ts"]
+    "solution": [
+      "service.js"
+    ],
+    "test": [
+      "service.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ],
+    "editor": [
+      "api.js",
+      "errors.js",
+      "global.d.ts"
+    ]
   },
-  "forked_from": [],
+  "blurb": "Connect to the Klingon Translation Service and learn about promises.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/translation-service/.meta/config.json
+++ b/exercises/concept/translation-service/.meta/config.json
@@ -8,5 +8,11 @@
     "exemplar": [".meta/exemplar.js"],
     "editor": ["api.js", "errors.js", "global.d.ts"]
   },
-  "forked_from": []
+  "forked_from": [],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/vehicle-purchase/.meta/config.json
+++ b/exercises/concept/vehicle-purchase/.meta/config.json
@@ -1,11 +1,17 @@
 {
   "blurb": "Learn about comparison and conditionals while preparing for your next vehicle purchase",
   "authors": ["junedev"],
-  "contributors": [],
+  "contributors": ["SleeplessByte"],
   "files": {
     "solution": ["vehicle-purchase.js"],
     "test": ["vehicle-purchase.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": ["julia/vehicle-purchase"]
+  "forked_from": ["julia/vehicle-purchase"],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/vehicle-purchase/.meta/config.json
+++ b/exercises/concept/vehicle-purchase/.meta/config.json
@@ -1,13 +1,25 @@
 {
-  "blurb": "Learn about comparison and conditionals while preparing for your next vehicle purchase",
-  "authors": ["junedev"],
-  "contributors": ["SleeplessByte"],
+  "authors": [
+    "junedev"
+  ],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["vehicle-purchase.js"],
-    "test": ["vehicle-purchase.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "vehicle-purchase.js"
+    ],
+    "test": [
+      "vehicle-purchase.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": ["julia/vehicle-purchase"],
+  "forked_from": [
+    "julia/vehicle-purchase"
+  ],
+  "blurb": "Learn about comparison and conditionals while preparing for your next vehicle purchase",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/vehicle-purchase/vehicle-purchase.spec.js
+++ b/exercises/concept/vehicle-purchase/vehicle-purchase.spec.js
@@ -4,71 +4,69 @@ import {
   calculateResellPrice,
 } from './vehicle-purchase';
 
-describe('vehicle purchase', () => {
-  describe('needsLicense', () => {
-    test('requires a license for a car', () => {
-      expect(needsLicense('car')).toBe(true);
-    });
-
-    test('requires a license for a truck', () => {
-      expect(needsLicense('truck')).toBe(true);
-    });
-
-    test('does not require a license for a bike', () => {
-      expect(needsLicense('bike')).toBe(false);
-    });
-
-    test('does not require a license for a stroller', () => {
-      expect(needsLicense('stroller')).toBe(false);
-    });
-
-    test('does not require a license for an e-scooter', () => {
-      expect(needsLicense('e-scooter')).toBe(false);
-    });
+describe('needsLicense', () => {
+  test('requires a license for a car', () => {
+    expect(needsLicense('car')).toBe(true);
   });
 
-  describe('chooseVehicle', () => {
-    const rest = ' is clearly the better choice.';
-
-    test('correctly recommends the first option', () => {
-      expect(chooseVehicle('Bugatti Veyron', 'Ford Pinto')).toBe(
-        'Bugatti Veyron' + rest
-      );
-      expect(chooseVehicle('Chery EQ', 'Kia Niro Elektro')).toBe(
-        'Chery EQ' + rest
-      );
-    });
-
-    test('correctly recommends the second option', () => {
-      expect(chooseVehicle('Ford Pinto', 'Bugatti Veyron')).toBe(
-        'Bugatti Veyron' + rest
-      );
-      expect(chooseVehicle('2020 Gazelle Medeo', '2018 Bergamont City')).toBe(
-        '2018 Bergamont City' + rest
-      );
-    });
+  test('requires a license for a truck', () => {
+    expect(needsLicense('truck')).toBe(true);
   });
 
-  describe('calculateResellPrice', () => {
-    test('price is reduced to 80% for age below 3', () => {
-      expect(calculateResellPrice(40000, 2)).toBe(32000);
-      expect(calculateResellPrice(40000, 2.5)).toBe(32000);
-    });
+  test('does not require a license for a bike', () => {
+    expect(needsLicense('bike')).toBe(false);
+  });
 
-    test('price is reduced to 50% for age above 10', () => {
-      expect(calculateResellPrice(40000, 12)).toBe(20000);
-    });
+  test('does not require a license for a stroller', () => {
+    expect(needsLicense('stroller')).toBe(false);
+  });
 
-    test('price is reduced to 70% for between 3 and 10', () => {
-      expect(calculateResellPrice(25000, 7)).toBe(17500);
-    });
+  test('does not require a license for an e-scooter', () => {
+    expect(needsLicense('e-scooter')).toBe(false);
+  });
+});
 
-    test('works correctly for threshold age 3', () => {
-      expect(calculateResellPrice(40000, 3)).toBe(28000);
-    });
+describe('chooseVehicle', () => {
+  const rest = ' is clearly the better choice.';
 
-    test('works correctly for threshold age 10', () => {
-      expect(calculateResellPrice(25000, 10)).toBe(17500);
-    });
+  test('correctly recommends the first option', () => {
+    expect(chooseVehicle('Bugatti Veyron', 'Ford Pinto')).toBe(
+      'Bugatti Veyron' + rest
+    );
+    expect(chooseVehicle('Chery EQ', 'Kia Niro Elektro')).toBe(
+      'Chery EQ' + rest
+    );
+  });
+
+  test('correctly recommends the second option', () => {
+    expect(chooseVehicle('Ford Pinto', 'Bugatti Veyron')).toBe(
+      'Bugatti Veyron' + rest
+    );
+    expect(chooseVehicle('2020 Gazelle Medeo', '2018 Bergamont City')).toBe(
+      '2018 Bergamont City' + rest
+    );
+  });
+});
+
+describe('calculateResellPrice', () => {
+  test('price is reduced to 80% for age below 3', () => {
+    expect(calculateResellPrice(40000, 2)).toBe(32000);
+    expect(calculateResellPrice(40000, 2.5)).toBe(32000);
+  });
+
+  test('price is reduced to 50% for age above 10', () => {
+    expect(calculateResellPrice(40000, 12)).toBe(20000);
+  });
+
+  test('price is reduced to 70% for between 3 and 10', () => {
+    expect(calculateResellPrice(25000, 7)).toBe(17500);
+  });
+
+  test('works correctly for threshold age 3', () => {
+    expect(calculateResellPrice(40000, 3)).toBe(28000);
+  });
+
+  test('works correctly for threshold age 10', () => {
+    expect(calculateResellPrice(25000, 10)).toBe(17500);
   });
 });

--- a/exercises/concept/windowing-system/.meta/config.json
+++ b/exercises/concept/windowing-system/.meta/config.json
@@ -1,13 +1,25 @@
 {
-  "blurb": "Learn about prototypes and classes by developing a windowing system.",
-  "authors": ["junedev"],
-  "contributors": ["SleeplessByte"],
+  "authors": [
+    "junedev"
+  ],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["windowing-system.js"],
-    "test": ["windowing-system.spec.js"],
-    "exemplar": [".meta/exemplar.js"]
+    "solution": [
+      "windowing-system.js"
+    ],
+    "test": [
+      "windowing-system.spec.js"
+    ],
+    "exemplar": [
+      ".meta/exemplar.js"
+    ]
   },
-  "forked_from": ["swift/windowing-system"],
+  "forked_from": [
+    "swift/windowing-system"
+  ],
+  "blurb": "Learn about prototypes and classes by developing a windowing system.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": true,

--- a/exercises/concept/windowing-system/.meta/config.json
+++ b/exercises/concept/windowing-system/.meta/config.json
@@ -1,11 +1,17 @@
 {
   "blurb": "Learn about prototypes and classes by developing a windowing system.",
   "authors": ["junedev"],
-  "contributors": [],
+  "contributors": ["SleeplessByte"],
   "files": {
     "solution": ["windowing-system.js"],
     "test": ["windowing-system.spec.js"],
     "exemplar": [".meta/exemplar.js"]
   },
-  "forked_from": ["swift/windowing-system"]
+  "forked_from": ["swift/windowing-system"],
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": true,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/concept/windowing-system/windowing-system.spec.js
+++ b/exercises/concept/windowing-system/windowing-system.spec.js
@@ -5,7 +5,7 @@ import {
   changeWindow,
 } from './windowing-system';
 
-describe('Size', () => {
+describe('Size class', () => {
   test('allows to create a new instance', () => {
     const size = new Size(110, 220);
     expect(size.width).toBe(110);
@@ -26,7 +26,7 @@ describe('Size', () => {
   });
 });
 
-describe('Position', () => {
+describe('Position class', () => {
   test('allows to create a new instance', () => {
     const position = new Position(10, 20);
     expect(position.x).toBe(10);
@@ -47,7 +47,7 @@ describe('Position', () => {
   });
 });
 
-describe('ProgramWindow', () => {
+describe('ProgramWindow class', () => {
   test('allows to create a new instance', () => {
     const window = new ProgramWindow();
 
@@ -72,7 +72,9 @@ describe('ProgramWindow', () => {
     expect(programWindow.position.x).toBe(0);
     expect(programWindow.position.y).toBe(0);
   });
+});
 
+describe('resize', () => {
   test('provides a resize method', () => {
     const programWindow = new ProgramWindow();
     const newSize = new Size(300, 200);
@@ -90,18 +92,9 @@ describe('ProgramWindow', () => {
     expect(programWindow.size.width).toBe(1);
     expect(programWindow.size.height).toBe(1);
   });
+});
 
-  test('resize respects limits due to position and screen size', () => {
-    const programWindow = new ProgramWindow();
-    const newPosition = new Position(710, 525);
-    programWindow.move(newPosition);
-    const newSize = new Size(1000, 1000);
-    programWindow.resize(newSize);
-
-    expect(programWindow.size.width).toBe(90);
-    expect(programWindow.size.height).toBe(75);
-  });
-
+describe('move', () => {
   test('provides a move method', () => {
     const programWindow = new ProgramWindow();
     const newPosition = new Position(525, 450);
@@ -129,6 +122,17 @@ describe('ProgramWindow', () => {
 
     expect(programWindow.position.x).toBe(700);
     expect(programWindow.position.y).toBe(500);
+  });
+
+  test('resize respects limits due to position and screen size', () => {
+    const programWindow = new ProgramWindow();
+    const newPosition = new Position(710, 525);
+    programWindow.move(newPosition);
+    const newSize = new Size(1000, 1000);
+    programWindow.resize(newSize);
+
+    expect(programWindow.size.width).toBe(90);
+    expect(programWindow.size.height).toBe(75);
   });
 });
 

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Conversation with James Edward Gray II",
-  "source_url": "https://twitter.com/jeg2"
+  "source_url": "https://twitter.com/jeg2",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "gargrave",
@@ -10,10 +11,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["accumulate.js"],
-    "test": ["accumulate.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "accumulate.js"
+    ],
+    "test": [
+      "accumulate.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2",
   "custom": {

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Convert a long phrase to its acronym",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "cmccandless",
@@ -11,10 +12,17 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": ["acronym.js"],
-    "test": ["acronym.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "acronym.js"
+    ],
+    "test": [
+      "acronym.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Convert a long phrase to its acronym",
   "source": "Julien Vanier",
   "source_url": "https://github.com/monkbroc",
   "custom": {

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -16,5 +16,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Julien Vanier",
-  "source_url": "https://github.com/monkbroc"
+  "source_url": "https://github.com/monkbroc",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/Affine_cipher"
+  "source_url": "http://en.wikipedia.org/wiki/Affine_cipher",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -1,12 +1,22 @@
 {
-  "blurb": "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East.",
-  "authors": ["TomPradat"],
-  "contributors": ["SleeplessByte"],
+  "authors": [
+    "TomPradat"
+  ],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["affine-cipher.js"],
-    "test": ["affine-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "affine-cipher.js"
+    ],
+    "test": [
+      "affine-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East.",
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Affine_cipher",
   "custom": {

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
-  "authors": ["javaeeeee"],
+  "authors": [
+    "javaeeeee"
+  ],
   "contributors": [
     "ankorGH",
     "matthewmorgan",
@@ -10,10 +11,17 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": ["all-your-base.js"],
-    "test": ["all-your-base.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "all-your-base.js"
+    ],
+    "test": [
+      "all-your-base.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -13,5 +13,11 @@
     "solution": ["all-your-base.js"],
     "test": ["all-your-base.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -17,5 +17,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Jumpstart Lab Warm-up",
-  "source_url": "http://jumpstartlab.com"
+  "source_url": "http://jumpstartlab.com",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "matthewmorgan",
@@ -12,10 +13,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["allergies.js"],
-    "test": ["allergies.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "allergies.js"
+    ],
+    "test": [
+      "allergies.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
   "source": "Jumpstart Lab Warm-up",
   "source_url": "http://jumpstartlab.com",
   "custom": {

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Write a function to solve alphametics puzzles.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "rchavarria",
     "slaymance",
@@ -9,10 +10,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["alphametics.js"],
-    "test": ["alphametics.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "alphametics.js"
+    ],
+    "test": [
+      "alphametics.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Write a function to solve alphametics puzzles.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -12,5 +12,11 @@
     "solution": ["alphametics.js"],
     "test": ["alphametics.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "amscotti",
     "ankorGH",
@@ -15,10 +16,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["anagram.js"],
-    "test": ["anagram.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "anagram.js"
+    ],
+    "test": [
+      "anagram.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup",
   "custom": {

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -20,5 +20,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the Extreme Startup game",
-  "source_url": "https://github.com/rchatley/extreme_startup"
+  "source_url": "https://github.com/rchatley/extreme_startup",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number"
+  "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Determine if a number is an Armstrong number",
-  "authors": ["PakkuDon"],
+  "authors": [
+    "PakkuDon"
+  ],
   "contributors": [
     "ankorGH",
     "gargrave",
@@ -10,10 +11,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["armstrong-numbers.js"],
-    "test": ["armstrong-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "armstrong-numbers.js"
+    ],
+    "test": [
+      "armstrong-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Determine if a number is an Armstrong number",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number",
   "custom": {

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -16,5 +16,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/Atbash"
+  "source_url": "http://en.wikipedia.org/wiki/Atbash",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "Futuro212",
     "ovidiu141",
@@ -11,10 +12,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["atbash-cipher.js"],
-    "test": ["atbash-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "atbash-cipher.js"
+    ],
+    "test": [
+      "atbash-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Atbash",
   "custom": {

--- a/exercises/practice/bank-account/.meta/config.json
+++ b/exercises/practice/bank-account/.meta/config.json
@@ -6,5 +6,11 @@
     "solution": ["bank-account.js"],
     "test": ["bank-account.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/bank-account/.meta/config.json
+++ b/exercises/practice/bank-account/.meta/config.json
@@ -1,12 +1,22 @@
 {
-  "blurb": "Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!",
-  "authors": ["TomPradat"],
-  "contributors": ["SleeplessByte"],
+  "authors": [
+    "TomPradat"
+  ],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["bank-account.js"],
-    "test": ["bank-account.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "bank-account.js"
+    ],
+    "test": [
+      "bank-account.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -19,5 +19,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Learn to Program by Chris Pine",
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"
+  "source_url": "http://pine.fm/LearnToProgram/?Chapter=06",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -14,10 +15,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["beer-song.js"],
-    "test": ["beer-song.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "beer-song.js"
+    ],
+    "test": [
+      "beer-song.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
   "source": "Learn to Program by Chris Pine",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06",
   "custom": {

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Insert and search for numbers in a binary tree.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "Futuro212",
@@ -10,10 +11,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["binary-search-tree.js"],
-    "test": ["binary-search-tree.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "binary-search-tree.js"
+    ],
+    "test": [
+      "binary-search-tree.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Insert and search for numbers in a binary tree.",
   "source": "Josh Cheek",
   "source_url": "https://twitter.com/josh_cheek",
   "custom": {

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Josh Cheek",
-  "source_url": "https://twitter.com/josh_cheek"
+  "source_url": "https://twitter.com/josh_cheek",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm"
+  "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Implement a binary search algorithm.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "Futuro212",
     "matthewmorgan",
@@ -10,10 +11,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["binary-search.js"],
-    "test": ["binary-search.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "binary-search.js"
+    ],
+    "test": [
+      "binary-search.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement a binary search algorithm.",
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm",
   "custom": {

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
-  "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"
+  "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "Futuro212",
@@ -10,10 +11,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["binary.js"],
-    "test": ["binary.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "binary.js"
+    ],
+    "test": [
+      "binary.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-",
   "custom": {

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "amscotti",
     "austinratcliff",
@@ -15,10 +16,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["bob.js"],
-    "test": ["bob.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "bob.js"
+    ],
+    "test": [
+      "bob.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06",
   "custom": {

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -20,5 +20,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"
+  "source_url": "http://pine.fm/LearnToProgram/?Chapter=06",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -1,12 +1,19 @@
 {
-  "blurb": "To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts of multiple-book purchases.",
-  "authors": ["kmelow"],
-  "contributors": [],
+  "authors": [
+    "kmelow"
+  ],
   "files": {
-    "solution": ["book-store.js"],
-    "test": ["book-store.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "book-store.js"
+    ],
+    "test": [
+      "book-store.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts of multiple-book purchases.",
   "source": "Inspired by the harry potter kata from Cyber-Dojo.",
   "source_url": "http://cyber-dojo.org",
   "custom": {

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the harry potter kata from Cyber-Dojo.",
-  "source_url": "http://cyber-dojo.org"
+  "source_url": "http://cyber-dojo.org",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -1,12 +1,24 @@
 {
-  "blurb": "Score a bowling game",
-  "authors": ["trvrfrd"],
-  "contributors": ["danielj-jordan", "SleeplessByte", "tejasbubane"],
+  "authors": [
+    "trvrfrd"
+  ],
+  "contributors": [
+    "danielj-jordan",
+    "SleeplessByte",
+    "tejasbubane"
+  ],
   "files": {
-    "solution": ["bowling.js"],
-    "test": ["bowling.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "bowling.js"
+    ],
+    "test": [
+      "bowling.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Score a bowling game",
   "source": "The Bowling Game Kata at but UncleBob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata",
   "custom": {

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "The Bowling Game Kata at but UncleBob",
-  "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"
+  "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Software Craftsmanship - Coin Change Kata",
-  "source_url": "https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata"
+  "source_url": "https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Correctly determine change to be given using the least number of coins",
-  "authors": ["RobinCsl"],
+  "authors": [
+    "RobinCsl"
+  ],
   "contributors": [
     "adamxtokyo",
     "rchavarria",
@@ -10,10 +11,17 @@
     "whatcoda"
   ],
   "files": {
-    "solution": ["change.js"],
-    "test": ["change.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "change.js"
+    ],
+    "test": [
+      "change.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Correctly determine change to be given using the least number of coins",
   "source": "Software Craftsmanship - Coin Change Kata",
   "source_url": "https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata",
   "custom": {

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -18,5 +18,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/Circular_buffer"
+  "source_url": "http://en.wikipedia.org/wiki/Circular_buffer",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "diego-caceres",
     "ramitmittal",
@@ -13,10 +14,17 @@
     "yanick"
   ],
   "files": {
-    "solution": ["circular-buffer.js"],
-    "test": ["circular-buffer.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "circular-buffer.js"
+    ],
+    "test": [
+      "circular-buffer.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end.",
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Circular_buffer",
   "custom": {

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -17,5 +17,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Pairing session with Erin Drummond",
-  "source_url": "https://twitter.com/ebdrummond"
+  "source_url": "https://twitter.com/ebdrummond",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Implement a clock that handles times without dates.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "ovidiu141",
@@ -12,10 +13,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["clock.js"],
-    "test": ["clock.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "clock.js"
+    ],
+    "test": [
+      "clock.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement a clock that handles times without dates.",
   "source": "Pairing session with Erin Drummond",
   "source_url": "https://twitter.com/ebdrummond",
   "custom": {

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
-  "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"
+  "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,12 +1,23 @@
 {
-  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
   "authors": [],
-  "contributors": ["ankorGH", "rchavarria", "SleeplessByte", "xarxziux"],
+  "contributors": [
+    "ankorGH",
+    "rchavarria",
+    "SleeplessByte",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["collatz-conjecture.js"],
-    "test": ["collatz-conjecture.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "collatz-conjecture.js"
+    ],
+    "test": [
+      "collatz-conjecture.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
   "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem",
   "custom": {

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "https://en.wikipedia.org/wiki/Complex_number"
+  "source_url": "https://en.wikipedia.org/wiki/Complex_number",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Implement complex numbers.",
-  "authors": ["MattH-be"],
+  "authors": [
+    "MattH-be"
+  ],
   "contributors": [
     "ankorGH",
     "burennto",
@@ -10,10 +11,17 @@
     "trvrfrd"
   ],
   "files": {
-    "solution": ["complex-numbers.js"],
-    "test": ["complex-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "complex-numbers.js"
+    ],
+    "test": [
+      "complex-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement complex numbers.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Complex_number",
   "custom": {

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -13,5 +13,11 @@
     "solution": ["connect.js"],
     "test": ["connect.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Compute the result for a game of Hex / Polygon",
-  "authors": ["arthurchipdean"],
+  "authors": [
+    "arthurchipdean"
+  ],
   "contributors": [
     "diego-caceres",
     "matthewmorgan",
@@ -10,10 +11,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["connect.js"],
-    "test": ["connect.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "connect.js"
+    ],
+    "test": [
+      "connect.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Compute the result for a game of Hex / Polygon",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Implement the classic method for composing secret messages called a square code.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "diego-caceres",
     "ntshcalleia",
@@ -10,10 +11,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["crypto-square.js"],
-    "test": ["crypto-square.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "crypto-square.js"
+    ],
+    "test": [
+      "crypto-square.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement the classic method for composing secret messages called a square code.",
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html",
   "custom": {

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "J Dalbey's Programming Practice problems",
-  "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"
+  "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": true
+  }
 }

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -14,5 +14,11 @@
     "solution": ["custom-set.js"],
     "test": ["custom-set.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Create a custom set type.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "apapirovski",
@@ -11,10 +12,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["custom-set.js"],
-    "test": ["custom-set.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "custom-set.js"
+    ],
+    "test": [
+      "custom-set.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Create a custom set type.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -13,5 +13,11 @@
     "test": ["darts.spec.js"],
     "example": [".meta/proof.ci.js"]
   },
-  "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
+  "source": "Inspired by an exercise created by a professor Della Paolera in Argentina",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
-  "authors": ["ramadis"],
+  "authors": [
+    "ramadis"
+  ],
   "contributors": [
     "ankorGH",
     "d-vail",
@@ -9,10 +10,17 @@
     "Tyresius92"
   ],
   "files": {
-    "solution": ["darts.js"],
-    "test": ["darts.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "darts.js"
+    ],
+    "test": [
+      "darts.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
   "source": "Inspired by an exercise created by a professor Della Paolera in Argentina",
   "custom": {
     "version.tests.compatibility": "jest-27",

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -1,5 +1,4 @@
 {
-  "blurb": "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.",
   "authors": [],
   "contributors": [
     "ankorGH",
@@ -11,10 +10,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["diamond.js"],
-    "test": ["diamond.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "diamond.js"
+    ],
+    "test": [
+      "diamond.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.",
   "source": "Seb Rose",
   "source_url": "http://claysnow.co.uk/recycling-tests-in-tdd/",
   "custom": {

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -16,5 +16,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Seb Rose",
-  "source_url": "http://claysnow.co.uk/recycling-tests-in-tdd/"
+  "source_url": "http://claysnow.co.uk/recycling-tests-in-tdd/",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -17,5 +17,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Problem 6 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=6"
+  "source_url": "http://projecteuler.net/problem=6",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "hayashi-ay",
@@ -12,10 +13,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["difference-of-squares.js"],
-    "test": ["difference-of-squares.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "difference-of-squares.js"
+    ],
+    "test": [
+      "difference-of-squares.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "source": "Problem 6 at Project Euler",
   "source_url": "http://projecteuler.net/problem=6",
   "custom": {

--- a/exercises/practice/diffie-hellman/.meta/config.json
+++ b/exercises/practice/diffie-hellman/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Diffie-Hellman key exchange.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -9,10 +10,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["diffie-hellman.js"],
-    "test": ["diffie-hellman.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "diffie-hellman.js"
+    ],
+    "test": [
+      "diffie-hellman.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Diffie-Hellman key exchange.",
   "source": "Wikipedia, 1024 bit key from www.cryptopp.com/wiki.",
   "source_url": "http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange",
   "custom": {

--- a/exercises/practice/diffie-hellman/.meta/config.json
+++ b/exercises/practice/diffie-hellman/.meta/config.json
@@ -14,5 +14,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia, 1024 bit key from www.cryptopp.com/wiki.",
-  "source_url": "http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange"
+  "source_url": "http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/dnd-character/.meta/config.json
+++ b/exercises/practice/dnd-character/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Simon Shine, Erik Schierboom",
-  "source_url": "https://github.com/exercism/problem-specifications/issues/616#issuecomment-437358945"
+  "source_url": "https://github.com/exercism/problem-specifications/issues/616#issuecomment-437358945",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/dnd-character/.meta/config.json
+++ b/exercises/practice/dnd-character/.meta/config.json
@@ -1,12 +1,24 @@
 {
-  "blurb": "Randomly generate Dungeons & Dragons characters",
-  "authors": ["Tyresius92"],
-  "contributors": ["ankorGH", "hayashi-ay", "SleeplessByte"],
+  "authors": [
+    "Tyresius92"
+  ],
+  "contributors": [
+    "ankorGH",
+    "hayashi-ay",
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["dnd-character.js"],
-    "test": ["dnd-character.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "dnd-character.js"
+    ],
+    "test": [
+      "dnd-character.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Randomly generate Dungeons & Dragons characters",
   "source": "Simon Shine, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/616#issuecomment-437358945",
   "custom": {

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -1,12 +1,22 @@
 {
-  "blurb": "Make a chain of dominoes.",
-  "authors": ["chauchakching"],
-  "contributors": ["SleeplessByte"],
+  "authors": [
+    "chauchakching"
+  ],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["dominoes.js"],
-    "test": ["dominoes.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "dominoes.js"
+    ],
+    "test": [
+      "dominoes.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Make a chain of dominoes.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -6,5 +6,11 @@
     "solution": ["dominoes.js"],
     "test": ["dominoes.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -13,10 +14,17 @@
     "trvrfrd"
   ],
   "files": {
-    "solution": ["etl.js"],
-    "test": ["etl.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "etl.js"
+    ],
+    "test": [
+      "etl.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
   "source": "The Jumpstart Lab team",
   "source_url": "http://jumpstartlab.com",
   "custom": {

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -18,5 +18,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "The Jumpstart Lab team",
-  "source_url": "http://jumpstartlab.com"
+  "source_url": "http://jumpstartlab.com",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Take a nested list and return a single list with all values except nil/null",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "gabriel376",
@@ -10,10 +11,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["flatten-array.js"],
-    "test": ["flatten-array.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "flatten-array.js"
+    ],
+    "test": [
+      "flatten-array.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Take a nested list and return a single list with all values except nil/null",
   "source": "Interview Question",
   "source_url": "https://reference.wolfram.com/language/ref/Flatten.html",
   "custom": {

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Interview Question",
-  "source_url": "https://reference.wolfram.com/language/ref/Flatten.html"
+  "source_url": "https://reference.wolfram.com/language/ref/Flatten.html",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -17,5 +17,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly"
+  "source_url": "http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -12,10 +13,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["food-chain.js"],
-    "test": ["food-chain.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "food-chain.js"
+    ],
+    "test": [
+      "food-chain.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'",
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly",
   "custom": {

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -13,5 +13,11 @@
     "solution": ["forth.js"],
     "test": ["forth.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Implement an evaluator for a very simple subset of Forth",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "brendanmckeown",
     "slaymance",
@@ -10,10 +11,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["forth.js"],
-    "test": ["forth.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "forth.js"
+    ],
+    "test": [
+      "forth.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement an evaluator for a very simple subset of Forth",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -18,5 +18,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=09"
+  "source_url": "http://pine.fm/LearnToProgram/?Chapter=09",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -13,10 +14,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["gigasecond.js"],
-    "test": ["gigasecond.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "gigasecond.js"
+    ],
+    "test": [
+      "gigasecond.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=09",
   "custom": {

--- a/exercises/practice/go-counting/.meta/config.json
+++ b/exercises/practice/go-counting/.meta/config.json
@@ -6,5 +6,11 @@
     "solution": ["go-counting.js"],
     "test": ["go-counting.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/go-counting/.meta/config.json
+++ b/exercises/practice/go-counting/.meta/config.json
@@ -1,12 +1,19 @@
 {
-  "blurb": "Count the scored points on a Go board.",
-  "authors": ["lpizzinidev"],
-  "contributors": [],
+  "authors": [
+    "lpizzinidev"
+  ],
   "files": {
-    "solution": ["go-counting.js"],
-    "test": ["go-counting.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "go-counting.js"
+    ],
+    "test": [
+      "go-counting.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Count the scored points on a Go board.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -19,5 +19,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "A pairing session with Phil Battos at gSchool",
-  "source_url": "http://gschool.it"
+  "source_url": "http://gschool.it",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -14,10 +15,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["grade-school.js"],
-    "test": ["grade-school.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "grade-school.js"
+    ],
+    "test": [
+      "grade-school.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
   "source": "A pairing session with Phil Battos at gSchool",
   "source_url": "http://gschool.it",
   "custom": {

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -19,5 +19,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "JavaRanch Cattle Drive, exercise 6",
-  "source_url": "http://www.javaranch.com/grains.jsp"
+  "source_url": "http://www.javaranch.com/grains.jsp",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "drericrobinson",
@@ -14,10 +15,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["grains.js"],
-    "test": ["grains.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "grains.js"
+    ],
+    "test": [
+      "grains.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
   "source": "JavaRanch Cattle Drive, exercise 6",
   "source_url": "http://www.javaranch.com/grains.jsp",
   "custom": {

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Conversation with Nate Foster.",
-  "source_url": "http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf"
+  "source_url": "http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -1,12 +1,23 @@
 {
-  "blurb": "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line.",
-  "authors": ["TomPradat"],
-  "contributors": ["iHiD", "SleeplessByte"],
+  "authors": [
+    "TomPradat"
+  ],
+  "contributors": [
+    "iHiD",
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["grep.js"],
-    "test": ["grep.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "grep.js"
+    ],
+    "test": [
+      "grep.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line.",
   "source": "Conversation with Nate Foster.",
   "source_url": "http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf",
   "custom": {

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Calculate the Hamming difference between two DNA strands.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -13,10 +14,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["hamming.js"],
-    "test": ["hamming.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "hamming.js"
+    ],
+    "test": [
+      "hamming.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Calculate the Hamming difference between two DNA strands.",
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/",
   "custom": {

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -18,5 +18,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
-  "source_url": "http://rosalind.info/problems/hamm/"
+  "source_url": "http://rosalind.info/problems/hamm/",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "austinratcliff",
     "designfrontier",
@@ -12,10 +13,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["hello-world.js"],
-    "test": ["hello-world.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "hello-world.js"
+    ],
+    "test": [
+      "hello-world.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program",
   "custom": {

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -17,5 +17,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "This is an exercise to introduce users to using Exercism",
-  "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"
+  "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/hexadecimal/.meta/config.json
+++ b/exercises/practice/hexadecimal/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
-  "source_url": "http://www.wolframalpha.com/examples/NumberBases.html"
+  "source_url": "http://www.wolframalpha.com/examples/NumberBases.html",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/hexadecimal/.meta/config.json
+++ b/exercises/practice/hexadecimal/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Convert a hexadecimal number, represented as a string (e.g. \"10af8c\"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -10,10 +11,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["hexadecimal.js"],
-    "test": ["hexadecimal.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "hexadecimal.js"
+    ],
+    "test": [
+      "hexadecimal.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Convert a hexadecimal number, represented as a string (e.g. \"10af8c\"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/examples/NumberBases.html",
   "custom": {

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Manage a player's High Score list",
-  "authors": ["PakkuDon"],
+  "authors": [
+    "PakkuDon"
+  ],
   "contributors": [
     "ankorGH",
     "cmccandless",
@@ -9,10 +10,17 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": ["high-scores.js"],
-    "test": ["high-scores.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "high-scores.js"
+    ],
+    "test": [
+      "high-scores.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Manage a player's High Score list",
   "source": "Tribute to the eighties' arcade game Frogger",
   "custom": {
     "version.tests.compatibility": "jest-27",

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -13,5 +13,11 @@
     "test": ["high-scores.spec.js"],
     "example": [".meta/proof.ci.js"]
   },
-  "source": "Tribute to the eighties' arcade game Frogger"
+  "source": "Tribute to the eighties' arcade game Frogger",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "British nursery rhyme",
-  "source_url": "http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built"
+  "source_url": "http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -1,12 +1,25 @@
 {
-  "blurb": "Output the nursery rhyme 'This is the House that Jack Built'.",
-  "authors": ["laurmurclar"],
-  "contributors": ["ankorGH", "rchavarria", "SleeplessByte", "tejasbubane"],
+  "authors": [
+    "laurmurclar"
+  ],
+  "contributors": [
+    "ankorGH",
+    "rchavarria",
+    "SleeplessByte",
+    "tejasbubane"
+  ],
   "files": {
-    "solution": ["house.js"],
-    "test": ["house.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "house.js"
+    ],
+    "test": [
+      "house.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Output the nursery rhyme 'This is the House that Jack Built'.",
   "source": "British nursery rhyme",
   "source_url": "http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built",
   "custom": {

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Converting a string into a number and some basic processing utilizing a relatable real world example.",
-  "source_url": "https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation"
+  "source_url": "https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Check if a given string is a valid ISBN-10 number.",
-  "authors": ["MattH-be"],
+  "authors": [
+    "MattH-be"
+  ],
   "contributors": [
     "ankorGH",
     "ovidiu141",
@@ -10,10 +11,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["isbn-verifier.js"],
-    "test": ["isbn-verifier.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "isbn-verifier.js"
+    ],
+    "test": [
+      "isbn-verifier.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Check if a given string is a valid ISBN-10 number.",
   "source": "Converting a string into a number and some basic processing utilizing a relatable real world example.",
   "source_url": "https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation",
   "custom": {

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -17,5 +17,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "https://en.wikipedia.org/wiki/Isogram"
+  "source_url": "https://en.wikipedia.org/wiki/Isogram",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,5 +1,4 @@
 {
-  "blurb": "Determine if a word or phrase is an isogram.",
   "authors": [],
   "contributors": [
     "amscotti",
@@ -12,10 +11,17 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": ["isogram.js"],
-    "test": ["isogram.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "isogram.js"
+    ],
+    "test": [
+      "isogram.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Determine if a word or phrase is an isogram.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Isogram",
   "custom": {

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a diagram, determine which plants each child in the kindergarten class is responsible for.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "brendanmckeown",
     "matthewmorgan",
@@ -10,10 +11,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["kindergarten-garden.js"],
-    "test": ["kindergarten-garden.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "kindergarten-garden.js"
+    ],
+    "test": [
+      "kindergarten-garden.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a diagram, determine which plants each child in the kindergarten class is responsible for.",
   "source": "Random musings during airplane trip.",
   "source_url": "http://jumpstartlab.com",
   "custom": {

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Random musings during airplane trip.",
-  "source_url": "http://jumpstartlab.com"
+  "source_url": "http://jumpstartlab.com",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/knapsack/.meta/config.json
+++ b/exercises/practice/knapsack/.meta/config.json
@@ -1,12 +1,19 @@
 {
-  "blurb": "Given a knapsack that can only carry a certain weight, determine which items to put in the knapsack in order to maximize their combined value.",
-  "authors": ["lpizzinidev"],
-  "contributors": [],
+  "authors": [
+    "lpizzinidev"
+  ],
   "files": {
-    "solution": ["knapsack.js"],
-    "test": ["knapsack.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "knapsack.js"
+    ],
+    "test": [
+      "knapsack.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a knapsack that can only carry a certain weight, determine which items to put in the knapsack in order to maximize their combined value.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Knapsack_problem",
   "custom": {

--- a/exercises/practice/knapsack/.meta/config.json
+++ b/exercises/practice/knapsack/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "https://en.wikipedia.org/wiki/Knapsack_problem"
+  "source_url": "https://en.wikipedia.org/wiki/Knapsack_problem",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -17,5 +17,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on Problem 8 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=8"
+  "source_url": "http://projecteuler.net/problem=8",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "ovidiu141",
@@ -12,10 +13,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["largest-series-product.js"],
-    "test": ["largest-series-product.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "largest-series-product.js"
+    ],
+    "test": [
+      "largest-series-product.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
   "source": "A variation on Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8",
   "custom": {

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a year, report if it is a leap year.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -14,10 +15,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["leap.js"],
-    "test": ["leap.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "leap.js"
+    ],
+    "test": [
+      "leap.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a year, report if it is a leap year.",
   "source": "JavaRanch Cattle Drive, exercise 3",
   "source_url": "http://www.javaranch.com/leap.jsp",
   "custom": {

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -19,5 +19,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "JavaRanch Cattle Drive, exercise 3",
-  "source_url": "http://www.javaranch.com/leap.jsp"
+  "source_url": "http://www.javaranch.com/leap.jsp",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Implement a doubly linked list",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "bdjnk",
@@ -14,10 +15,17 @@
     "thanhcng"
   ],
   "files": {
-    "solution": ["linked-list.js"],
-    "test": ["linked-list.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "linked-list.js"
+    ],
+    "test": [
+      "linked-list.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement a doubly linked list",
   "source": "Classic computer science topic",
   "custom": {
     "version.tests.compatibility": "jest-27",

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -18,5 +18,11 @@
     "test": ["linked-list.spec.js"],
     "example": [".meta/proof.ci.js"]
   },
-  "source": "Classic computer science topic"
+  "source": "Classic computer science topic",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Implement basic list operations",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "archanid",
@@ -12,10 +13,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["list-ops.js"],
-    "test": ["list-ops.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "list-ops.js"
+    ],
+    "test": [
+      "list-ops.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement basic list operations",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -15,5 +15,11 @@
     "solution": ["list-ops.js"],
     "test": ["list-ops.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "gabriel376",
@@ -12,10 +13,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["luhn.js"],
-    "test": ["luhn.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "luhn.js"
+    ],
+    "test": [
+      "luhn.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
   "source": "The Luhn Algorithm on Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm",
   "custom": {

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -17,5 +17,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "The Luhn Algorithm on Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm"
+  "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Make sure the brackets and braces all match.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "Futuro212",
@@ -11,10 +12,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["matching-brackets.js"],
-    "test": ["matching-brackets.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "matching-brackets.js"
+    ],
+    "test": [
+      "matching-brackets.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Make sure the brackets and braces all match.",
   "source": "Ginna Baker",
   "custom": {
     "version.tests.compatibility": "jest-27",

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -15,5 +15,11 @@
     "test": ["matching-brackets.spec.js"],
     "example": [".meta/proof.ci.js"]
   },
-  "source": "Ginna Baker"
+  "source": "Ginna Baker",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a string representing a matrix of numbers, return the rows and columns of that matrix.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "amscotti",
     "ankorGH",
@@ -13,10 +14,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["matrix.js"],
-    "test": ["matrix.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "matrix.js"
+    ],
+    "test": [
+      "matrix.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a string representing a matrix of numbers, return the rows and columns of that matrix.",
   "source": "Warmup to the `saddle-points` warmup.",
   "source_url": "http://jumpstartlab.com",
   "custom": {

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -18,5 +18,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Warmup to the `saddle-points` warmup.",
-  "source_url": "http://jumpstartlab.com"
+  "source_url": "http://jumpstartlab.com",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Calculate the date of meetups.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ovidiu141",
     "rchavarria",
@@ -10,10 +11,17 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": ["meetup.js"],
-    "test": ["meetup.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "meetup.js"
+    ],
+    "test": [
+      "meetup.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Calculate the date of meetups.",
   "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
   "source_url": "https://twitter.com/copiousfreetime",
   "custom": {

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
-  "source_url": "https://twitter.com/copiousfreetime"
+  "source_url": "https://twitter.com/copiousfreetime",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Add the numbers to a minesweeper board",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "brendanmckeown",
     "cr0t",
@@ -10,10 +11,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["minesweeper.js"],
-    "test": ["minesweeper.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "minesweeper.js"
+    ],
+    "test": [
+      "minesweeper.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Add the numbers to a minesweeper board",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -13,5 +13,11 @@
     "solution": ["minesweeper.js"],
     "test": ["minesweeper.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a number n, determine what the nth prime is.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "hayashi-ay",
@@ -12,10 +13,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["nth-prime.js"],
-    "test": ["nth-prime.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "nth-prime.js"
+    ],
+    "test": [
+      "nth-prime.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a number n, determine what the nth prime is.",
   "source": "A variation on Problem 7 at Project Euler",
   "source_url": "http://projecteuler.net/problem=7",
   "custom": {

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -17,5 +17,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on Problem 7 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=7"
+  "source_url": "http://projecteuler.net/problem=7",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
-  "source_url": "http://rosalind.info/problems/dna/"
+  "source_url": "http://rosalind.info/problems/dna/",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,12 +1,25 @@
 {
-  "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
-  "authors": ["tarunvelli"],
-  "contributors": ["ankorGH", "hayashi-ay", "SleeplessByte", "tejasbubane"],
+  "authors": [
+    "tarunvelli"
+  ],
+  "contributors": [
+    "ankorGH",
+    "hayashi-ay",
+    "SleeplessByte",
+    "tejasbubane"
+  ],
   "files": {
-    "solution": ["nucleotide-count.js"],
-    "test": ["nucleotide-count.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "nucleotide-count.js"
+    ],
+    "test": [
+      "nucleotide-count.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
   "source_url": "http://rosalind.info/problems/dna/",
   "custom": {

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -9,10 +10,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["ocr-numbers.js"],
-    "test": ["ocr-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "ocr-numbers.js"
+    ],
+    "test": [
+      "ocr-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.",
   "source": "Inspired by the Bank OCR kata",
   "source_url": "http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR",
   "custom": {

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -14,5 +14,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the Bank OCR kata",
-  "source_url": "http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR"
+  "source_url": "http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/octal/.meta/config.json
+++ b/exercises/practice/octal/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
-  "source_url": "http://www.wolframalpha.com/input/?i=base+8"
+  "source_url": "http://www.wolframalpha.com/input/?i=base+8",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/octal/.meta/config.json
+++ b/exercises/practice/octal/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "msomji",
@@ -10,10 +11,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["octal.js"],
-    "test": ["octal.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "octal.js"
+    ],
+    "test": [
+      "octal.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=base+8",
   "custom": {

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -21,5 +21,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Problem 4 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=4"
+  "source_url": "http://projecteuler.net/problem=4",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": true
+  }
 }

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -1,5 +1,4 @@
 {
-  "blurb": "Detect palindrome products in a given range.",
   "authors": [],
   "contributors": [
     "ankorGH",
@@ -16,10 +15,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["palindrome-products.js"],
-    "test": ["palindrome-products.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "palindrome-products.js"
+    ],
+    "test": [
+      "palindrome-products.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Detect palindrome products in a given range.",
   "source": "Problem 4 at Project Euler",
   "source_url": "http://projecteuler.net/problem=4",
   "custom": {

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -17,5 +17,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "https://en.wikipedia.org/wiki/Pangram"
+  "source_url": "https://en.wikipedia.org/wiki/Pangram",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Determine if a sentence is a pangram.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "amscotti",
     "ankorGH",
@@ -12,10 +13,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["pangram.js"],
-    "test": ["pangram.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pangram.js"
+    ],
+    "test": [
+      "pangram.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Determine if a sentence is a pangram.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Pangram",
   "custom": {

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Pascal's Triangle at Wolfram Math World",
-  "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html"
+  "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Compute Pascal's triangle up to a given number of rows.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "matthewmorgan",
@@ -10,10 +11,17 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": ["pascals-triangle.js"],
-    "test": ["pascals-triangle.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pascals-triangle.js"
+    ],
+    "test": [
+      "pascals-triangle.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Compute Pascal's triangle up to a given number of rows.",
   "source": "Pascal's Triangle at Wolfram Math World",
   "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html",
   "custom": {

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
-  "authors": ["komyg"],
+  "authors": [
+    "komyg"
+  ],
   "contributors": [
     "ankorGH",
     "matthewmorgan",
@@ -10,10 +11,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["perfect-numbers.js"],
-    "test": ["perfect-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "perfect-numbers.js"
+    ],
+    "test": [
+      "perfect-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
   "source_url": "http://shop.oreilly.com/product/0636920029687.do",
   "custom": {

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
-  "source_url": "http://shop.oreilly.com/product/0636920029687.do"
+  "source_url": "http://shop.oreilly.com/product/0636920029687.do",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -19,5 +19,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Event Manager by JumpstartLab",
-  "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html"
+  "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -14,10 +15,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["phone-number.js"],
-    "test": ["phone-number.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "phone-number.js"
+    ],
+    "test": [
+      "phone-number.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
   "source": "Event Manager by JumpstartLab",
   "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html",
   "custom": {

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -16,5 +16,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",
-  "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/"
+  "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Implement a program that translates from English to Pig Latin",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "konni2020",
@@ -11,10 +12,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["pig-latin.js"],
-    "test": ["pig-latin.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pig-latin.js"
+    ],
+    "test": [
+      "pig-latin.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement a program that translates from English to Pig Latin",
   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",
   "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/",
   "custom": {

--- a/exercises/practice/point-mutations/.meta/config.json
+++ b/exercises/practice/point-mutations/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
-  "source_url": "http://rosalind.info/problems/hamm/"
+  "source_url": "http://rosalind.info/problems/hamm/",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/point-mutations/.meta/config.json
+++ b/exercises/practice/point-mutations/.meta/config.json
@@ -1,12 +1,25 @@
 {
-  "blurb": "Calculate the Hamming difference between two DNA strands.",
-  "authors": ["matthewmorgan"],
-  "contributors": ["ankorGH", "SleeplessByte", "tejasbubane", "thanhcng"],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "ankorGH",
+    "SleeplessByte",
+    "tejasbubane",
+    "thanhcng"
+  ],
   "files": {
-    "solution": ["point-mutations.js"],
-    "test": ["point-mutations.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "point-mutations.js"
+    ],
+    "test": [
+      "point-mutations.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Calculate the Hamming difference between two DNA strands.",
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/",
   "custom": {

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -14,5 +14,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "The Prime Factors Kata by Uncle Bob",
-  "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata"
+  "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Compute the prime factors of a given natural number.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "matthewmorgan",
@@ -9,10 +10,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["prime-factors.js"],
-    "test": ["prime-factors.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "prime-factors.js"
+    ],
+    "test": [
+      "prime-factors.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Compute the prime factors of a given natural number.",
   "source": "The Prime Factors Kata by Uncle Bob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata",
   "custom": {

--- a/exercises/practice/promises/.meta/config.json
+++ b/exercises/practice/promises/.meta/config.json
@@ -1,12 +1,23 @@
 {
-  "blurb": "Practice promises by implementing some common promise functions.",
-  "authors": ["slaymance"],
-  "contributors": ["SleeplessByte", "TomPradat"],
+  "authors": [
+    "slaymance"
+  ],
+  "contributors": [
+    "SleeplessByte",
+    "TomPradat"
+  ],
   "files": {
-    "solution": ["promises.js"],
-    "test": ["promises.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "promises.js"
+    ],
+    "test": [
+      "promises.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Practice promises by implementing some common promise functions.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/promises/.meta/config.json
+++ b/exercises/practice/promises/.meta/config.json
@@ -6,5 +6,11 @@
     "solution": ["promises.js"],
     "test": ["promises.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["protein-translation.spec.js"],
     "example": [".meta/proof.ci.js"]
   },
-  "source": "Tyler Long"
+  "source": "Tyler Long",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -1,12 +1,25 @@
 {
-  "blurb": "Translate RNA sequences into proteins.",
-  "authors": ["RobinCsl"],
-  "contributors": ["ankorGH", "SleeplessByte", "tejasbubane", "WebCu"],
+  "authors": [
+    "RobinCsl"
+  ],
+  "contributors": [
+    "ankorGH",
+    "SleeplessByte",
+    "tejasbubane",
+    "WebCu"
+  ],
   "files": {
-    "solution": ["protein-translation.js"],
-    "test": ["protein-translation.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "protein-translation.js"
+    ],
+    "test": [
+      "protein-translation.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Translate RNA sequences into proteins.",
   "source": "Tyler Long",
   "custom": {
     "version.tests.compatibility": "jest-27",

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
-  "authors": ["skabbass1"],
+  "authors": [
+    "skabbass1"
+  ],
   "contributors": [
     "ankorGH",
     "serixscorpio",
@@ -9,10 +10,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["proverb.js"],
-    "test": ["proverb.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "proverb.js"
+    ],
+    "test": [
+      "proverb.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/For_Want_of_a_Nail",
   "custom": {

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -14,5 +14,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/For_Want_of_a_Nail"
+  "source_url": "http://en.wikipedia.org/wiki/For_Want_of_a_Nail",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -10,10 +11,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["pythagorean-triplet.js"],
-    "test": ["pythagorean-triplet.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "pythagorean-triplet.js"
+    ],
+    "test": [
+      "pythagorean-triplet.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
   "source": "Problem 9 at Project Euler",
   "source_url": "http://projecteuler.net/problem=9",
   "custom": {

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Problem 9 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=9"
+  "source_url": "http://projecteuler.net/problem=9",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": true
+  }
 }

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "abhnvgupta",
     "alexashley",
@@ -14,10 +15,17 @@
     "smb26"
   ],
   "files": {
-    "solution": ["queen-attack.js"],
-    "test": ["queen-attack.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "queen-attack.js"
+    ],
+    "test": [
+      "queen-attack.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html",
   "custom": {

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -19,5 +19,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "J Dalbey's Programming Practice problems",
-  "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"
+  "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher"
+  "source_url": "https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -1,12 +1,19 @@
 {
-  "blurb": "Implement encoding and decoding for the rail fence cipher.",
-  "authors": ["lpizzinidev"],
-  "contributors": [],
+  "authors": [
+    "lpizzinidev"
+  ],
   "files": {
-    "solution": ["rail-fence-cipher.js"],
-    "test": ["rail-fence-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rail-fence-cipher.js"
+    ],
+    "test": [
+      "rail-fence-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement encoding and decoding for the rail fence cipher.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher",
   "custom": {

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -16,5 +16,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
-  "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz"
+  "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "cmccandless",
@@ -11,10 +12,17 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": ["raindrops.js"],
-    "test": ["raindrops.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "raindrops.js"
+    ],
+    "test": [
+      "raindrops.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
   "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz",
   "custom": {

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -1,12 +1,24 @@
 {
-  "blurb": "Implement rational numbers.",
-  "authors": ["matthewmorgan"],
-  "contributors": ["ankorGH", "SleeplessByte", "tejasbubane"],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "ankorGH",
+    "SleeplessByte",
+    "tejasbubane"
+  ],
   "files": {
-    "solution": ["rational-numbers.js"],
-    "test": ["rational-numbers.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rational-numbers.js"
+    ],
+    "test": [
+      "rational-numbers.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement rational numbers.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Rational_number",
   "custom": {

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "https://en.wikipedia.org/wiki/Rational_number"
+  "source_url": "https://en.wikipedia.org/wiki/Rational_number",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Implement a basic reactive system.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "Boto1",
     "joshgoebel",
@@ -9,10 +10,17 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": ["react.js"],
-    "test": ["react.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "react.js"
+    ],
+    "test": [
+      "react.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement a basic reactive system.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -12,5 +12,11 @@
     "solution": ["react.js"],
     "test": ["react.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -6,5 +6,11 @@
     "solution": ["rectangles.js"],
     "test": ["rectangles.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -1,12 +1,25 @@
 {
-  "blurb": "Count the rectangles in an ASCII diagram.",
-  "authors": ["MattH-be"],
-  "contributors": ["ankorGH", "SleeplessByte", "tejasbubane", "xarxziux"],
+  "authors": [
+    "MattH-be"
+  ],
+  "contributors": [
+    "ankorGH",
+    "SleeplessByte",
+    "tejasbubane",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["rectangles.js"],
-    "test": ["rectangles.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rectangles.js"
+    ],
+    "test": [
+      "rectangles.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Count the rectangles in an ASCII diagram.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Maud de Vries, Erik Schierboom",
-  "source_url": "https://github.com/exercism/problem-specifications/issues/1464"
+  "source_url": "https://github.com/exercism/problem-specifications/issues/1464",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -1,12 +1,24 @@
 {
-  "blurb": "Convert color codes, as used on resistors, to a numeric value.",
-  "authors": ["tejasbubane"],
-  "contributors": ["ankorGH", "clockelliptic", "SleeplessByte"],
+  "authors": [
+    "tejasbubane"
+  ],
+  "contributors": [
+    "ankorGH",
+    "clockelliptic",
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["resistor-color-duo.js"],
-    "test": ["resistor-color-duo.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "resistor-color-duo.js"
+    ],
+    "test": [
+      "resistor-color-duo.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Convert color codes, as used on resistors, to a numeric value.",
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1464",
   "custom": {

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Maud de Vries, Erik Schierboom",
-  "source_url": "https://github.com/exercism/problem-specifications/issues/1549"
+  "source_url": "https://github.com/exercism/problem-specifications/issues/1549",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -1,12 +1,22 @@
 {
-  "blurb": "Convert color codes, as used on resistors, to a human-readable label.",
-  "authors": ["SleeplessByte"],
-  "contributors": ["hayashi-ay"],
+  "authors": [
+    "SleeplessByte"
+  ],
+  "contributors": [
+    "hayashi-ay"
+  ],
   "files": {
-    "solution": ["resistor-color-trio.js"],
-    "test": ["resistor-color-trio.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "resistor-color-trio.js"
+    ],
+    "test": [
+      "resistor-color-trio.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Convert color codes, as used on resistors, to a human-readable label.",
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1549",
   "custom": {

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -1,12 +1,23 @@
 {
-  "blurb": "Convert a resistor band's color to its numeric representation",
-  "authors": ["SleeplessByte"],
-  "contributors": ["ankorGH", "TomPradat"],
+  "authors": [
+    "SleeplessByte"
+  ],
+  "contributors": [
+    "ankorGH",
+    "TomPradat"
+  ],
   "files": {
-    "solution": ["resistor-color.js"],
-    "test": ["resistor-color.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "resistor-color.js"
+    ],
+    "test": [
+      "resistor-color.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Convert a resistor band's color to its numeric representation",
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1458",
   "custom": {

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Maud de Vries, Erik Schierboom",
-  "source_url": "https://github.com/exercism/problem-specifications/issues/1458"
+  "source_url": "https://github.com/exercism/problem-specifications/issues/1458",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/rest-api/.meta/config.json
+++ b/exercises/practice/rest-api/.meta/config.json
@@ -1,10 +1,17 @@
 {
-  "blurb": "Implement a RESTful API for tracking IOUs.",
-  "authors": ["lpizzinidev"],
-  "contributors": [],
+  "authors": [
+    "lpizzinidev"
+  ],
   "files": {
-    "solution": ["rest-api.js"],
-    "test": ["rest-api.spec.js"],
-    "example": [".meta/proof.ci.js"]
-  }
+    "solution": [
+      "rest-api.js"
+    ],
+    "test": [
+      "rest-api.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
+  },
+  "blurb": "Implement a RESTful API for tracking IOUs."
 }

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,12 +1,25 @@
 {
-  "blurb": "Reverse a string",
-  "authors": ["gavinhenderson"],
-  "contributors": ["ankorGH", "d-vail", "ovidiu141", "SleeplessByte"],
+  "authors": [
+    "gavinhenderson"
+  ],
+  "contributors": [
+    "ankorGH",
+    "d-vail",
+    "ovidiu141",
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["reverse-string.js"],
-    "test": ["reverse-string.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "reverse-string.js"
+    ],
+    "test": [
+      "reverse-string.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Reverse a string",
   "source": "Introductory challenge to reverse an input string",
   "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb",
   "custom": {

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Introductory challenge to reverse an input string",
-  "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"
+  "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "amscotti",
     "ankorGH",
@@ -14,10 +15,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["rna-transcription.js"],
-    "test": ["rna-transcription.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rna-transcription.js"
+    ],
+    "test": [
+      "rna-transcription.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "source": "Hyperphysics",
   "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html",
   "custom": {

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -19,5 +19,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Hyperphysics",
-  "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"
+  "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -15,5 +15,11 @@
     "test": ["robot-name.spec.js"],
     "example": [".meta/proof.ci.js"]
   },
-  "source": "A debugging session with Paul Blackwell at gSchool."
+  "source": "A debugging session with Paul Blackwell at gSchool.",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": true
+  }
 }

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Manage robot factory settings.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "draalger",
     "kytrinyx",
@@ -11,10 +12,17 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": ["robot-name.js"],
-    "test": ["robot-name.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "robot-name.js"
+    ],
+    "test": [
+      "robot-name.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Manage robot factory settings.",
   "source": "A debugging session with Paul Blackwell at gSchool.",
   "custom": {
     "version.tests.compatibility": "jest-27",

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -15,5 +15,11 @@
     "test": ["robot-simulator.spec.js"],
     "example": [".meta/proof.ci.js"]
   },
-  "source": "Inspired by an interview question at a famous company."
+  "source": "Inspired by an interview question at a famous company.",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Write a robot simulator.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "jscheffner",
@@ -11,10 +12,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["robot-simulator.js"],
-    "test": ["robot-simulator.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "robot-simulator.js"
+    ],
+    "test": [
+      "robot-simulator.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Write a robot simulator.",
   "source": "Inspired by an interview question at a famous company.",
   "custom": {
     "version.tests.compatibility": "jest-27",

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "cmccandless",
@@ -10,10 +11,17 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": ["roman-numerals.js"],
-    "test": ["roman-numerals.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "roman-numerals.js"
+    ],
+    "test": [
+      "roman-numerals.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
   "source": "The Roman Numeral Kata",
   "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals",
   "custom": {

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "The Roman Numeral Kata",
-  "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals"
+  "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "https://en.wikipedia.org/wiki/Caesar_cipher"
+  "source_url": "https://en.wikipedia.org/wiki/Caesar_cipher",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -1,12 +1,25 @@
 {
-  "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
-  "authors": ["MattH-be"],
-  "contributors": ["ankorGH", "SleeplessByte", "tejasbubane", "xarxziux"],
+  "authors": [
+    "MattH-be"
+  ],
+  "contributors": [
+    "ankorGH",
+    "SleeplessByte",
+    "tejasbubane",
+    "xarxziux"
+  ],
   "files": {
-    "solution": ["rotational-cipher.js"],
-    "test": ["rotational-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "rotational-cipher.js"
+    ],
+    "test": [
+      "rotational-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Caesar_cipher",
   "custom": {

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -1,12 +1,24 @@
 {
-  "blurb": "Implement run-length encoding and decoding.",
-  "authors": ["skabbass1"],
-  "contributors": ["ankorGH", "serixscorpio", "SleeplessByte"],
+  "authors": [
+    "skabbass1"
+  ],
+  "contributors": [
+    "ankorGH",
+    "serixscorpio",
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["run-length-encoding.js"],
-    "test": ["run-length-encoding.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "run-length-encoding.js"
+    ],
+    "test": [
+      "run-length-encoding.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement run-length encoding and decoding.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Run-length_encoding",
   "custom": {

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "https://en.wikipedia.org/wiki/Run-length_encoding"
+  "source_url": "https://en.wikipedia.org/wiki/Run-length_encoding",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "J Dalbey's Programming Practice problems",
-  "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"
+  "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Detect saddle points in a matrix.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "ovidiu141",
@@ -10,10 +11,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["saddle-points.js"],
-    "test": ["saddle-points.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "saddle-points.js"
+    ],
+    "test": [
+      "saddle-points.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Detect saddle points in a matrix.",
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html",
   "custom": {

--- a/exercises/practice/satellite/.meta/config.json
+++ b/exercises/practice/satellite/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["satellite.spec.js"],
     "example": [".meta/proof.ci.js"]
   },
-  "title": "Satellite"
+  "title": "Satellite",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/satellite/.meta/config.json
+++ b/exercises/practice/satellite/.meta/config.json
@@ -1,13 +1,19 @@
 {
-  "blurb": "Rebuild binary trees from pre-order and in-order traversals.",
-  "authors": ["lpizzinidev"],
-  "contributors": [],
+  "authors": [
+    "lpizzinidev"
+  ],
   "files": {
-    "solution": ["satellite.js"],
-    "test": ["satellite.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "satellite.js"
+    ],
+    "test": [
+      "satellite.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
-  "title": "Satellite",
+  "blurb": "Rebuild binary trees from pre-order and in-order traversals.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "msomji",
@@ -11,10 +12,17 @@
     "fearless-spider"
   ],
   "files": {
-    "solution": ["say.js"],
-    "test": ["say.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "say.js"
+    ],
+    "test": [
+      "say.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
   "source": "A variation on JavaRanch CattleDrive, exercise 4a",
   "source_url": "http://www.javaranch.com/say.jsp",
   "custom": {

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -16,5 +16,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on JavaRanch CattleDrive, exercise 4a",
-  "source_url": "http://www.javaranch.com/say.jsp"
+  "source_url": "http://www.javaranch.com/say.jsp",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -1,12 +1,22 @@
 {
-  "blurb": "Generate musical scales, given a starting note and a set of intervals. ",
-  "authors": ["seeksort"],
-  "contributors": ["SleeplessByte"],
+  "authors": [
+    "seeksort"
+  ],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["scale-generator.js"],
-    "test": ["scale-generator.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "scale-generator.js"
+    ],
+    "test": [
+      "scale-generator.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Generate musical scales, given a starting note and a set of intervals. ",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -6,5 +6,11 @@
     "solution": ["scale-generator.js"],
     "test": ["scale-generator.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -16,5 +16,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by the Extreme Startup game",
-  "source_url": "https://github.com/rchatley/extreme_startup"
+  "source_url": "https://github.com/rchatley/extreme_startup",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a word, compute the Scrabble score for that word.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "amscotti",
     "ankorGH",
@@ -11,10 +12,17 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": ["scrabble-score.js"],
-    "test": ["scrabble-score.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "scrabble-score.js"
+    ],
+    "test": [
+      "scrabble-score.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a word, compute the Scrabble score for that word.",
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup",
   "custom": {

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -16,5 +16,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Bert, in Mary Poppins",
-  "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047"
+  "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "ovidiu141",
@@ -11,10 +12,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["secret-handshake.js"],
-    "test": ["secret-handshake.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "secret-handshake.js"
+    ],
+    "test": [
+      "secret-handshake.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
   "source": "Bert, in Mary Poppins",
   "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047",
   "custom": {

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -11,10 +12,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["series.js"],
-    "test": ["series.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "series.js"
+    ],
+    "test": [
+      "series.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
   "source": "A subset of the Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8",
   "custom": {

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -16,5 +16,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "A subset of the Problem 8 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=8"
+  "source_url": "http://projecteuler.net/problem=8",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -16,5 +16,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Sieve of Eratosthenes at Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes"
+  "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": true,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "ntshcalleia",
@@ -11,10 +12,17 @@
     "smb26"
   ],
   "files": {
-    "solution": ["sieve.js"],
-    "test": ["sieve.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "sieve.js"
+    ],
+    "test": [
+      "sieve.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
   "source": "Sieve of Eratosthenes at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes",
   "custom": {

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -23,5 +23,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Substitution Cipher at Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/Substitution_cipher"
+  "source_url": "http://en.wikipedia.org/wiki/Substitution_cipher",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Implement a simple shift cipher like Caesar and a more secure substitution cipher",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "daveyarwood",
@@ -18,10 +19,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["simple-cipher.js"],
-    "test": ["simple-cipher.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "simple-cipher.js"
+    ],
+    "test": [
+      "simple-cipher.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement a simple shift cipher like Caesar and a more secure substitution cipher",
   "source": "Substitution Cipher at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Substitution_cipher",
   "custom": {

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -13,5 +13,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists.",
-  "source_url": "https://web.archive.org/web/20160731005714/http://brpreiss.com/books/opus8/html/page96.html"
+  "source_url": "https://web.archive.org/web/20160731005714/http://brpreiss.com/books/opus8/html/page96.html",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Write a simple linked list implementation that uses Elements and a List",
-  "authors": ["apapirovski"],
+  "authors": [
+    "apapirovski"
+  ],
   "contributors": [
     "maruthimohan",
     "matthewmorgan",
@@ -8,10 +9,17 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": ["simple-linked-list.js"],
-    "test": ["simple-linked-list.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "simple-linked-list.js"
+    ],
+    "test": [
+      "simple-linked-list.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Write a simple linked list implementation that uses Elements and a List",
   "source": "Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists.",
   "source_url": "https://web.archive.org/web/20160731005714/http://brpreiss.com/books/opus8/html/page96.html",
   "custom": {

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -21,5 +21,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=01"
+  "source_url": "http://pine.fm/LearnToProgram/?Chapter=01",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "cmccandless",
@@ -16,10 +17,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["space-age.js"],
-    "test": ["space-age.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "space-age.js"
+    ],
+    "test": [
+      "space-age.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=01",
   "custom": {

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": " Given the size, return a square matrix of numbers in spiral order.",
-  "authors": ["MattH-be"],
+  "authors": [
+    "MattH-be"
+  ],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -10,10 +11,17 @@
     "ProProgrammer2504"
   ],
   "files": {
-    "solution": ["spiral-matrix.js"],
-    "test": ["spiral-matrix.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "spiral-matrix.js"
+    ],
+    "test": [
+      "spiral-matrix.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": " Given the size, return a square matrix of numbers in spiral order.",
   "source": "Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension.",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/",
   "custom": {

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension.",
-  "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/"
+  "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/square-root/.meta/config.json
+++ b/exercises/practice/square-root/.meta/config.json
@@ -1,12 +1,23 @@
 {
-  "blurb": "Given a natural radicand, return its square root.",
-  "authors": ["evelynstender"],
-  "contributors": ["SleeplessByte", "zimmah"],
+  "authors": [
+    "evelynstender"
+  ],
+  "contributors": [
+    "SleeplessByte",
+    "zimmah"
+  ],
   "files": {
-    "solution": ["square-root.js"],
-    "test": ["square-root.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "square-root.js"
+    ],
+    "test": [
+      "square-root.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a natural radicand, return its square root.",
   "source": "wolf99",
   "source_url": "https://github.com/exercism/problem-specifications/pull/1582",
   "custom": {

--- a/exercises/practice/square-root/.meta/config.json
+++ b/exercises/practice/square-root/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "wolf99",
-  "source_url": "https://github.com/exercism/problem-specifications/pull/1582"
+  "source_url": "https://github.com/exercism/problem-specifications/pull/1582",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -10,10 +11,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["strain.js"],
-    "test": ["strain.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "strain.js"
+    ],
+    "test": [
+      "strain.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2",
   "custom": {

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Conversation with James Edward Gray II",
-  "source_url": "https://twitter.com/jeg2"
+  "source_url": "https://twitter.com/jeg2",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Write a function to determine if a list is a sublist of another list.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "rchavarria",
@@ -9,10 +10,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["sublist.js"],
-    "test": ["sublist.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "sublist.js"
+    ],
+    "test": [
+      "sublist.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Write a function to determine if a list is a sublist of another list.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -12,5 +12,11 @@
     "solution": ["sublist.js"],
     "test": ["sublist.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "hayashi-ay",
@@ -12,10 +13,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["sum-of-multiples.js"],
-    "test": ["sum-of-multiples.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "sum-of-multiples.js"
+    ],
+    "test": [
+      "sum-of-multiples.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
   "source": "A variation on Problem 1 at Project Euler",
   "source_url": "http://projecteuler.net/problem=1",
   "custom": {

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -17,5 +17,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "A variation on Problem 1 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=1"
+  "source_url": "http://projecteuler.net/problem=1",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/tournament/.meta/config.json
+++ b/exercises/practice/tournament/.meta/config.json
@@ -1,12 +1,19 @@
 {
-  "blurb": "Tally the results of a small football competition.",
-  "authors": ["lpizzinidev"],
-  "contributors": [],
+  "authors": [
+    "lpizzinidev"
+  ],
   "files": {
-    "solution": ["tournament.js"],
-    "test": ["tournament.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "tournament.js"
+    ],
+    "test": [
+      "tournament.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Tally the results of a small football competition.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/tournament/.meta/config.json
+++ b/exercises/practice/tournament/.meta/config.json
@@ -6,5 +6,11 @@
     "solution": ["tournament.js"],
     "test": ["tournament.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -15,5 +15,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Reddit r/dailyprogrammer challenge #270 [Easy].",
-  "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text"
+  "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Take input text and output it transposed.",
-  "authors": ["RobinCsl"],
+  "authors": [
+    "RobinCsl"
+  ],
   "contributors": [
     "ankorGH",
     "matthewmorgan",
@@ -10,10 +11,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["transpose.js"],
-    "test": ["transpose.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "transpose.js"
+    ],
+    "test": [
+      "transpose.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Take input text and output it transposed.",
   "source": "Reddit r/dailyprogrammer challenge #270 [Easy].",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text",
   "custom": {

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -17,5 +17,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "The Ruby Koans triangle project, parts 1 & 2",
-  "source_url": "http://rubykoans.com"
+  "source_url": "http://rubykoans.com",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "matthewmorgan",
@@ -12,10 +13,17 @@
     "WebCu"
   ],
   "files": {
-    "solution": ["triangle.js"],
-    "test": ["triangle.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "triangle.js"
+    ],
+    "test": [
+      "triangle.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
   "source": "The Ruby Koans triangle project, parts 1 & 2",
   "source_url": "http://rubykoans.com",
   "custom": {

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -16,5 +16,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "All of Computer Science",
-  "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"
+  "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "msomji",
@@ -11,10 +12,17 @@
     "xarxziux"
   ],
   "files": {
-    "solution": ["trinary.js"],
-    "test": ["trinary.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "trinary.js"
+    ],
+    "test": [
+      "trinary.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.",
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-",
   "custom": {

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -14,5 +14,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)"
+  "source_url": "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
-  "authors": ["AakashMallik"],
+  "authors": [
+    "AakashMallik"
+  ],
   "contributors": [
     "ankorGH",
     "cmccandless",
@@ -9,10 +10,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["twelve-days.js"],
-    "test": ["twelve-days.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "twelve-days.js"
+    ],
+    "test": [
+      "twelve-days.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)",
   "custom": {

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given two buckets of different size, demonstrate how to measure an exact number of liters.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "ankorGH",
     "ganderzz",
@@ -11,10 +12,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["two-bucket.js"],
-    "test": ["two-bucket.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "two-bucket.js"
+    ],
+    "test": [
+      "two-bucket.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given two buckets of different size, demonstrate how to measure an exact number of liters.",
   "source": "Water Pouring Problem",
   "source_url": "http://demonstrations.wolfram.com/WaterPouringProblem/",
   "custom": {

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -16,5 +16,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Water Pouring Problem",
-  "source_url": "http://demonstrations.wolfram.com/WaterPouringProblem/"
+  "source_url": "http://demonstrations.wolfram.com/WaterPouringProblem/",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,12 +1,24 @@
 {
-  "blurb": "Create a sentence of the form \"One for X, one for me.\"",
-  "authors": ["laurmurclar"],
-  "contributors": ["mluisamc", "serixscorpio", "SleeplessByte"],
+  "authors": [
+    "laurmurclar"
+  ],
+  "contributors": [
+    "mluisamc",
+    "serixscorpio",
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["two-fer.js"],
-    "test": ["two-fer.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "two-fer.js"
+    ],
+    "test": [
+      "two-fer.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Create a sentence of the form \"One for X, one for me.\"",
   "source_url": "https://github.com/exercism/problem-specifications/issues/757",
   "custom": {
     "version.tests.compatibility": "jest-27",

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -7,5 +7,11 @@
     "test": ["two-fer.spec.js"],
     "example": [".meta/proof.ci.js"]
   },
-  "source_url": "https://github.com/exercism/problem-specifications/issues/757"
+  "source_url": "https://github.com/exercism/problem-specifications/issues/757",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -1,12 +1,25 @@
 {
-  "blurb": "Implement variable length quantity encoding and decoding.",
-  "authors": ["matthewmorgan"],
-  "contributors": ["ankorGH", "hayashi-ay", "SleeplessByte", "smb26"],
+  "authors": [
+    "matthewmorgan"
+  ],
+  "contributors": [
+    "ankorGH",
+    "hayashi-ay",
+    "SleeplessByte",
+    "smb26"
+  ],
   "files": {
-    "solution": ["variable-length-quantity.js"],
-    "test": ["variable-length-quantity.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "variable-length-quantity.js"
+    ],
+    "test": [
+      "variable-length-quantity.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Implement variable length quantity encoding and decoding.",
   "source": "A poor Splice developer having to implement MIDI encoding/decoding.",
   "source_url": "https://splice.com",
   "custom": {

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "A poor Splice developer having to implement MIDI encoding/decoding.",
-  "source_url": "https://splice.com"
+  "source_url": "https://splice.com",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -18,5 +18,11 @@
     "test": ["word-count.spec.js"],
     "example": [".meta/proof.ci.js"]
   },
-  "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour."
+  "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
-  "authors": ["rchavarria"],
+  "authors": [
+    "rchavarria"
+  ],
   "contributors": [
     "ankorGH",
     "draalger",
@@ -14,10 +15,17 @@
     "ZacharyRSmith"
   ],
   "files": {
-    "solution": ["word-count.js"],
-    "test": ["word-count.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "word-count.js"
+    ],
+    "test": [
+      "word-count.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.",
   "custom": {
     "version.tests.compatibility": "jest-27",

--- a/exercises/practice/word-search/.meta/config.json
+++ b/exercises/practice/word-search/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Create a program to solve a word search puzzle.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "hyuko21",
     "ivanvotti",
@@ -9,10 +10,17 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": ["word-search.js"],
-    "test": ["word-search.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "word-search.js"
+    ],
+    "test": [
+      "word-search.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Create a program to solve a word search puzzle.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/word-search/.meta/config.json
+++ b/exercises/practice/word-search/.meta/config.json
@@ -12,5 +12,11 @@
     "solution": ["word-search.js"],
     "test": ["word-search.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -16,5 +16,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Inspired by one of the generated questions in the Extreme Startup game.",
-  "source_url": "https://github.com/rchatley/extreme_startup"
+  "source_url": "https://github.com/rchatley/extreme_startup",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "hyuko21",
     "msomji",
@@ -11,10 +12,17 @@
     "SleeplessByte"
   ],
   "files": {
-    "solution": ["wordy.js"],
-    "test": ["wordy.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "wordy.js"
+    ],
+    "test": [
+      "wordy.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
   "source": "Inspired by one of the generated questions in the Extreme Startup game.",
   "source_url": "https://github.com/rchatley/extreme_startup",
   "custom": {

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "James Kilfiger, using wikipedia",
-  "source_url": "https://en.wikipedia.org/wiki/Yacht_(dice_game)"
+  "source_url": "https://en.wikipedia.org/wiki/Yacht_(dice_game)",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -1,12 +1,22 @@
 {
-  "blurb": "Score a single throw of dice in the game Yacht",
-  "authors": ["ovidiu141"],
-  "contributors": ["SleeplessByte"],
+  "authors": [
+    "ovidiu141"
+  ],
+  "contributors": [
+    "SleeplessByte"
+  ],
   "files": {
-    "solution": ["yacht.js"],
-    "test": ["yacht.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "yacht.js"
+    ],
+    "test": [
+      "yacht.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Score a single throw of dice in the game Yacht",
   "source": "James Kilfiger, using wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Yacht_(dice_game)",
   "custom": {

--- a/exercises/practice/zebra-puzzle/.meta/config.json
+++ b/exercises/practice/zebra-puzzle/.meta/config.json
@@ -1,12 +1,19 @@
 {
-  "blurb": "Solve the zebra puzzle.",
-  "authors": ["lpizzinidev"],
-  "contributors": [],
+  "authors": [
+    "lpizzinidev"
+  ],
   "files": {
-    "solution": ["zebra-puzzle.js"],
-    "test": ["zebra-puzzle.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "zebra-puzzle.js"
+    ],
+    "test": [
+      "zebra-puzzle.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Solve the zebra puzzle.",
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Zebra_Puzzle",
   "custom": {

--- a/exercises/practice/zebra-puzzle/.meta/config.json
+++ b/exercises/practice/zebra-puzzle/.meta/config.json
@@ -8,5 +8,11 @@
     "example": [".meta/proof.ci.js"]
   },
   "source": "Wikipedia",
-  "source_url": "https://en.wikipedia.org/wiki/Zebra_Puzzle"
+  "source_url": "https://en.wikipedia.org/wiki/Zebra_Puzzle",
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
+  }
 }

--- a/exercises/practice/zipper/.meta/config.json
+++ b/exercises/practice/zipper/.meta/config.json
@@ -1,6 +1,7 @@
 {
-  "blurb": "Creating a zipper for a binary tree.",
-  "authors": ["matthewmorgan"],
+  "authors": [
+    "matthewmorgan"
+  ],
   "contributors": [
     "felbit",
     "ganderzz",
@@ -10,10 +11,17 @@
     "tejasbubane"
   ],
   "files": {
-    "solution": ["zipper.js"],
-    "test": ["zipper.spec.js"],
-    "example": [".meta/proof.ci.js"]
+    "solution": [
+      "zipper.js"
+    ],
+    "test": [
+      "zipper.spec.js"
+    ],
+    "example": [
+      ".meta/proof.ci.js"
+    ]
   },
+  "blurb": "Creating a zipper for a binary tree.",
   "custom": {
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,

--- a/exercises/practice/zipper/.meta/config.json
+++ b/exercises/practice/zipper/.meta/config.json
@@ -13,5 +13,11 @@
     "solution": ["zipper.js"],
     "test": ["zipper.spec.js"],
     "example": [".meta/proof.ci.js"]
+  },
+  "custom": {
+    "version.tests.compatibility": "jest-27",
+    "flag.tests.task-per-describe": false,
+    "flag.tests.may-run-long": false,
+    "flag.tests.includes-optional": false
   }
 }


### PR DESCRIPTION
Supports https://github.com/exercism/javascript-test-runner/pull/79.

This adds hand-written flags to the `.meta/config.json` files to be consumed by our tooling.

```json
"version.tests.compatibility": "jest-27"
```

This doesn't do anything by itself, but jest 27 is technically a breaking change. Adding this to our config files allows us to:

- separate exercises that have been updated vs. those that are on pre-27 versions
- give special error messages if something timeout related happens. Why? Jest 27 imposes a standard 5s timeout on each individual `test`.
- track unupdated exercises the next time jest is breaking

```json
"flag.tests.task-per-describe": true
```
This should generally be `true` for all `concept` exercises and `false` for all `practice` exercises. When `true`, the test-runner can calculate the `task_id` based on the `describe` in the test files. This PR also contains updates to the spec files to match this newly imposed format.

```json
"flag.tests.may-run-long": false
```
When we see students complain about timeouts on naive implementations, we should turn this to true. Doesn't do something right now, but if we see it a lot, we can use it to actually impose a _shorter_ timeout (in the runner) and then show guided help.

```json
"flag.tests.includes-optional": false
```
When true, skipped tests with `test.skip` are present and optional. This allows us to:
- enforce in the test-runner that there are only skipped tests if this is true
- add a message in the analyzer that there are optional tests that the student can run via the CLI. We can add an informational message with data how to do that, even if they did run this via the CLI.