### PR TITLE
Fix test description in coordinate-transformation

### DIFF
--- a/exercises/concept/coordinate-transformation/coordinate-transformation.spec.js
+++ b/exercises/concept/coordinate-transformation/coordinate-transformation.spec.js
@@ -91,7 +91,7 @@ describe('composeTransform', () => {
     expect(composed(0, 0)).toEqual([-6, 10]);
   });
 
-  test('should compose in the opposite order: g(f(x))', () => {
+  test('should compose in the opposite order: f(g(x))', () => {
     const composed = composeTransform(translator, scaler);
     expect(composed(0, 0)).toEqual([-18, 20]);
   });


### PR DESCRIPTION
In the previous test description we state that the "correct" order is `g(f(x))`. Since the order should be the opposite in the description being fixed, it should be `f(g(x))`

```
  test('should compose in the correct order: g(f(x))', () => {
    const composed = composeTransform(scaler, translator);
    expect(composed(0, 0)).toEqual([-6, 10]);
  });


  test('should compose in the opposite order: f(g(x))', () => {
    const composed = composeTransform(translator, scaler);
    expect(composed(0, 0)).toEqual([-18, 20]);
  });
```