### PR TITLE
refactor: Use substring instead of substr

### DIFF
--- a/exercises/practice/ocr-numbers/.meta/proof.ci.js
+++ b/exercises/practice/ocr-numbers/.meta/proof.ci.js
@@ -30,7 +30,7 @@ const splitIntoDigits = (row) => {
   for (let digitNumber = 0; digitNumber < rows[0].length; digitNumber += 3) {
     let digit = '';
     for (let rowNumber = 0; rowNumber < rows.length; rowNumber += 1) {
-      digit += rows[rowNumber].substr(digitNumber, 3);
+      digit += rows[rowNumber].substring(digitNumber, digitNumber+3);
     }
     digits.push(digit);
   }

--- a/exercises/practice/robot-name/robot-name.spec.js
+++ b/exercises/practice/robot-name/robot-name.spec.js
@@ -1,10 +1,10 @@
 import { Robot } from './robot-name';
 
 const areSequential = (name1, name2) => {
-  const alpha1 = name1.substr(0, 2);
-  const alpha2 = name2.substr(0, 2);
-  const num1 = Number(name1.substr(2, 3));
-  const num2 = Number(name2.substr(2, 3));
+  const alpha1 = name1.substring(0, 2);
+  const alpha2 = name2.substring(0, 2);
+  const num1 = Number(name1.substring(2, 5));
+  const num2 = Number(name2.substring(2, 5));
 
   const numDiff = num2 - num1;
   const alphaDiff =

--- a/exercises/practice/simple-cipher/simple-cipher.spec.js
+++ b/exercises/practice/simple-cipher/simple-cipher.spec.js
@@ -8,11 +8,11 @@ describe('Random key cipher', () => {
     // Here we take advantage of the fact that plaintext of "aaa..."
     // outputs the key. This is a critical problem with shift ciphers, some
     // characters will always output the key verbatim.
-    expect(cipher.encode('aaaaaaaaaa')).toEqual(cipher.key.substr(0, 10));
+    expect(cipher.encode('aaaaaaaaaa')).toEqual(cipher.key.substring(0, 10));
   });
 
   xtest('can decode', () => {
-    expect(cipher.decode(cipher.key.substr(0, 10))).toEqual('aaaaaaaaaa');
+    expect(cipher.decode(cipher.key.substring(0, 10))).toEqual('aaaaaaaaaa');
   });
 
   xtest('is reversible', () => {


### PR DESCRIPTION
Since `String.prototype.substr()` is [no longer recommended](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr), let's get rid of it here, too 🙂 