### PR TITLE
fixes #1685

### DIFF
--- a/exercises/concept/elyses-enchantments/enchantments.spec.js
+++ b/exercises/concept/elyses-enchantments/enchantments.spec.js
@@ -191,8 +191,8 @@ describe('make the top card disappear', () => {
   test('remove two cards from the bottom', () => {
     let stack = [1, 2, 3];
 
-    stack = removeItemFromTop(stack);
-    stack = removeItemFromTop(stack);
+    stack = removeItemAtBottom(stack);
+    stack = removeItemAtBottom(stack);
 
     const expected = [3];
     expect(stack).toStrictEqual(expected);

--- a/exercises/concept/elyses-enchantments/enchantments.spec.js
+++ b/exercises/concept/elyses-enchantments/enchantments.spec.js
@@ -97,10 +97,10 @@ describe('make cards appear at the top', () => {
   });
 
   test('adding multiple cards to the stack at the top', () => {
-    const stack = [1];
+    let stack = [1];
 
-    insertItemAtTop(stack, 5);
-    insertItemAtTop(stack, 9);
+    stack = insertItemAtTop(stack, 5);
+    stack = insertItemAtTop(stack, 9);
 
     const expected = [1, 5, 9];
     expect(stack).toStrictEqual(expected);
@@ -143,13 +143,13 @@ describe('make cards disappear', () => {
   });
 
   test('remove the middle two cards', () => {
-    const stack = [1, 2, 3, 4];
+    let stack = [1, 2, 3, 4];
 
-    removeItem(stack, 1);
-    removeItem(stack, 1);
+    stack = removeItem(stack, 1);
+    stack = removeItem(stack, 1);
 
     const expected = [1, 4];
-    expect(expected).toStrictEqual(expected);
+    expect(stack).toStrictEqual(expected);
   });
 });
 
@@ -167,13 +167,13 @@ describe('make the top card disappear', () => {
   });
 
   test('remove two cards from the top', () => {
-    const stack = [1, 2, 3];
+    let stack = [1, 2, 3];
 
-    removeItemFromTop(stack);
-    removeItemFromTop(stack);
+    stack = removeItemFromTop(stack);
+    stack = removeItemFromTop(stack);
 
     const expected = [1];
-    expect(expected).toStrictEqual(expected);
+    expect(stack).toStrictEqual(expected);
   });
 
   test('remove the only card from the bottom', () => {
@@ -189,13 +189,13 @@ describe('make the top card disappear', () => {
   });
 
   test('remove two cards from the bottom', () => {
-    const stack = [1, 2, 3];
+    let stack = [1, 2, 3];
 
-    removeItemFromTop(stack);
-    removeItemFromTop(stack);
+    stack = removeItemFromTop(stack);
+    stack = removeItemFromTop(stack);
 
     const expected = [3];
-    expect(expected).toStrictEqual(expected);
+    expect(stack).toStrictEqual(expected);
   });
 });
 
@@ -233,10 +233,10 @@ describe('make cards appear at the bottom', () => {
   });
 
   test('adding multiple cards to the stack to the bottom', () => {
-    const stack = [1];
+    let stack = [1];
 
-    insertItemAtBottom(stack, 5);
-    insertItemAtBottom(stack, 9);
+    stack = insertItemAtBottom(stack, 5);
+    stack = insertItemAtBottom(stack, 9);
 
     const expected = [9, 5, 1];
     expect(stack).toStrictEqual(expected);

--- a/exercises/concept/elyses-enchantments/enchantments.spec.js
+++ b/exercises/concept/elyses-enchantments/enchantments.spec.js
@@ -97,10 +97,10 @@ describe('make cards appear at the top', () => {
   });
 
   test('adding multiple cards to the stack at the top', () => {
-    let stack = [1];
+    const stack = [1];
 
-    stack = insertItemAtTop(stack, 5);
-    stack = insertItemAtTop(stack, 9);
+    insertItemAtTop(stack, 5);
+    insertItemAtTop(stack, 9);
 
     const expected = [1, 5, 9];
     expect(stack).toStrictEqual(expected);
@@ -143,10 +143,10 @@ describe('make cards disappear', () => {
   });
 
   test('remove the middle two cards', () => {
-    let stack = [1, 2, 3, 4];
+    const stack = [1, 2, 3, 4];
 
-    stack = removeItem(stack, 1);
-    stack = removeItem(stack, 1);
+    removeItem(stack, 1);
+    removeItem(stack, 1);
 
     const expected = [1, 4];
     expect(stack).toStrictEqual(expected);
@@ -167,10 +167,10 @@ describe('make the top card disappear', () => {
   });
 
   test('remove two cards from the top', () => {
-    let stack = [1, 2, 3];
+    const stack = [1, 2, 3];
 
-    stack = removeItemFromTop(stack);
-    stack = removeItemFromTop(stack);
+    removeItemFromTop(stack);
+    removeItemFromTop(stack);
 
     const expected = [1];
     expect(stack).toStrictEqual(expected);
@@ -189,10 +189,10 @@ describe('make the top card disappear', () => {
   });
 
   test('remove two cards from the bottom', () => {
-    let stack = [1, 2, 3];
+    const stack = [1, 2, 3];
 
-    stack = removeItemAtBottom(stack);
-    stack = removeItemAtBottom(stack);
+    removeItemAtBottom(stack);
+    removeItemAtBottom(stack);
 
     const expected = [3];
     expect(stack).toStrictEqual(expected);
@@ -233,10 +233,10 @@ describe('make cards appear at the bottom', () => {
   });
 
   test('adding multiple cards to the stack to the bottom', () => {
-    let stack = [1];
+    const stack = [1];
 
-    stack = insertItemAtBottom(stack, 5);
-    stack = insertItemAtBottom(stack, 9);
+    insertItemAtBottom(stack, 5);
+    insertItemAtBottom(stack, 9);
 
     const expected = [9, 5, 1];
     expect(stack).toStrictEqual(expected);


### PR DESCRIPTION
I've updated the tests errors in Elyses Enchantments so that:

- tests no longer check equality between `expect => to be strictly equal to expected` but instead check `result stack => to be strictly equal to expected`
- tests that call one function multiple times to remove multiple cards now set equality on stack variable each time they run so that mutation is not required in order to pass strict equality test