### PR TITLE
Fix up test case checks

### DIFF
--- a/exercises/practice/bank-account/bank-account.spec.js
+++ b/exercises/practice/bank-account/bank-account.spec.js
@@ -7,14 +7,14 @@ describe('Bank Account', () => {
     expect(account.balance).toEqual(0);
   });
 
-  test('can deposit money', () => {
+  xtest('can deposit money', () => {
     const account = new BankAccount();
     account.open();
     account.deposit(100);
     expect(account.balance).toEqual(100);
   });
 
-  test('can deposit money sequentially', () => {
+  xtest('can deposit money sequentially', () => {
     const account = new BankAccount();
     account.open();
     account.deposit(100);
@@ -22,7 +22,7 @@ describe('Bank Account', () => {
     expect(account.balance).toEqual(150);
   });
 
-  test('can withdraw money', () => {
+  xtest('can withdraw money', () => {
     const account = new BankAccount();
     account.open();
     account.deposit(100);
@@ -30,7 +30,7 @@ describe('Bank Account', () => {
     expect(account.balance).toEqual(50);
   });
 
-  test('can withdraw money sequentially', () => {
+  xtest('can withdraw money sequentially', () => {
     const account = new BankAccount();
     account.open();
     account.deposit(100);
@@ -39,14 +39,14 @@ describe('Bank Account', () => {
     expect(account.balance).toEqual(0);
   });
 
-  test('checking balance of closed account throws error', () => {
+  xtest('checking balance of closed account throws error', () => {
     const account = new BankAccount();
     account.open();
     account.close();
     expect(() => account.balance).toThrow(ValueError);
   });
 
-  test('deposit into closed account throws error', () => {
+  xtest('deposit into closed account throws error', () => {
     const account = new BankAccount();
     account.open();
     account.close();
@@ -55,7 +55,7 @@ describe('Bank Account', () => {
     }).toThrow(ValueError);
   });
 
-  test('withdraw from closed account throws error', () => {
+  xtest('withdraw from closed account throws error', () => {
     const account = new BankAccount();
     account.open();
     account.close();
@@ -64,14 +64,14 @@ describe('Bank Account', () => {
     }).toThrow(ValueError);
   });
 
-  test('close already closed account throws error', () => {
+  xtest('close already closed account throws error', () => {
     const account = new BankAccount();
     expect(() => {
       account.close();
     }).toThrow(ValueError);
   });
 
-  test('open already opened account throws error', () => {
+  xtest('open already opened account throws error', () => {
     const account = new BankAccount();
     account.open();
     expect(() => {
@@ -79,7 +79,7 @@ describe('Bank Account', () => {
     }).toThrow(ValueError);
   });
 
-  test('reopened account does not retain balance', () => {
+  xtest('reopened account does not retain balance', () => {
     const account = new BankAccount();
     account.open();
     account.deposit(50);
@@ -88,7 +88,7 @@ describe('Bank Account', () => {
     expect(account.balance).toEqual(0);
   });
 
-  test('cannot withdraw more than deposited', () => {
+  xtest('cannot withdraw more than deposited', () => {
     const account = new BankAccount();
     account.open();
     account.deposit(25);
@@ -97,7 +97,7 @@ describe('Bank Account', () => {
     }).toThrow(ValueError);
   });
 
-  test('cannot withdraw negative amount', () => {
+  xtest('cannot withdraw negative amount', () => {
     const account = new BankAccount();
     account.open();
     account.deposit(100);
@@ -106,7 +106,7 @@ describe('Bank Account', () => {
     }).toThrow(ValueError);
   });
 
-  test('cannot deposit negative amount', () => {
+  xtest('cannot deposit negative amount', () => {
     const account = new BankAccount();
     account.open();
     expect(() => {
@@ -114,7 +114,7 @@ describe('Bank Account', () => {
     }).toThrow(ValueError);
   });
 
-  test('changing balance directly throws error', () => {
+  xtest('changing balance directly throws error', () => {
     const account = new BankAccount();
     account.open();
     expect(() => {

--- a/exercises/practice/crypto-square/crypto-square.spec.js
+++ b/exercises/practice/crypto-square/crypto-square.spec.js
@@ -6,17 +6,17 @@ describe('Crypto', () => {
     expect(crypto.ciphertext).toEqual('');
   });
 
-  test('Lowercase', () => {
+  xtest('Lowercase', () => {
     const crypto = new Crypto('A');
     expect(crypto.ciphertext).toEqual('a');
   });
 
-  test('Remove spaces', () => {
+  xtest('Remove spaces', () => {
     const crypto = new Crypto('  b ');
     expect(crypto.ciphertext).toEqual('b');
   });
 
-  test('Remove punctuation', () => {
+  xtest('Remove punctuation', () => {
     const crypto = new Crypto('@1,%!');
     expect(crypto.ciphertext).toEqual('1');
   });

--- a/exercises/practice/dominoes/dominoes.spec.js
+++ b/exercises/practice/dominoes/dominoes.spec.js
@@ -23,11 +23,11 @@ function runTestsExpectingChain(dominoes) {
     expect(result).not.toBe(null);
   });
 
-  it('The number of dominoes in the output equals the number of dominoes in the input.', () => {
+  xit('The number of dominoes in the output equals the number of dominoes in the input.', () => {
     expect(result).toHaveLength(dominoes.length);
   });
 
-  it('For each adjacent pair of dominoes ... (a, b), (c, d) ...: b is equal to c.', () => {
+  xit('For each adjacent pair of dominoes ... (a, b), (c, d) ...: b is equal to c.', () => {
     expect(
       result
         .map((v, i) => {
@@ -39,14 +39,14 @@ function runTestsExpectingChain(dominoes) {
   });
 
   if (dominoes.length > 0) {
-    it('For the dominoes on the ends (a, b) ... (c, d): a is equal to d.', () => {
+    xit('For the dominoes on the ends (a, b) ... (c, d): a is equal to d.', () => {
       expect(result[0][0] === result[result.length - 1][1]).toBe(true);
     });
   }
 
   // 4. Every domino appears in the output an equal number of times as the number of times it appears in the input.
   // (in other words, the dominoes in the output are the same dominoes as the ones in the input)
-  it('Should have the same dominoes', () => {
+  xit('Should have the same dominoes', () => {
     const sortDomino = (domino) => [...domino].sort();
     expect([...dominoes].map(sortDomino).sort()).toEqual(
       [...result].map(sortDomino).sort()

--- a/exercises/practice/go-counting/go-counting.spec.js
+++ b/exercises/practice/go-counting/go-counting.spec.js
@@ -16,14 +16,14 @@ describe('Go Counting', () => {
       expect(goCounting.getTerritory(0, 1)).toEqual(expectedTerritory);
     });
 
-    test('White center territory on 5x5 board', () => {
+    xtest('White center territory on 5x5 board', () => {
       const board = ['  B  ', ' B B ', 'B W B', ' W W ', '  W  '];
       const goCounting = new GoCounting(board);
       const expectedTerritory = { owner: 'WHITE', territory: [[2, 3]] };
       expect(goCounting.getTerritory(2, 3)).toEqual(expectedTerritory);
     });
 
-    test('Open corner territory on 5x5 board', () => {
+    xtest('Open corner territory on 5x5 board', () => {
       const board = ['  B  ', ' B B ', 'B W B', ' W W ', '  W  '];
       const goCounting = new GoCounting(board);
       const expectedTerritory = {
@@ -37,35 +37,35 @@ describe('Go Counting', () => {
       expect(goCounting.getTerritory(1, 4)).toEqual(expectedTerritory);
     });
 
-    test('A stone and not a territory on 5x5 board', () => {
+    xtest('A stone and not a territory on 5x5 board', () => {
       const board = ['  B  ', ' B B ', 'B W B', ' W W ', '  W  '];
       const goCounting = new GoCounting(board);
       const expectedTerritory = { owner: 'NONE', territory: [] };
       expect(goCounting.getTerritory(1, 1)).toEqual(expectedTerritory);
     });
 
-    test('Invalid because X is too low for 5x5 board', () => {
+    xtest('Invalid because X is too low for 5x5 board', () => {
       const board = ['  B  ', ' B B ', 'B W B', ' W W ', '  W  '];
       const goCounting = new GoCounting(board);
       const expectedTerritory = { error: 'Invalid coordinate' };
       expect(goCounting.getTerritory(-1, 1)).toEqual(expectedTerritory);
     });
 
-    test('Invalid because X is too high for 5x5 board', () => {
+    xtest('Invalid because X is too high for 5x5 board', () => {
       const board = ['  B  ', ' B B ', 'B W B', ' W W ', '  W  '];
       const goCounting = new GoCounting(board);
       const expectedTerritory = { error: 'Invalid coordinate' };
       expect(goCounting.getTerritory(5, 1)).toEqual(expectedTerritory);
     });
 
-    test('Invalid because Y is too low for 5x5 board', () => {
+    xtest('Invalid because Y is too low for 5x5 board', () => {
       const board = ['  B  ', ' B B ', 'B W B', ' W W ', '  W  '];
       const goCounting = new GoCounting(board);
       const expectedTerritory = { error: 'Invalid coordinate' };
       expect(goCounting.getTerritory(1, -1)).toEqual(expectedTerritory);
     });
 
-    test('Invalid because Y is too high for 5x5 board', () => {
+    xtest('Invalid because Y is too high for 5x5 board', () => {
       const board = ['  B  ', ' B B ', 'B W B', ' W W ', '  W  '];
       const goCounting = new GoCounting(board);
       const expectedTerritory = { error: 'Invalid coordinate' };
@@ -74,7 +74,7 @@ describe('Go Counting', () => {
   });
 
   describe('getTerritories', () => {
-    test('One territory is the whole board', () => {
+    xtest('One territory is the whole board', () => {
       const board = [' '];
       const goCounting = new GoCounting(board);
       const expectedTerritories = {
@@ -85,7 +85,7 @@ describe('Go Counting', () => {
       expect(goCounting.getTerritories()).toEqual(expectedTerritories);
     });
 
-    test('Two territory rectangular board', () => {
+    xtest('Two territory rectangular board', () => {
       const board = [' BW ', ' BW '];
       const goCounting = new GoCounting(board);
       const expectedTerritories = {
@@ -102,7 +102,7 @@ describe('Go Counting', () => {
       expect(goCounting.getTerritories()).toEqual(expectedTerritories);
     });
 
-    test('Two region rectangular board', () => {
+    xtest('Two region rectangular board', () => {
       const board = [' B '];
       const goCounting = new GoCounting(board);
       const expectedTerritories = {

--- a/exercises/practice/rail-fence-cipher/rail-fence-cipher.spec.js
+++ b/exercises/practice/rail-fence-cipher/rail-fence-cipher.spec.js
@@ -6,25 +6,25 @@ describe('Rail Fence Cipher', () => {
       const fence = encode('XOXOXOXOXOXOXOXOXO', 2);
       expect(fence).toEqual('XXXXXXXXXOOOOOOOOO');
     });
-    test('encode with three rails', () => {
+    xtest('encode with three rails', () => {
       const fence = encode('WEAREDISCOVEREDFLEEATONCE', 3);
       expect(fence).toEqual('WECRLTEERDSOEEFEAOCAIVDEN');
     });
-    test('encode with ending in the middle', () => {
+    xtest('encode with ending in the middle', () => {
       const fence = encode('EXERCISES', 4);
       expect(fence).toEqual('ESXIEECSR');
     });
   });
   describe('decode', () => {
-    test('decode with three rails', () => {
+    xtest('decode with three rails', () => {
       const fence = decode('TEITELHDVLSNHDTISEIIEA', 3);
       expect(fence).toEqual('THEDEVILISINTHEDETAILS');
     });
-    test('decode with five rails', () => {
+    xtest('decode with five rails', () => {
       const fence = decode('EIEXMSMESAORIWSCE', 5);
       expect(fence).toEqual('EXERCISMISAWESOME');
     });
-    test('decode with six rails', () => {
+    xtest('decode with six rails', () => {
       const encodedString =
         '133714114238148966225439541018335470986172518171757571896261';
       const fence = decode(encodedString, 6);

--- a/exercises/practice/rest-api/rest-api.spec.js
+++ b/exercises/practice/rest-api/rest-api.spec.js
@@ -7,7 +7,7 @@ describe('Rest API', () => {
       expect(restAPI.get('/users')).toEqual({ users: [] });
     });
 
-    test('add user', () => {
+    xtest('add user', () => {
       const restAPI = new RestAPI({ users: [] });
       expect(restAPI.post('/add', { user: 'Adam' })).toEqual({
         name: 'Adam',
@@ -17,7 +17,7 @@ describe('Rest API', () => {
       });
     });
 
-    test('get single user', () => {
+    xtest('get single user', () => {
       const seedUsers = [
         { name: 'Adam', owes: {}, owed_by: {}, balance: 0 },
         { name: 'Bob', owes: {}, owed_by: {}, balance: 0 },
@@ -31,7 +31,7 @@ describe('Rest API', () => {
   });
 
   describe('iou', () => {
-    test('both users have 0 balance', () => {
+    xtest('both users have 0 balance', () => {
       const seedUsers = [
         { name: 'Adam', owes: {}, owed_by: {}, balance: 0 },
         { name: 'Bob', owes: {}, owed_by: {}, balance: 0 },
@@ -45,7 +45,7 @@ describe('Rest API', () => {
       expect(restAPI.post('/iou', payload)).toEqual({ users: expectedUsers });
     });
 
-    test('borrower has negative balance', () => {
+    xtest('borrower has negative balance', () => {
       const seedUsers = [
         { name: 'Adam', owes: {}, owed_by: {}, balance: 0 },
         { name: 'Bob', owes: { Chuck: 3 }, owed_by: {}, balance: -3 },
@@ -60,7 +60,7 @@ describe('Rest API', () => {
       expect(restAPI.post('/iou', payload)).toEqual({ users: expectedUsers });
     });
 
-    test('lender has negative balance', () => {
+    xtest('lender has negative balance', () => {
       const seedUsers = [
         { name: 'Adam', owes: {}, owed_by: {}, balance: 0 },
         { name: 'Bob', owes: { Chuck: 3 }, owed_by: {}, balance: -3 },
@@ -75,7 +75,7 @@ describe('Rest API', () => {
       expect(restAPI.post('/iou', payload)).toEqual({ users: expectedUsers });
     });
 
-    test('lender owes borrower', () => {
+    xtest('lender owes borrower', () => {
       const seedUsers = [
         { name: 'Adam', owes: { Bob: 3 }, owed_by: {}, balance: -3 },
         { name: 'Bob', owes: {}, owed_by: { Adam: 3 }, balance: 3 },
@@ -89,7 +89,7 @@ describe('Rest API', () => {
       expect(restAPI.post('/iou', payload)).toEqual({ users: expectedUsers });
     });
 
-    test('lender owes borrower less than new loan', () => {
+    xtest('lender owes borrower less than new loan', () => {
       const seedUsers = [
         { name: 'Adam', owes: { Bob: 3 }, owed_by: {}, balance: -3 },
         { name: 'Bob', owes: {}, owed_by: { Adam: 3 }, balance: 3 },
@@ -103,7 +103,7 @@ describe('Rest API', () => {
       expect(restAPI.post('/iou', payload)).toEqual({ users: expectedUsers });
     });
 
-    test('lender owes borrower same as new loan', () => {
+    xtest('lender owes borrower same as new loan', () => {
       const seedUsers = [
         { name: 'Adam', owes: { Bob: 3 }, owed_by: {}, balance: -3 },
         { name: 'Bob', owes: {}, owed_by: { Adam: 3 }, balance: 3 },

--- a/exercises/practice/robot-simulator/robot-simulator.spec.js
+++ b/exercises/practice/robot-simulator/robot-simulator.spec.js
@@ -19,14 +19,14 @@ describe('Robot', () => {
       expect(robot.bearing).toEqual('north');
     });
 
-    test('facing east', () => {
+    xtest('facing east', () => {
       const robot = new Robot();
       robot.place({ direction: 'east', x: 0, y: 0 });
 
       expect(robot.bearing).toEqual('east');
     });
 
-    test('facing west, at origin', () => {
+    xtest('facing west, at origin', () => {
       const robot = new Robot();
       robot.place({ direction: 'west', x: 0, y: 0 });
 
@@ -34,7 +34,7 @@ describe('Robot', () => {
       expect(robot.coordinates).toEqual([0, 0]);
     });
 
-    test('at negative position facing south', () => {
+    xtest('at negative position facing south', () => {
       const robot = new Robot();
       robot.place({ direction: 'south', x: -1, y: -1 });
 

--- a/exercises/practice/satellite/satellite.spec.js
+++ b/exercises/practice/satellite/satellite.spec.js
@@ -5,12 +5,12 @@ describe('Satellite', () => {
     expect(treeFromTraversals([], [])).toEqual({});
   });
 
-  test('Tree with one item', () => {
+  xtest('Tree with one item', () => {
     const expected = { value: 'a', left: {}, right: {} };
     expect(treeFromTraversals(['a'], ['a'])).toEqual(expected);
   });
 
-  test('Tree with many items', () => {
+  xtest('Tree with many items', () => {
     const preorder = ['a', 'i', 'x', 'f', 'r'];
     const inorder = ['i', 'a', 'f', 'x', 'r'];
     const expected = {
@@ -25,7 +25,7 @@ describe('Satellite', () => {
     expect(treeFromTraversals(preorder, inorder)).toEqual(expected);
   });
 
-  test('Reject traversals of different length', () => {
+  xtest('Reject traversals of different length', () => {
     const preorder = ['a', 'b'];
     const inorder = ['b', 'a', 'r'];
     expect(() => {
@@ -33,7 +33,7 @@ describe('Satellite', () => {
     }).toThrow(new Error('traversals must have the same length'));
   });
 
-  test('Reject inconsistent traversals of same length', () => {
+  xtest('Reject inconsistent traversals of same length', () => {
     const preorder = ['x', 'y', 'z'];
     const inorder = ['a', 'b', 'c'];
     expect(() => {
@@ -41,7 +41,7 @@ describe('Satellite', () => {
     }).toThrow(new Error('traversals must have the same elements'));
   });
 
-  test('Reject traversals with repeated items', () => {
+  xtest('Reject traversals with repeated items', () => {
     const preorder = ['a', 'b', 'a'];
     const inorder = ['b', 'a', 'a'];
     expect(() => {

--- a/exercises/practice/series/series.spec.js
+++ b/exercises/practice/series/series.spec.js
@@ -1,7 +1,7 @@
 import { Series } from './series';
 
 describe('Series', () => {
-  xtest('slices of one from one', () => {
+  test('slices of one from one', () => {
     expect(new Series('1').slices(1)).toEqual([[1]]);
   });
 

--- a/exercises/practice/tournament/tournament.spec.js
+++ b/exercises/practice/tournament/tournament.spec.js
@@ -6,7 +6,7 @@ describe('Tournament', () => {
     const expected = 'Team                           | MP |  W |  D |  L |  P';
     expect(tally).toEqual(expected);
   });
-  test('a win is three points, a loss is zero points', () => {
+  xtest('a win is three points, a loss is zero points', () => {
     const tally = tournamentTally('Allegoric Alaskans;Blithering Badgers;win');
     const expected =
       'Team                           | MP |  W |  D |  L |  P\n' +
@@ -14,7 +14,7 @@ describe('Tournament', () => {
       'Blithering Badgers             |  1 |  0 |  0 |  1 |  0';
     expect(tally).toEqual(expected);
   });
-  test('a win can also be expressed as a loss', () => {
+  xtest('a win can also be expressed as a loss', () => {
     const tally = tournamentTally('Blithering Badgers;Allegoric Alaskans;loss');
     const expected =
       'Team                           | MP |  W |  D |  L |  P\n' +
@@ -22,7 +22,7 @@ describe('Tournament', () => {
       'Blithering Badgers             |  1 |  0 |  0 |  1 |  0';
     expect(tally).toEqual(expected);
   });
-  test('a different team can win', () => {
+  xtest('a different team can win', () => {
     const tally = tournamentTally('Blithering Badgers;Allegoric Alaskans;win');
     const expected =
       'Team                           | MP |  W |  D |  L |  P\n' +
@@ -30,7 +30,7 @@ describe('Tournament', () => {
       'Allegoric Alaskans             |  1 |  0 |  0 |  1 |  0';
     expect(tally).toEqual(expected);
   });
-  test('a draw is one point each', () => {
+  xtest('a draw is one point each', () => {
     const tally = tournamentTally('Allegoric Alaskans;Blithering Badgers;draw');
     const expected =
       'Team                           | MP |  W |  D |  L |  P\n' +
@@ -38,7 +38,7 @@ describe('Tournament', () => {
       'Blithering Badgers             |  1 |  0 |  1 |  0 |  1';
     expect(tally).toEqual(expected);
   });
-  test('there can be more than one match', () => {
+  xtest('there can be more than one match', () => {
     const input =
       'Allegoric Alaskans;Blithering Badgers;win\n' +
       'Allegoric Alaskans;Blithering Badgers;win';
@@ -49,7 +49,7 @@ describe('Tournament', () => {
       'Blithering Badgers             |  2 |  0 |  0 |  2 |  0';
     expect(tally).toEqual(expected);
   });
-  test('there can be more than one winner', () => {
+  xtest('there can be more than one winner', () => {
     const input =
       'Allegoric Alaskans;Blithering Badgers;loss\n' +
       'Allegoric Alaskans;Blithering Badgers;win';
@@ -60,7 +60,7 @@ describe('Tournament', () => {
       'Blithering Badgers             |  2 |  1 |  0 |  1 |  3';
     expect(tally).toEqual(expected);
   });
-  test('there can be more than two teams', () => {
+  xtest('there can be more than two teams', () => {
     const input =
       'Allegoric Alaskans;Blithering Badgers;win\n' +
       'Blithering Badgers;Courageous Californians;win\n' +
@@ -73,7 +73,7 @@ describe('Tournament', () => {
       'Courageous Californians        |  2 |  0 |  0 |  2 |  0';
     expect(tally).toEqual(expected);
   });
-  test('typical input', () => {
+  xtest('typical input', () => {
     const input =
       'Allegoric Alaskans;Blithering Badgers;win\n' +
       'Devastating Donkeys;Courageous Californians;draw\n' +
@@ -90,7 +90,7 @@ describe('Tournament', () => {
       'Courageous Californians        |  3 |  0 |  1 |  2 |  1';
     expect(tally).toEqual(expected);
   });
-  test('incomplete competition (not all pairs have played)', () => {
+  xtest('incomplete competition (not all pairs have played)', () => {
     const input =
       'Allegoric Alaskans;Blithering Badgers;loss\n' +
       'Devastating Donkeys;Allegoric Alaskans;loss\n' +
@@ -105,7 +105,7 @@ describe('Tournament', () => {
       'Devastating Donkeys            |  1 |  0 |  0 |  1 |  0';
     expect(tally).toEqual(expected);
   });
-  test('ties broken alphabetically', () => {
+  xtest('ties broken alphabetically', () => {
     const input =
       'Courageous Californians;Devastating Donkeys;win\n' +
       'Allegoric Alaskans;Blithering Badgers;win\n' +
@@ -122,7 +122,7 @@ describe('Tournament', () => {
       'Devastating Donkeys            |  3 |  0 |  1 |  2 |  1';
     expect(tally).toEqual(expected);
   });
-  test('ensure points sorted numerically', () => {
+  xtest('ensure points sorted numerically', () => {
     const input =
       'Devastating Donkeys;Blithering Badgers;win\n' +
       'Devastating Donkeys;Blithering Badgers;win\n' +

--- a/exercises/practice/zebra-puzzle/zebra-puzzle.spec.js
+++ b/exercises/practice/zebra-puzzle/zebra-puzzle.spec.js
@@ -5,7 +5,7 @@ describe('Zebra puzzle', () => {
     const puzzle = new ZebraPuzzle();
     expect(puzzle.waterDrinker()).toEqual('Norwegian');
   });
-  test('resident who owns zebra', () => {
+  xtest('resident who owns zebra', () => {
     const puzzle = new ZebraPuzzle();
     expect(puzzle.zebraOwner()).toEqual('Japanese');
   });


### PR DESCRIPTION
In the test files of the practice exercises, our rule is that the test cases should be marked as skipped and only the first one should be active (un-skipped).
The test files are all the <exercise-slug>.spec.js files in the folder exercises/practice/<exercise-slug>.
