### PR TITLE
Correct a bank-account test to close account

### DIFF
--- a/exercises/practice/bank-account/bank-account.spec.js
+++ b/exercises/practice/bank-account/bank-account.spec.js
@@ -66,6 +66,7 @@ describe('Bank Account', () => {
 
   xtest('close already closed account throws error', () => {
     const account = new BankAccount();
+    account.close();
     expect(() => {
       account.close();
     }).toThrow(ValueError);


### PR DESCRIPTION
The test that checks "close already closed account throws error"  does not currently try to close the account twice. Adding in `account.close()` before the `expect()` should fix this.