### PR TITLE
move the resize test to the correct describe block

### DIFF
--- a/exercises/concept/windowing-system/windowing-system.spec.js
+++ b/exercises/concept/windowing-system/windowing-system.spec.js
@@ -92,6 +92,17 @@ describe('resize', () => {
     expect(programWindow.size.width).toBe(1);
     expect(programWindow.size.height).toBe(1);
   });
+  
+  test('resize respects limits due to position and screen size', () => {
+    const programWindow = new ProgramWindow();
+    const newPosition = new Position(710, 525);
+    programWindow.move(newPosition);
+    const newSize = new Size(1000, 1000);
+    programWindow.resize(newSize);
+
+    expect(programWindow.size.width).toBe(90);
+    expect(programWindow.size.height).toBe(75);
+  });
 });
 
 describe('move', () => {
@@ -122,17 +133,6 @@ describe('move', () => {
 
     expect(programWindow.position.x).toBe(700);
     expect(programWindow.position.y).toBe(500);
-  });
-
-  test('resize respects limits due to position and screen size', () => {
-    const programWindow = new ProgramWindow();
-    const newPosition = new Position(710, 525);
-    programWindow.move(newPosition);
-    const newSize = new Size(1000, 1000);
-    programWindow.resize(newSize);
-
-    expect(programWindow.size.width).toBe(90);
-    expect(programWindow.size.height).toBe(75);
   });
 });
 


### PR DESCRIPTION
as of now, the resize test to check whether whether window boundaries are respected is in the wrong describe block.