### PR TITLE
Fix wrong test case in Translation Service

### DIFF
--- a/exercises/concept/translation-service/service.spec.js
+++ b/exercises/concept/translation-service/service.spec.js
@@ -185,7 +185,14 @@ describe('Premium service', () => {
     await expect(actual).rejects.toThrow(Error);
   });
 
-  test('it ensures the quality of the translation', async () => {
+  test('it recognizes sufficient quality', async () => {
+    const actual = service.premium('‘arlogh Qoylu’pu’?', 40);
+    const expected = 'What time is it?';
+
+    await expect(actual).resolves.toBe(expected);
+  });
+
+  test('it recognizes insufficient quality', async () => {
     const actual = service.premium('majQa’', 100);
     const expected = QualityThresholdNotMet;
 

--- a/exercises/concept/translation-service/service.spec.js
+++ b/exercises/concept/translation-service/service.spec.js
@@ -193,11 +193,6 @@ describe('Premium service', () => {
   });
 
   test('it ensures the quality even after a request', async () => {
-    const actual = service.premium('‘arlogh Qoylu’pu’?', 40);
-    const expected = 'What time is it?';
-
-    await expect(actual).resolves.toBe(expected);
-
     const actualQuality = service.premium('‘arlogh Qoylu’pu’?', 100);
     const expectedQuality = QualityThresholdNotMet;
     await expect(actualQuality).rejects.toThrow(expectedQuality);


### PR DESCRIPTION
The first call to `premium` already requested and resolved the translation. Therefore the quality check after requesting was never tested.

This caused code snippets like this to pass the tests, when it shouldn't
```javascript
async premium(text, minimumQuality) {
    try {
      const translation = await this.api.fetch(text);

      if (translation.quality >= minimumQuality) {
        return translation.translation;
      }

      throw new QualityThresholdNotMet(text);
    } catch (error) {
      if (error instanceof NotAvailable) {
        await this.request(text);
        const { translation } = await this.api.fetch(text);
        return translation;
      }

      throw error;
    }
  }
```
(Credits for this snippet to dominguezcelada as part of the mentoring discussion)

The snippet above does not check the quality after requesting it and still passed the test. \
The correct way would be to check the quality also after requesting it, which can be done by recalling the `premium` function because the translation has been requested and resolved.

```javascript
async premium(text, minimumQuality) {
        try {
            const translation = await this.api.fetch(text);
            if (translation.quality >= minimumQuality) {
                return translation.translation;
            }
            throw new QualityThresholdNotMet(text);
        } catch (error) {
            if (error instanceof NotAvailable) {
                await this.request(text);
                return await this.premium(text, minimumQuality);
            }
            throw error;
        }
    }
```