### PR TITLE
Remove reference to Gitter

### DIFF
--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -2,7 +2,6 @@
 
 To get help if you're having trouble, you can use one of the following resources:
 
-- [Gitter](https://gitter.im/exercism/support) is Exercism's Gitter room; go here to get support and ask questions if you face any issues with downloading or submitting your exercises.
 - [/r/javascript](https://www.reddit.com/r/javascript) is the Javascript subreddit.
 - [StackOverflow](https://stackoverflow.com/questions/tagged/javascript+exercism) can be used to search for your problem and see if it has been answered already. You can also ask and answer questions.
 - [Github issue tracker](https://github.com/exercism/javascript/issues) is where we track our development and maintainance of Javascript exercises in exercism. But if none of the above links help you, feel free to post an issue here.


### PR DESCRIPTION
The Exerism Forum (https://forum.exercism.org/) has now made Gitter redundant.
We're directing everyone there.
