### PR TITLE
DRY up tests to remove extra tests and to make the intent more clear

### DIFF
--- a/exercises/concept/freelancer-rates/freelancer-rates.spec.js
+++ b/exercises/concept/freelancer-rates/freelancer-rates.spec.js
@@ -9,14 +9,9 @@ import {
 const DIFFERENCE_PRECISION_IN_DIGITS = 6;
 
 describe('day rate', () => {
-  test('at 16/hour', () => {
-    const actual = dayRate(16);
-    expect(actual).toBe(128);
-  });
-
-  test('at 25/hour', () => {
-    const actual = dayRate(25);
-    expect(actual).toBe(200);
+  test('calculates given hourly rate, assuming 8-hour day', () => {
+    expect(dayRate(1)).toBe(8);
+    expect(dayRate(2)).toBe(2 * 8);
   });
 
   test('at 31.40/hour', () => {


### PR DESCRIPTION
I propose 
- to have only 2 tests as they are enough to test that the right logic is used
- to use simple numbers starting with 1 and 2, rather than 16 and 25 which most people will find it hard to do mental math
- to use the multiplication itself in the expected result rather than result of the multiplication - show 2*8 instead of 16