### PR TITLE
Add examples to undefined

### DIFF
--- a/concepts/null-undefined/introduction.md
+++ b/concepts/null-undefined/introduction.md
@@ -40,8 +40,8 @@ That means while `null` represents an empty value (but still a value), `undefine
 - If you try to access a value for a non-existing key in an object, you get `undefined`.
 
   ```js
-  let obj = { 
-    name: 'John' 
+  let obj = {
+    name: 'John',
   };
   console.log(obj.age); // => undefined
   ```
@@ -49,16 +49,16 @@ That means while `null` represents an empty value (but still a value), `undefine
 - If a function does not return a value, the result is `undefined`.
 
   ```js
-  function printName(name){
-    "My name is " + name;
+  function printName(name) {
+    'My name is ' + name;
   }
-  console.log(printName("John")); // => undefined
+  console.log(printName('John')); // => undefined
   ```
 
 - If an argument is not passed to a function, it is `undefined`, unless that argument has a default value.
 
   ```js
-  function printName(name){
+  function printName(name) {
     return name;
   }
   console.log(printName()); // => undefined

--- a/concepts/null-undefined/introduction.md
+++ b/concepts/null-undefined/introduction.md
@@ -31,14 +31,35 @@ That means while `null` represents an empty value (but still a value), `undefine
 `undefined` appears in different contexts.
 
 - If a variable is declared without a value (initialization), it is `undefined`.
+
+```js
+let name;
+console.log(name); // => undefined
+```
+
 - If you try to access a value for a non-existing key in an object, you get `undefined`.
+
+```js
+let obj = { name: 'John' };
+console.log(obj.age); // => undefined
+```
+
 - If a function does not return a value, the result is `undefined`.
+
+```js
+function printName(name){
+  "My name is " + name;
+}
+console.log(printName("John")); // => undefined
+```
+
 - If an argument is not passed to a function, it is `undefined`, unless that argument has a default value.
 
-```javascript
-let name;
-console.log(name);
-// => undefined
+```js
+function printName(name){
+  return name;
+}
+console.log(printName()); // => undefined
 ```
 
 You can check whether a variable is undefined using the strict equality operator `===`.

--- a/concepts/null-undefined/introduction.md
+++ b/concepts/null-undefined/introduction.md
@@ -32,35 +32,37 @@ That means while `null` represents an empty value (but still a value), `undefine
 
 - If a variable is declared without a value (initialization), it is `undefined`.
 
-```js
-let name;
-console.log(name); // => undefined
-```
+  ```js
+  let name;
+  console.log(name); // => undefined
+  ```
 
 - If you try to access a value for a non-existing key in an object, you get `undefined`.
 
-```js
-let obj = { name: 'John' };
-console.log(obj.age); // => undefined
-```
+  ```js
+  let obj = { 
+    name: 'John' 
+  };
+  console.log(obj.age); // => undefined
+  ```
 
 - If a function does not return a value, the result is `undefined`.
 
-```js
-function printName(name){
-  "My name is " + name;
-}
-console.log(printName("John")); // => undefined
-```
+  ```js
+  function printName(name){
+    "My name is " + name;
+  }
+  console.log(printName("John")); // => undefined
+  ```
 
 - If an argument is not passed to a function, it is `undefined`, unless that argument has a default value.
 
-```js
-function printName(name){
-  return name;
-}
-console.log(printName()); // => undefined
-```
+  ```js
+  function printName(name){
+    return name;
+  }
+  console.log(printName()); // => undefined
+  ```
 
 You can check whether a variable is undefined using the strict equality operator `===`.
 


### PR DESCRIPTION
I realized that the examples were missing while going over the list of different contexts in which the **undefined** appears. This PR adds these examples to the list items.