### PR TITLE
Ensure recalculation when a new function is passed in

### DIFF
--- a/exercises/concept/coordinate-transformation/coordinate-transformation.spec.js
+++ b/exercises/concept/coordinate-transformation/coordinate-transformation.spec.js
@@ -128,4 +128,14 @@ describe('memoizeTransform', () => {
     expect(memoizedTransform(1, 1)).toEqual([2, 2]);
     expect(mockFunction).toBeCalledTimes(3);
   });
+
+  test('should recalculate when a new function is passed in', () => {
+    const sumFunction = (x, y) => x + y;
+    const differenceFunction = (x, y) => x - y;
+    const memoizedSum = memoizeTransform(sumFunction);
+    const memoizedDifference = memoizeTransform(differenceFunction);
+
+    expect(memoizedSum(1, 2)).toEqual(3);
+    expect(memoizedDifference(1, 2)).toEqual(-1);
+  });
 });


### PR DESCRIPTION
Context
-------

Coming from other programming languages, the [scope](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures#scoping_with_let_and_const) of the cached values may be surprising in JavaScript. When looking at community solutions, I was certainly surprised that other folks were not testing whether `f` had changed between invocations of the closure returned from `memoizeTransform()`.

Change
------

Add a new test case asserting that different values of `f` have different caches.