### PR TITLE
Update poetry-club-door-policy instructions

### DIFF
--- a/exercises/concept/poetry-club-door-policy/.docs/instructions.md
+++ b/exercises/concept/poetry-club-door-policy/.docs/instructions.md
@@ -87,7 +87,7 @@ backDoorResponse('Stands so high   ');
 To enter the poetry club via the back door, you need to be extra polite.
 So to derive the password, this time you need to correctly capitalize the word and add `', please'` at the end.
 
-Implement the function `backDoorPassword` that accepts a string (the combined letters you found in task 3) and returns the polite version of the capitalized password.
+Implement the function `backDoorPassword` that accepts a string (the combined letters you found in task 2) and returns the polite version of the capitalized password.
 
 ```javascript
 backDoorPassword('horse');


### PR DESCRIPTION
I updated the poetry-club-door-policy instructions as they were referencing the wrong task in the 4th task which is confusing.

The relevant exercise for completing #4 should be task #2 (which capitalizes the word) not task #3 (which returns the last letter of a sentence). This update to the instructions is aligned with the information that is in the `poetry-club-door-policy` hint.md https://github.com/exercism/javascript/blob/d6744220f89c8c9172ed59c70fa7337016010f76/exercises/concept/poetry-club-door-policy/.docs/hints.md#4-be-polite.