### PR TITLE
Fix typo in callbacks concept

### DIFF
--- a/concepts/callbacks/about.md
+++ b/concepts/callbacks/about.md
@@ -11,7 +11,7 @@ function applySideLength(callback) {
 }
 
 // Callback must expect the possible argument from the calling function
-function squareArea(side) {
+function areaOfSquare(side) {
   return side * side;
 }
 

--- a/concepts/callbacks/introduction.md
+++ b/concepts/callbacks/introduction.md
@@ -13,7 +13,7 @@ function applySideLength(callback) {
 }
 
 // Callback must expect the possible argument from the calling function
-function squareArea(side) {
+function areaOfSquare(side) {
   return side * side;
 }
 


### PR DESCRIPTION
In the example code, `squareArea` was defined but never used, and `areaOfSquare` was used but not defined, so I made them both `areaOfSquare`.