### PR TITLE
Update windowing-system.spec.js

### DIFF
--- a/exercises/concept/windowing-system/windowing-system.spec.js
+++ b/exercises/concept/windowing-system/windowing-system.spec.js
@@ -110,7 +110,7 @@ describe('move', () => {
     programWindow.move(newPosition);
 
     expect(programWindow.position.x).toBe(0);
-    expect(programWindow.position.y).toBe(0);
+    expect(programWindow.position.y).toBe(60);
   });
 
   test('move respects limits due to screen and window size', () => {
@@ -121,7 +121,7 @@ describe('move', () => {
     programWindow.move(newPosition);
 
     expect(programWindow.position.x).toBe(700);
-    expect(programWindow.position.y).toBe(500);
+    expect(programWindow.position.y).toBe(650);
   });
 
   test('resize respects limits due to position and screen size', () => {
@@ -150,7 +150,7 @@ describe('changeWindow', () => {
     const updatedWindow = changeWindow(programWindow);
 
     expect(updatedWindow.position.x).toBe(100);
-    expect(updatedWindow.position.y).toBe(150);
+    expect(updatedWindow.position.y).toBe(300);
   });
 
   test('returns the same instance that was passed in', () => {


### PR DESCRIPTION
Hello. In instructions you drew how the system works. You chose the >upper<  left of the window as the reference point for Window. As such, the maximum value for position.y for the window is the screenSize.height itself. And the minimum value for the position.y is the height of the window. Think about it. For your tests to make sense you would have to have chosen the lower left of the window as the reference point for the positon of the Window.