### PR TITLE
fix order of tests

### DIFF
--- a/exercises/concept/elyses-enchantments/enchantments.spec.js
+++ b/exercises/concept/elyses-enchantments/enchantments.spec.js
@@ -177,30 +177,6 @@ describe('make the top card disappear', () => {
   });
 });
 
-describe('make the bottom card disappear', () => {
-  test('remove the only card from the bottom', () => {
-    const stack = [1];
-    const expected = [];
-    expect(removeItemAtBottom(stack)).toStrictEqual(expected);
-  });
-
-  test('remove the card from the bottom', () => {
-    const stack = [1, 2, 3];
-    const expected = [2, 3];
-    expect(removeItemAtBottom(stack)).toStrictEqual(expected);
-  });
-
-  test('remove two cards from the bottom', () => {
-    const stack = [1, 2, 3];
-
-    removeItemAtBottom(stack);
-    removeItemAtBottom(stack);
-
-    const expected = [3];
-    expect(stack).toStrictEqual(expected);
-  });
-});
-
 describe('make cards appear at the bottom', () => {
   test('adding a second card to the bottom', () => {
     const stack = [1];
@@ -241,6 +217,30 @@ describe('make cards appear at the bottom', () => {
     insertItemAtBottom(stack, 9);
 
     const expected = [9, 5, 1];
+    expect(stack).toStrictEqual(expected);
+  });
+});
+
+describe('make the bottom card disappear', () => {
+  test('remove the only card from the bottom', () => {
+    const stack = [1];
+    const expected = [];
+    expect(removeItemAtBottom(stack)).toStrictEqual(expected);
+  });
+
+  test('remove the card from the bottom', () => {
+    const stack = [1, 2, 3];
+    const expected = [2, 3];
+    expect(removeItemAtBottom(stack)).toStrictEqual(expected);
+  });
+
+  test('remove two cards from the bottom', () => {
+    const stack = [1, 2, 3];
+
+    removeItemAtBottom(stack);
+    removeItemAtBottom(stack);
+
+    const expected = [3];
     expect(stack).toStrictEqual(expected);
   });
 });


### PR DESCRIPTION
In the [exercise](https://exercism.org/tracks/javascript/exercises/elyses-enchantments/edit) on exercism.org implementing the function `insertItemAtBottom()` passes the tests of Task 7. While these are the correct tests they should be swapped with those from Task 6.

The tests listed under Task 6 are actually the tests for removing an item and should be part of Task 7. (see screenshot)

![image](https://user-images.githubusercontent.com/76426580/177983790-0136d0ab-aa53-48cf-9590-8d136f9b560a.png)
