### PR TITLE
Added /.idea to .gitignore for JetBrains based IDEs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /bin/configlet.exe
 /pnpm-lock.yaml
 /yarn.lock
+/.idea


### PR DESCRIPTION
Accommodates contributors who use WebStorm and other JetBrains IDEs, since it will auto-generate environment info. In line with other repos like exercism/python for PyCharm and exercism/java for IntelliJ.