### PR TITLE
Remove duplicate test case in Simple Linked List

### DIFF
--- a/exercises/practice/simple-linked-list/simple-linked-list.spec.js
+++ b/exercises/practice/simple-linked-list/simple-linked-list.spec.js
@@ -109,10 +109,6 @@ describe('Lists with multiple elements', () => {
     const twoList = new List([1, 2]);
     expect(twoList.head.value).toEqual(2);
   });
-  xtest('can convert to an array', () => {
-    const oneList = new List([1]);
-    expect(oneList.toArray()).toEqual([1]);
-  });
   xtest('can convert longer list to an array', () => {
     expect(list.toArray()).toEqual([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
   });


### PR DESCRIPTION
The same test case 'can convert to an array' is duplicated on lines 104 and 112. This commit removes the unnecessary duplicate.