### PR TITLE
Add representer normalizations document

### DIFF
--- a/docs/REPRESENTER_NORMALIZATIONS.md
+++ b/docs/REPRESENTER_NORMALIZATIONS.md
@@ -1,0 +1,89 @@
+# Representer normalizations
+
+The [JavaScript representer][github-javascript-representer] applies the following normalizations:
+
+## Remove comments
+
+All comments are removed.
+The following examples are equivalent:
+
+### Example with comments
+
+```javascript
+/**
+ * Returns the string literal 'hi there' just to say hello
+ * @return [String]
+ */
+function hello(/* nothing*/) {
+  // just return it
+  return 'hi there'
+}
+```
+
+### Example without comments
+
+```javascript
+function hello() {
+  return 'hi there'
+}
+```
+
+## Normalize whitespace
+
+When the code is represented, it's _order_ is significant, but its physical location is not.
+This means that whitespace is normalized.
+The following examples are equivalent:
+
+
+### Example with two-space indentation
+
+```javascript
+function hello() {
+  return 'hello world'
+}
+```
+
+### Example with four-space indentation
+
+```javascript
+function hello() {
+    return 'hello world'
+}
+```
+
+### Example with interesting indentation
+
+```javascript
+function   hello() {
+
+return 'hello world'
+
+
+    }
+```
+
+## Normalize identifiers
+
+Identifiers are normalized to a placeholder value.
+
+### Before
+
+```javascript
+const MY_CONSTANT = 42
+
+function answer(multiplier, addition = 1) {
+  return MY_CONSTANT * multiplier + addition
+}
+```
+
+### After
+
+```javascript
+const PLACEHOLDER_1 = 42
+
+function PLACEHOLDER_2(PLACEHOLDER_3, PLACEHOLDER_4 = 1) {
+  return PLACEHOLDER_1 * PLACEHOLDER_3 + PLACEHOLDER_4
+}
+```
+
+[github-javascript-representer]: https://github.com/exercism/javascript-representer

--- a/docs/REPRESENTER_NORMALIZATIONS.md
+++ b/docs/REPRESENTER_NORMALIZATIONS.md
@@ -16,7 +16,7 @@ The following examples are equivalent:
  */
 function hello(/* nothing*/) {
   // just return it
-  return 'hi there'
+  return 'hi there';
 }
 ```
 
@@ -24,7 +24,7 @@ function hello(/* nothing*/) {
 
 ```javascript
 function hello() {
-  return 'hi there'
+  return 'hi there';
 }
 ```
 
@@ -34,12 +34,11 @@ When the code is represented, it's _order_ is significant, but its physical loca
 This means that whitespace is normalized.
 The following examples are equivalent:
 
-
 ### Example with two-space indentation
 
 ```javascript
 function hello() {
-  return 'hello world'
+  return 'hello world';
 }
 ```
 
@@ -47,19 +46,16 @@ function hello() {
 
 ```javascript
 function hello() {
-    return 'hello world'
+  return 'hello world';
 }
 ```
 
 ### Example with interesting indentation
 
 ```javascript
-function   hello() {
-
-return 'hello world'
-
-
-    }
+function hello() {
+  return 'hello world';
+}
 ```
 
 ## Normalize identifiers
@@ -69,20 +65,20 @@ Identifiers are normalized to a placeholder value.
 ### Before
 
 ```javascript
-const MY_CONSTANT = 42
+const MY_CONSTANT = 42;
 
 function answer(multiplier, addition = 1) {
-  return MY_CONSTANT * multiplier + addition
+  return MY_CONSTANT * multiplier + addition;
 }
 ```
 
 ### After
 
 ```javascript
