### PR TITLE
add missing inner brackets in conditionals concept

### DIFF
--- a/concepts/conditionals/about.md
+++ b/concepts/conditionals/about.md
@@ -67,9 +67,13 @@ if (num >= 0 && num < 1) {
 
 // The inner brackets are obsolete because relational operators
 // have higher precedence than logical operators.
-if (num >= 0 && num < 1) {
+<!-- prettier-ignore-start -->
+
+if ((num >= 0) && (num < 1)) {
   // ...
 }
+<!-- prettier-ignore-end -->
+
 ```
 
 Also, consider using additional variables to make the code more readable.


### PR DESCRIPTION
add inner brackets in conditionals concept that were removed by the auto-formatting.
add prettier-ignore to prevent prettier from removing them
