### PR TITLE
Re-add babel core

### DIFF
--- a/exercises/concept/amusement-park/package.json
+++ b/exercises/concept/amusement-park/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/amusement-park"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/amusement-park/package.json
+++ b/exercises/concept/amusement-park/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/annalyns-infiltration/package.json
+++ b/exercises/concept/annalyns-infiltration/package.json
@@ -23,6 +23,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/annalyns-infiltration/package.json
+++ b/exercises/concept/annalyns-infiltration/package.json
@@ -13,6 +13,7 @@
     "directory": "exercises/concept/annalyns-infiltration"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -22,7 +23,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/bird-watcher/package.json
+++ b/exercises/concept/bird-watcher/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/bird-watcher"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/bird-watcher/package.json
+++ b/exercises/concept/bird-watcher/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/coordinate-transformation/package.json
+++ b/exercises/concept/coordinate-transformation/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/coordinate-transformation"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/coordinate-transformation/package.json
+++ b/exercises/concept/coordinate-transformation/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/custom-signs/package.json
+++ b/exercises/concept/custom-signs/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/custom-signs"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/custom-signs/package.json
+++ b/exercises/concept/custom-signs/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/elyses-analytic-enchantments/package.json
+++ b/exercises/concept/elyses-analytic-enchantments/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/elyses-analytic-enchantments"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/elyses-analytic-enchantments/package.json
+++ b/exercises/concept/elyses-analytic-enchantments/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/elyses-destructured-enchantments/package.json
+++ b/exercises/concept/elyses-destructured-enchantments/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/elyses-destructured-enchantments"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/elyses-destructured-enchantments/package.json
+++ b/exercises/concept/elyses-destructured-enchantments/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/elyses-enchantments/package.json
+++ b/exercises/concept/elyses-enchantments/package.json
@@ -13,6 +13,7 @@
     "directory": "exercises/concept/elyses-enchantments"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -22,7 +23,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/elyses-enchantments/package.json
+++ b/exercises/concept/elyses-enchantments/package.json
@@ -23,6 +23,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/elyses-looping-enchantments/package.json
+++ b/exercises/concept/elyses-looping-enchantments/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/elyses-looping-enchantments"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/elyses-looping-enchantments/package.json
+++ b/exercises/concept/elyses-looping-enchantments/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/elyses-transformative-enchantments/package.json
+++ b/exercises/concept/elyses-transformative-enchantments/package.json
@@ -24,6 +24,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/elyses-transformative-enchantments/package.json
+++ b/exercises/concept/elyses-transformative-enchantments/package.json
@@ -14,6 +14,7 @@
     "directory": "exercises/concept/elyses-transformative-enchantments"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -23,7 +24,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/factory-sensors/package.json
+++ b/exercises/concept/factory-sensors/package.json
@@ -19,6 +19,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/factory-sensors/package.json
+++ b/exercises/concept/factory-sensors/package.json
@@ -9,6 +9,7 @@
     "directory": "exercises/concept/factory-sensors"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -18,7 +19,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/freelancer-rates/package.json