-const PLACEHOLDER_1 = 42
+const PLACEHOLDER_1 = 42;
 
 function PLACEHOLDER_2(PLACEHOLDER_3, PLACEHOLDER_4 = 1) {
-  return PLACEHOLDER_1 * PLACEHOLDER_3 + PLACEHOLDER_4
+  return PLACEHOLDER_1 * PLACEHOLDER_3 + PLACEHOLDER_4;
 }
 ```
 

--- a/exercises/shared/.docs/representations.md
+++ b/exercises/shared/.docs/representations.md
@@ -1,191 +1,22 @@
 ## JavaScript representations
 
-The JavaScript representer works with the `@typescript-eslint/parser`, a packager that generates an [ESTree](https://github.com/estree/estree).
+The [JavaScript representer][github-javascript-representer] applies the following normalizations: 
 
-This abstract syntax tree output is then traversed and the following normalisation steps are performed:
+- [All comments are removed][docs-representer-normalizations-comments]
+- [All whitespace is normalized][docs-representer-normalizations-whitespace]
+- [Identifiers are normalized to a placeholder value][docs-representer-normalizations-identifiers]
 
-- All comments are ignored / removed
-- All whitespace is ignored
-- All _identifiers_ are renamed, using a "key lookup"
+[github-javascript-representer]: https://github.com/exercism/javascript-representer
+[docs-representer-normalizations-comments]: https://exercism.org/docs/tracks/javascript/representer-normalizations#h-remove-comments
+[docs-representer-normalizations-whitespace]: https://exercism.org/docs/tracks/javascript/representer-normalizations#h-normalize-whitespace
+[docs-representer-normalizations-identifiers]: https://exercism.org/docs/tracks/javascript/representer-normalizations#h-normalize-identifiers
 
-## BEFORE YOU SUBMIT
+### Before you submit
 
-Before you submit your representation feedback, please check the following things:
+Please check the following things:
 
 1. You don't duplicate analyzer feedback
 2. You check the "examples" tab in the submit dialog and see if the feedback makes sense for _all_ tabs.
 3. You check that you have not referred to whitespace or comments
 4. You check that you don't refer to function names, or variable names as they appear in the solution, but rather use the mapping provided (or leave names out).
    Only _exported_ names (required by the tests) you can safely refer to because these are always the same for everyone.
-
-## Example
-
-```javascript
-// Clock constants
-
-const MINUTES_PER_HOUR = 60;
-const HOURS_ON_THE_CLOCK = 24;
-
-const MINUTES_PER_CLOCK = MINUTES_PER_HOUR * HOURS_ON_THE_CLOCK;
-```
-
-Given the snippet above, each declaration is transformed in the following way:
-
-```javascript
-const MINUTES_PER_HOUR = 60;
-```
-
-Becomes
-
-```json
-{
-  "type": "VariableDeclaration",
-  "declarations": [
-    {
-      "type": "VariableDeclarator",
-      "id": {
-        "type": "Identifier",
-        "name": "IDENTIFIER_0"
-      },
-      "init": {
-        "type": "Literal",
-        "value": 60,
-        "raw": "60"
-      }
-    }
-  ],
-  "kind": "const"
-},
-```
-
-And keeps track of the mapping:
-
-```json
-{ "IDENTIFIER_0": "MINUTES_PER_HOUR" }
-```
-
-The second declaration:
-
-```javascript
-const HOURS_ON_THE_CLOCK = 24;
-```
-
-Becomes
-
-```json
-{
-  "type": "VariableDeclaration",
-  "declarations": [
-    {
-      "type": "VariableDeclarator",
-      "id": {
-        "type": "Identifier",
-        "name": "IDENTIFIER_1"
-      },
-      "init": {
-        "type": "Literal",
-        "value": 24,
-        "raw": "24"
-      }
-    }
-  ],
-  "kind": "const"
-},
-```
-
-And keeps track of the mapping:
-
-```json
-{
-  "IDENTIFIER_0": "MINUTES_PER_HOUR",
-  "IDENTIFIER_1": "HOURS_ON_THE_CLOCK"
-}
-```
-
-And finally the third declaration:
-
-```javascript
-const MINUTES_PER_CLOCK = MINUTES_PER_HOUR * HOURS_ON_THE_CLOCK;
-```
-
-will use the tracked mapping to replace its "variables".
-
-```json
-{
-  "type": "VariableDeclaration",
-  "declarations": [
-    {
-      "type": "VariableDeclarator",
-      "id": {
-        "type": "Identifier",
-        "name": "IDENTIFIER_2"
-      },
-      "init": {
-        "type": "BinaryExpression",
-        "operator": "*",
-        "left": {
-          "type": "Identifier",
-          "name": "IDENTIFIER_0"
-        },
-        "right": {
-          "type": "Identifier",
-          "name": "IDENTIFIER_1"
-        }
-      }
-    }
-  ],
-  "kind": "const"
-}
-```
-
-## What is an identifier?
-
-In JavaScript, anything that _identifiers_ a variable, property, or function is an _identifier_.
-
-```javascript
-const FOO = 42;
-// => FOO is an identifier (variable)
-
-function bar() {}
-// => bar is an identifier (function)
-
-class Baz {}
-// => Baz is an identifier (function)
-
-object.pew = {};
-// => pew is an identifier (property)
-// => object is an identifier (variable)
-```
-
-You can drop any code into [AST explorer](https://astexplorer.net/) and configure it for `@typescript-eslint/parser`.
-
-## What is equivalent?
-
-Given all things just said, the following code snippets are equivalent:
-
-```javascript
-const SECONDS_TO_RELOAD = 3;
-
-function bang_time() {
-  return SECONDS_TO_RELOAD + 1;
-}
-```
-
-and
-
-```javascript
-const PewPower = 3;
-function pewpewpew() {
-  return PewPower + 1;
-}
-```
-
-## What is not equivalent?
-
-- Re-ordering declarations.
-  Unfortunately in JavaScript declaration order _can_ matter and thus it's not normalised away
-- Different ways of declarating a variable.
-  `const`, `var`, and `let` are _purposefully_ not normalised away, because each has its own use cases.
-- Different ways of declaring a function.
-  `const foo = () => {}`, `const foo = function() {}` and `function foo() {}` are all completely different, at the moment.
-  We may normalise this down the line.

--- a/exercises/shared/.docs/representations.md
+++ b/exercises/shared/.docs/representations.md
@@ -1,6 +1,6 @@
 ## JavaScript representations
 
-The [JavaScript representer][github-javascript-representer] applies the following normalizations: 
+The [JavaScript representer][github-javascript-representer] applies the following normalizations:
 
 - [All comments are removed][docs-representer-normalizations-comments]
 - [All whitespace is normalized][docs-representer-normalizations-whitespace]


### PR DESCRIPTION
This normalizes (ha pun intended) the representer guide documentation by adding a new doc with the examples, simplifying the snippet doc shown in the mentoring automation guide.