### PR TITLE
Make translation service more resilient against bad implementations

### DIFF
--- a/exercises/concept/translation-service/api.js
+++ b/exercises/concept/translation-service/api.js
@@ -39,6 +39,12 @@ export class ExternalApi {
    * @returns {Promise<Translation>}
    */
   fetch(text) {
+    if (typeof text !== 'string') {
+      throw new BadRequest(
+        `Expected text when calling fetch(text), actual ${typeof text}.`
+      );
+    }
+
     // Check if client is banned
     if (mutex.current) {
       return rejectWithRandomDelay(new AbusiveClientError());
@@ -60,6 +66,18 @@ export class ExternalApi {
    * @param {(err?: Error) => void} callback
    */
   request(text, callback) {
+    if (typeof text !== 'string') {
+      throw new BadRequest(
+        `Expected string text when calling request(text, callback), actual ${typeof text}.`
+      );
+    }
+
+    if (typeof callback !== 'function') {
+      throw new BadRequest(
+        `Expected callback function when calling fetch(text, callback), actual ${typeof callback}.`
+      );
+    }
+
     if (this.values[text] && this.values[text][0]) {
       mutex.current = true;
       callback(new AbusiveClientError());
@@ -97,4 +115,10 @@ function rejectWithRandomDelay(value) {
 
 function makeRandomError() {
   return new Error(`Error code ${Math.ceil(Math.random() * 10000)}`);
+}
+
+class BadRequest extends Error {
+  constructor(message) {
+    super(message);
+  }
 }


### PR DESCRIPTION
With this change, a faulty implementation when calling the API results in the respective test failing with the following message:

```text
Error: Expected callback function when calling fetch(text, callback), actual undefined.
    at new BadRequest (<solution>\api.js:122:5)
    at ExternalApi.request (<solution>\api.js:76:13)
    at TranslationService.request (<solution>\service.js:61:21)",
```

Without this change, the entire test run blows up and returns:

```json
{
  "status": "error",
  "message": "Expected to run at least one test, but none were found. This can happen if the test file(s) (.spec.js) are missing or empty. These files are normally not empty. Revert any changes or report an issue if the problem persists.",
  "tests": [],
  "version": 3
}
```

Because under the hood it shows:

```text
Determining test suites to run...<solution>\api.js:97       
      setTimeout(() => callback(this.values[text][0] ? undefined : makeRandomError()), 1);
                       ^

TypeError: callback is not a function
    at Timeout._onTimeout (<solution>\api.js:86:15)
    at listOnTimeout (node:internal/timers:557:17)
    at processTimers (node:internal/timers:500:7)
```