+++ b/exercises/concept/freelancer-rates/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/freelancer-rates"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/freelancer-rates/package.json
+++ b/exercises/concept/freelancer-rates/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/fruit-picker/package.json
+++ b/exercises/concept/fruit-picker/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/fruit-picker"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/fruit-picker/package.json
+++ b/exercises/concept/fruit-picker/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/high-score-board/package.json
+++ b/exercises/concept/high-score-board/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/high-score-board"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/high-score-board/package.json
+++ b/exercises/concept/high-score-board/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/lasagna-master/package.json
+++ b/exercises/concept/lasagna-master/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/lasagna-master"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/lasagna-master/package.json
+++ b/exercises/concept/lasagna-master/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/lasagna/package.json
+++ b/exercises/concept/lasagna/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/lasagna"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/lasagna/package.json
+++ b/exercises/concept/lasagna/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/lucky-numbers/package.json
+++ b/exercises/concept/lucky-numbers/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/lucky-numbers"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/lucky-numbers/package.json
+++ b/exercises/concept/lucky-numbers/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/mixed-juices/package.json
+++ b/exercises/concept/mixed-juices/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/mixed-juices"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/mixed-juices/package.json
+++ b/exercises/concept/mixed-juices/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/nullability/package.json
+++ b/exercises/concept/nullability/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/nullability"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/nullability/package.json
+++ b/exercises/concept/nullability/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/ozans-playlist/package.json
+++ b/exercises/concept/ozans-playlist/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/ozans-playlist"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/ozans-playlist/package.json
+++ b/exercises/concept/ozans-playlist/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/pizza-order/package.json
+++ b/exercises/concept/pizza-order/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/pizza-order"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/pizza-order/package.json
+++ b/exercises/concept/pizza-order/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/poetry-club-door-policy/package.json
+++ b/exercises/concept/poetry-club-door-policy/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/poetry-club-door-policy"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/poetry-club-door-policy/package.json
+++ b/exercises/concept/poetry-club-door-policy/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/translation-service/package.json
+++ b/exercises/concept/translation-service/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/translation-service/package.json
+++ b/exercises/concept/translation-service/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/translation-service"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/vehicle-purchase/package.json
+++ b/exercises/concept/vehicle-purchase/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/vehicle-purchase"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/vehicle-purchase/package.json
+++ b/exercises/concept/vehicle-purchase/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/windowing-system/package.json
+++ b/exercises/concept/windowing-system/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/concept/windowing-system"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/concept/windowing-system/package.json
+++ b/exercises/concept/windowing-system/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/accumulate/package.json
+++ b/exercises/practice/accumulate/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/accumulate"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/accumulate/package.json
+++ b/exercises/practice/accumulate/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/acronym/package.json
+++ b/exercises/practice/acronym/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/acronym"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/acronym/package.json
+++ b/exercises/practice/acronym/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/affine-cipher/package.json
+++ b/exercises/practice/affine-cipher/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/affine-cipher"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/affine-cipher/package.json
+++ b/exercises/practice/affine-cipher/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/all-your-base/package.json
+++ b/exercises/practice/all-your-base/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/all-your-base"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/all-your-base/package.json
+++ b/exercises/practice/all-your-base/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/allergies/package.json
+++ b/exercises/practice/allergies/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/allergies/package.json
+++ b/exercises/practice/allergies/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/allergies"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/alphametics/package.json
+++ b/exercises/practice/alphametics/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/alphametics"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/alphametics/package.json
+++ b/exercises/practice/alphametics/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/anagram/package.json
+++ b/exercises/practice/anagram/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/anagram"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/anagram/package.json
+++ b/exercises/practice/anagram/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/armstrong-numbers/package.json
+++ b/exercises/practice/armstrong-numbers/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/armstrong-numbers"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/armstrong-numbers/package.json
+++ b/exercises/practice/armstrong-numbers/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/atbash-cipher/package.json
+++ b/exercises/practice/atbash-cipher/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/atbash-cipher"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/atbash-cipher/package.json
+++ b/exercises/practice/atbash-cipher/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/bank-account/package.json
+++ b/exercises/practice/bank-account/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/bank-account"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/bank-account/package.json
+++ b/exercises/practice/bank-account/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/beer-song/package.json
+++ b/exercises/practice/beer-song/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/beer-song"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/beer-song/package.json
+++ b/exercises/practice/beer-song/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/binary-search-tree/package.json
+++ b/exercises/practice/binary-search-tree/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/binary-search-tree/package.json
+++ b/exercises/practice/binary-search-tree/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/binary-search-tree"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/binary-search/package.json
+++ b/exercises/practice/binary-search/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/binary-search"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/binary-search/package.json
+++ b/exercises/practice/binary-search/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/binary/package.json
+++ b/exercises/practice/binary/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/binary"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/binary/package.json
+++ b/exercises/practice/binary/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/bob/package.json
+++ b/exercises/practice/bob/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/bob"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/bob/package.json
+++ b/exercises/practice/bob/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/book-store/package.json
+++ b/exercises/practice/book-store/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/book-store"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/book-store/package.json
+++ b/exercises/practice/book-store/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/bowling/package.json
+++ b/exercises/practice/bowling/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/bowling/package.json
+++ b/exercises/practice/bowling/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/bowling"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/change/package.json
+++ b/exercises/practice/change/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/change"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/change/package.json
+++ b/exercises/practice/change/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/circular-buffer/package.json
+++ b/exercises/practice/circular-buffer/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/circular-buffer/package.json
+++ b/exercises/practice/circular-buffer/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/circular-buffer"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/clock/package.json
+++ b/exercises/practice/clock/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/clock/package.json
+++ b/exercises/practice/clock/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/clock"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/collatz-conjecture/package.json
+++ b/exercises/practice/collatz-conjecture/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/collatz-conjecture/package.json
+++ b/exercises/practice/collatz-conjecture/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/collatz-conjecture"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/complex-numbers/package.json
+++ b/exercises/practice/complex-numbers/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/complex-numbers"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/complex-numbers/package.json
+++ b/exercises/practice/complex-numbers/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/connect/package.json
+++ b/exercises/practice/connect/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/connect"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/connect/package.json
+++ b/exercises/practice/connect/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/crypto-square/package.json
+++ b/exercises/practice/crypto-square/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/crypto-square"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/crypto-square/package.json
+++ b/exercises/practice/crypto-square/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/custom-set/package.json
+++ b/exercises/practice/custom-set/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/custom-set"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/custom-set/package.json
+++ b/exercises/practice/custom-set/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/darts/package.json
+++ b/exercises/practice/darts/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/darts"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/darts/package.json
+++ b/exercises/practice/darts/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/diamond/package.json
+++ b/exercises/practice/diamond/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/diamond/package.json
+++ b/exercises/practice/diamond/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/diamond"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/difference-of-squares/package.json
+++ b/exercises/practice/difference-of-squares/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/difference-of-squares"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/difference-of-squares/package.json
+++ b/exercises/practice/difference-of-squares/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/diffie-hellman/package.json
+++ b/exercises/practice/diffie-hellman/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/diffie-hellman"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/diffie-hellman/package.json
+++ b/exercises/practice/diffie-hellman/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/dnd-character/package.json
+++ b/exercises/practice/dnd-character/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/dnd-character"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/dnd-character/package.json
+++ b/exercises/practice/dnd-character/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/dominoes/package.json
+++ b/exercises/practice/dominoes/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/dominoes"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/dominoes/package.json
+++ b/exercises/practice/dominoes/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/etl/package.json
+++ b/exercises/practice/etl/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/etl/package.json
+++ b/exercises/practice/etl/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/etl"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/flatten-array/package.json
+++ b/exercises/practice/flatten-array/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/flatten-array"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/flatten-array/package.json
+++ b/exercises/practice/flatten-array/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/food-chain/package.json
+++ b/exercises/practice/food-chain/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/food-chain"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/food-chain/package.json
+++ b/exercises/practice/food-chain/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/forth/package.json
+++ b/exercises/practice/forth/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/forth"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/forth/package.json
+++ b/exercises/practice/forth/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/gigasecond/package.json
+++ b/exercises/practice/gigasecond/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/gigasecond"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/gigasecond/package.json
+++ b/exercises/practice/gigasecond/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/go-counting/package.json
+++ b/exercises/practice/go-counting/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/go-counting/package.json
+++ b/exercises/practice/go-counting/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/go-counting"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/grade-school/package.json
+++ b/exercises/practice/grade-school/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/grade-school"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/grade-school/package.json
+++ b/exercises/practice/grade-school/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/grains/package.json
+++ b/exercises/practice/grains/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/grains"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/grains/package.json
+++ b/exercises/practice/grains/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/grep/package.json
+++ b/exercises/practice/grep/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/grep"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/grep/package.json
+++ b/exercises/practice/grep/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/hamming/package.json
+++ b/exercises/practice/hamming/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/hamming/package.json
+++ b/exercises/practice/hamming/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/hamming"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/hello-world/package.json
+++ b/exercises/practice/hello-world/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/hello-world"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/hello-world/package.json
+++ b/exercises/practice/hello-world/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/hexadecimal/package.json
+++ b/exercises/practice/hexadecimal/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/hexadecimal"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/hexadecimal/package.json
+++ b/exercises/practice/hexadecimal/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/high-scores/package.json
+++ b/exercises/practice/high-scores/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/high-scores"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/high-scores/package.json
+++ b/exercises/practice/high-scores/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/house/package.json
+++ b/exercises/practice/house/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/house"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/house/package.json
+++ b/exercises/practice/house/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/isbn-verifier/package.json
+++ b/exercises/practice/isbn-verifier/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/isbn-verifier"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/isbn-verifier/package.json
+++ b/exercises/practice/isbn-verifier/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/isogram/package.json
+++ b/exercises/practice/isogram/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/isogram"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/isogram/package.json
+++ b/exercises/practice/isogram/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/kindergarten-garden/package.json
+++ b/exercises/practice/kindergarten-garden/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/kindergarten-garden"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/kindergarten-garden/package.json
+++ b/exercises/practice/kindergarten-garden/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/knapsack/package.json
+++ b/exercises/practice/knapsack/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/knapsack/package.json
+++ b/exercises/practice/knapsack/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/knapsack"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/largest-series-product/package.json
+++ b/exercises/practice/largest-series-product/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/largest-series-product"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/largest-series-product/package.json
+++ b/exercises/practice/largest-series-product/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/leap/package.json
+++ b/exercises/practice/leap/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/leap/package.json
+++ b/exercises/practice/leap/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/leap"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/linked-list/package.json
+++ b/exercises/practice/linked-list/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/linked-list"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/linked-list/package.json
+++ b/exercises/practice/linked-list/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/list-ops/package.json
+++ b/exercises/practice/list-ops/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/list-ops"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/list-ops/package.json
+++ b/exercises/practice/list-ops/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/luhn/package.json
+++ b/exercises/practice/luhn/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/luhn/package.json
+++ b/exercises/practice/luhn/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/luhn"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/matching-brackets/package.json
+++ b/exercises/practice/matching-brackets/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/matching-brackets/package.json
+++ b/exercises/practice/matching-brackets/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/matching-brackets"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/matrix/package.json
+++ b/exercises/practice/matrix/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/matrix"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/matrix/package.json
+++ b/exercises/practice/matrix/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/meetup/package.json
+++ b/exercises/practice/meetup/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/meetup/package.json
+++ b/exercises/practice/meetup/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/meetup"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/minesweeper/package.json
+++ b/exercises/practice/minesweeper/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/minesweeper/package.json
+++ b/exercises/practice/minesweeper/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/minesweeper"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/nth-prime/package.json
+++ b/exercises/practice/nth-prime/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/nth-prime"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/nth-prime/package.json
+++ b/exercises/practice/nth-prime/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/nucleotide-count/package.json
+++ b/exercises/practice/nucleotide-count/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/nucleotide-count"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/nucleotide-count/package.json
+++ b/exercises/practice/nucleotide-count/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/ocr-numbers/package.json
+++ b/exercises/practice/ocr-numbers/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/ocr-numbers"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/ocr-numbers/package.json
+++ b/exercises/practice/ocr-numbers/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/octal/package.json
+++ b/exercises/practice/octal/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/octal"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/octal/package.json
+++ b/exercises/practice/octal/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/palindrome-products/package.json
+++ b/exercises/practice/palindrome-products/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/palindrome-products"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/palindrome-products/package.json
+++ b/exercises/practice/palindrome-products/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/pangram/package.json
+++ b/exercises/practice/pangram/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/pangram/package.json
+++ b/exercises/practice/pangram/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/pangram"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/pascals-triangle/package.json
+++ b/exercises/practice/pascals-triangle/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/pascals-triangle"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/pascals-triangle/package.json
+++ b/exercises/practice/pascals-triangle/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/perfect-numbers/package.json
+++ b/exercises/practice/perfect-numbers/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/perfect-numbers"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/perfect-numbers/package.json
+++ b/exercises/practice/perfect-numbers/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/phone-number/package.json
+++ b/exercises/practice/phone-number/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/phone-number"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/phone-number/package.json
+++ b/exercises/practice/phone-number/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/pig-latin/package.json
+++ b/exercises/practice/pig-latin/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/pig-latin"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/pig-latin/package.json
+++ b/exercises/practice/pig-latin/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/point-mutations/package.json
+++ b/exercises/practice/point-mutations/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/point-mutations"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/point-mutations/package.json
+++ b/exercises/practice/point-mutations/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/poker/package.json
+++ b/exercises/practice/poker/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/poker"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/poker/package.json
+++ b/exercises/practice/poker/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/prime-factors/package.json
+++ b/exercises/practice/prime-factors/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/prime-factors"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/prime-factors/package.json
+++ b/exercises/practice/prime-factors/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/promises/package.json
+++ b/exercises/practice/promises/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/promises"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/promises/package.json
+++ b/exercises/practice/promises/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/protein-translation/package.json
+++ b/exercises/practice/protein-translation/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/protein-translation"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/protein-translation/package.json
+++ b/exercises/practice/protein-translation/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/proverb/package.json
+++ b/exercises/practice/proverb/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/proverb"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/proverb/package.json
+++ b/exercises/practice/proverb/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/pythagorean-triplet/package.json
+++ b/exercises/practice/pythagorean-triplet/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/pythagorean-triplet"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/pythagorean-triplet/package.json
+++ b/exercises/practice/pythagorean-triplet/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/queen-attack/package.json
+++ b/exercises/practice/queen-attack/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/queen-attack"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/queen-attack/package.json
+++ b/exercises/practice/queen-attack/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/rail-fence-cipher/package.json
+++ b/exercises/practice/rail-fence-cipher/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/rail-fence-cipher"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/rail-fence-cipher/package.json
+++ b/exercises/practice/rail-fence-cipher/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/raindrops/package.json
+++ b/exercises/practice/raindrops/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/raindrops"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/raindrops/package.json
+++ b/exercises/practice/raindrops/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/rational-numbers/package.json
+++ b/exercises/practice/rational-numbers/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/rational-numbers"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/rational-numbers/package.json
+++ b/exercises/practice/rational-numbers/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/react/package.json
+++ b/exercises/practice/react/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/react/package.json
+++ b/exercises/practice/react/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/react"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/rectangles/package.json
+++ b/exercises/practice/rectangles/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/rectangles"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/rectangles/package.json
+++ b/exercises/practice/rectangles/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/resistor-color-duo/package.json
+++ b/exercises/practice/resistor-color-duo/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/resistor-color-duo"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/resistor-color-duo/package.json
+++ b/exercises/practice/resistor-color-duo/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/resistor-color-trio/package.json
+++ b/exercises/practice/resistor-color-trio/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/resistor-color-trio"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/resistor-color-trio/package.json
+++ b/exercises/practice/resistor-color-trio/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/resistor-color/package.json
+++ b/exercises/practice/resistor-color/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/resistor-color"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/resistor-color/package.json
+++ b/exercises/practice/resistor-color/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/rest-api/package.json
+++ b/exercises/practice/rest-api/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/rest-api/package.json
+++ b/exercises/practice/rest-api/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/rest-api"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/reverse-string/package.json
+++ b/exercises/practice/reverse-string/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/reverse-string"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/reverse-string/package.json
+++ b/exercises/practice/reverse-string/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/rna-transcription/package.json
+++ b/exercises/practice/rna-transcription/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/rna-transcription"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/rna-transcription/package.json
+++ b/exercises/practice/rna-transcription/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/robot-name/package.json
+++ b/exercises/practice/robot-name/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/robot-name"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/robot-name/package.json
+++ b/exercises/practice/robot-name/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/robot-simulator/package.json
+++ b/exercises/practice/robot-simulator/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/robot-simulator"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/robot-simulator/package.json
+++ b/exercises/practice/robot-simulator/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/roman-numerals/package.json
+++ b/exercises/practice/roman-numerals/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/roman-numerals"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/roman-numerals/package.json
+++ b/exercises/practice/roman-numerals/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/rotational-cipher/package.json
+++ b/exercises/practice/rotational-cipher/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/rotational-cipher"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/rotational-cipher/package.json
+++ b/exercises/practice/rotational-cipher/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/run-length-encoding/package.json
+++ b/exercises/practice/run-length-encoding/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/run-length-encoding"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/run-length-encoding/package.json
+++ b/exercises/practice/run-length-encoding/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/saddle-points/package.json
+++ b/exercises/practice/saddle-points/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/saddle-points"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/saddle-points/package.json
+++ b/exercises/practice/saddle-points/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/satellite/package.json
+++ b/exercises/practice/satellite/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/satellite/package.json
+++ b/exercises/practice/satellite/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/satellite"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/say/package.json
+++ b/exercises/practice/say/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/say"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/say/package.json
+++ b/exercises/practice/say/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/scale-generator/package.json
+++ b/exercises/practice/scale-generator/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/scale-generator"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/scale-generator/package.json
+++ b/exercises/practice/scale-generator/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/scrabble-score/package.json
+++ b/exercises/practice/scrabble-score/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/scrabble-score/package.json
+++ b/exercises/practice/scrabble-score/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/scrabble-score"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/secret-handshake/package.json
+++ b/exercises/practice/secret-handshake/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/secret-handshake"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/secret-handshake/package.json
+++ b/exercises/practice/secret-handshake/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/series/package.json
+++ b/exercises/practice/series/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/series"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/series/package.json
+++ b/exercises/practice/series/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/sieve/package.json
+++ b/exercises/practice/sieve/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/sieve/package.json
+++ b/exercises/practice/sieve/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/sieve"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/simple-cipher/package.json
+++ b/exercises/practice/simple-cipher/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/simple-cipher/package.json
+++ b/exercises/practice/simple-cipher/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/simple-cipher"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/simple-linked-list/package.json
+++ b/exercises/practice/simple-linked-list/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/simple-linked-list"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/simple-linked-list/package.json
+++ b/exercises/practice/simple-linked-list/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/space-age/package.json
+++ b/exercises/practice/space-age/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/space-age"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/space-age/package.json
+++ b/exercises/practice/space-age/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/spiral-matrix/package.json
+++ b/exercises/practice/spiral-matrix/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/spiral-matrix"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/spiral-matrix/package.json
+++ b/exercises/practice/spiral-matrix/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/square-root/package.json
+++ b/exercises/practice/square-root/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/square-root/package.json
+++ b/exercises/practice/square-root/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/square-root"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/strain/package.json
+++ b/exercises/practice/strain/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/strain"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/strain/package.json
+++ b/exercises/practice/strain/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/sublist/package.json
+++ b/exercises/practice/sublist/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/sublist"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/sublist/package.json
+++ b/exercises/practice/sublist/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/sum-of-multiples/package.json
+++ b/exercises/practice/sum-of-multiples/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/sum-of-multiples"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/sum-of-multiples/package.json
+++ b/exercises/practice/sum-of-multiples/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/tournament/package.json
+++ b/exercises/practice/tournament/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/tournament"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/tournament/package.json
+++ b/exercises/practice/tournament/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/transpose/package.json
+++ b/exercises/practice/transpose/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/transpose"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/transpose/package.json
+++ b/exercises/practice/transpose/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/triangle/package.json
+++ b/exercises/practice/triangle/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/triangle"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/triangle/package.json
+++ b/exercises/practice/triangle/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/trinary/package.json
+++ b/exercises/practice/trinary/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/trinary"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/trinary/package.json
+++ b/exercises/practice/trinary/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/twelve-days/package.json
+++ b/exercises/practice/twelve-days/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/twelve-days"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/twelve-days/package.json
+++ b/exercises/practice/twelve-days/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/two-bucket/package.json
+++ b/exercises/practice/two-bucket/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/two-bucket"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/two-bucket/package.json
+++ b/exercises/practice/two-bucket/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/two-fer/package.json
+++ b/exercises/practice/two-fer/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/two-fer"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/two-fer/package.json
+++ b/exercises/practice/two-fer/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/variable-length-quantity/package.json
+++ b/exercises/practice/variable-length-quantity/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/variable-length-quantity"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/variable-length-quantity/package.json
+++ b/exercises/practice/variable-length-quantity/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/word-count/package.json
+++ b/exercises/practice/word-count/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/word-count"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/word-count/package.json
+++ b/exercises/practice/word-count/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/word-search/package.json
+++ b/exercises/practice/word-search/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/word-search"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/word-search/package.json
+++ b/exercises/practice/word-search/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/wordy/package.json
+++ b/exercises/practice/wordy/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/wordy"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/wordy/package.json
+++ b/exercises/practice/wordy/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/yacht/package.json
+++ b/exercises/practice/yacht/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/yacht"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/yacht/package.json
+++ b/exercises/practice/yacht/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/zebra-puzzle/package.json
+++ b/exercises/practice/zebra-puzzle/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/zebra-puzzle"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/zebra-puzzle/package.json
+++ b/exercises/practice/zebra-puzzle/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/zipper/package.json
+++ b/exercises/practice/zipper/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/exercises/practice/zipper/package.json
+++ b/exercises/practice/zipper/package.json
@@ -10,6 +10,7 @@
     "directory": "exercises/practice/zipper"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -19,7 +20,6 @@
     "eslint": "^8.9.0",
     "jest": "^27.5.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "@exercism/javascript",
       "license": "MIT",
       "devDependencies": {
+        "@babel/core": "^7.17.4",
         "@exercism/babel-preset-javascript": "^0.1.2",
         "@exercism/eslint-config-javascript": "^0.6.0",
         "@types/jest": "^27.4.0",
@@ -22,9 +23,9 @@
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.0.4.tgz",
-      "integrity": "sha512-zU3pj3pf//YhaoozRTYKaL20KopXrzuZFc/8Ylc49AuV8grYKH23TTq9JJoR70F8zQbil58KjSchZTWeX+jrIQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.0"
@@ -55,20 +56,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.0.tgz",
-      "integrity": "sha512-x/5Ea+RO5MvF9ize5DeVICJoVrNv0Mi2RnIABrZEKYvPEpldXwauPkgvYA17cKa6WpU3LoYvYbuEMFtSNFsarA==",
+      "version": "7.17.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.4.tgz",
+      "integrity": "sha512-R9x5r4t4+hBqZTmioSnkrW+I6NmbojwjGT8p4G2Gw1thWbXIHGDnmGdLdFw0/7ljucdIrNRp7Npgb4CyBYzzJg==",
       "dev": true,
       "dependencies": {
-        "@ampproject/remapping": "^2.0.0",
+        "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
+        "@babel/generator": "^7.17.3",
         "@babel/helper-compilation-targets": "^7.16.7",
         "@babel/helper-module-transforms": "^7.16.7",
-        "@babel/helpers": "^7.17.0",
-        "@babel/parser": "^7.17.0",
+        "@babel/helpers": "^7.17.2",
+        "@babel/parser": "^7.17.3",
         "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
+        "@babel/traverse": "^7.17.3",
         "@babel/types": "^7.17.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
@@ -119,9 +120,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
-      "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
+      "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.17.0",
@@ -457,9 +458,9 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.0.tgz",
-      "integrity": "sha512-Xe/9NFxjPwELUvW2dsukcMZIp6XwPSbI4ojFBJuX5ramHuVE22SVcZIwqzdWo5uCgeTXW8qV97lMvSOjq+1+nQ==",
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.2.tgz",
+      "integrity": "sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.16.7",
@@ -564,9 +565,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+      "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1727,18 +1728,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
-      "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
+        "@babel/generator": "^7.17.3",
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-function-name": "^7.16.7",
         "@babel/helper-hoist-variables": "^7.16.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.0",
+        "@babel/parser": "^7.17.3",
         "@babel/types": "^7.17.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -2426,24 +2427,24 @@
       "dev": true
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz",
-      "integrity": "sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
+      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.10.tgz",
-      "integrity": "sha512-Ht8wIW5v165atIX1p+JvKR5ONzUyF4Ac8DZIQ5kZs9zrb6M8SJNXpx1zn04rn65VjBMygRoMXcyYwNK0fT7bEg==",
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
+      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.2.tgz",
-      "integrity": "sha512-9KzzH4kMjA2XmBRHfqG2/Vtl7s92l6uNDd0wW7frDE+EUvQFGqNXhWp0UGJjSkt3v2AYjzOZn1QO9XaTNJIt1Q==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
+      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -8124,9 +8125,9 @@
   },
   "dependencies": {
     "@ampproject/remapping": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.0.4.tgz",
-      "integrity": "sha512-zU3pj3pf//YhaoozRTYKaL20KopXrzuZFc/8Ylc49AuV8grYKH23TTq9JJoR70F8zQbil58KjSchZTWeX+jrIQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
@@ -8148,20 +8149,20 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.0.tgz",
-      "integrity": "sha512-x/5Ea+RO5MvF9ize5DeVICJoVrNv0Mi2RnIABrZEKYvPEpldXwauPkgvYA17cKa6WpU3LoYvYbuEMFtSNFsarA==",
+      "version": "7.17.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.4.tgz",
+      "integrity": "sha512-R9x5r4t4+hBqZTmioSnkrW+I6NmbojwjGT8p4G2Gw1thWbXIHGDnmGdLdFw0/7ljucdIrNRp7Npgb4CyBYzzJg==",
       "dev": true,
       "requires": {
-        "@ampproject/remapping": "^2.0.0",
+        "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
+        "@babel/generator": "^7.17.3",
         "@babel/helper-compilation-targets": "^7.16.7",
         "@babel/helper-module-transforms": "^7.16.7",
-        "@babel/helpers": "^7.17.0",
-        "@babel/parser": "^7.17.0",
+        "@babel/helpers": "^7.17.2",
+        "@babel/parser": "^7.17.3",
         "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
+        "@babel/traverse": "^7.17.3",
         "@babel/types": "^7.17.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
@@ -8191,9 +8192,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
-      "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
+      "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.17.0",
@@ -8445,9 +8446,9 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.0.tgz",
-      "integrity": "sha512-Xe/9NFxjPwELUvW2dsukcMZIp6XwPSbI4ojFBJuX5ramHuVE22SVcZIwqzdWo5uCgeTXW8qV97lMvSOjq+1+nQ==",
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.2.tgz",
+      "integrity": "sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.16.7",
@@ -8524,9 +8525,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+      "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
       "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -9303,18 +9304,18 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
-      "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.0",
+        "@babel/generator": "^7.17.3",
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-function-name": "^7.16.7",
         "@babel/helper-hoist-variables": "^7.16.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.0",
+        "@babel/parser": "^7.17.3",
         "@babel/types": "^7.17.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -9843,21 +9844,21 @@
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz",
-      "integrity": "sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
+      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.10.tgz",
-      "integrity": "sha512-Ht8wIW5v165atIX1p+JvKR5ONzUyF4Ac8DZIQ5kZs9zrb6M8SJNXpx1zn04rn65VjBMygRoMXcyYwNK0fT7bEg==",
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
+      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.2.tgz",
-      "integrity": "sha512-9KzzH4kMjA2XmBRHfqG2/Vtl7s92l6uNDd0wW7frDE+EUvQFGqNXhWp0UGJjSkt3v2AYjzOZn1QO9XaTNJIt1Q==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
+      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prettier": "^2.5.1",
     "shelljs": "^0.8.5"
   },
+  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/exercism/javascript"
   },
   "devDependencies": {
+    "@babel/core": "^7.17.4",
     "@exercism/babel-preset-javascript": "^0.1.2",
     "@exercism/eslint-config-javascript": "^0.6.0",
     "@types/jest": "^27.4.0",
@@ -26,7 +27,6 @@
     "prettier": "^2.5.1",
     "shelljs": "^0.8.5"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest ./*",
     "watch": "jest --watch ./*",


### PR DESCRIPTION
It currently doesn't break because we do import babel-core via a transitive dependency, but adding this to the exercise makes all warnings go away.