### PR TITLE
:sparkles: Sync `transpose` with problem-specifications

### DIFF
--- a/exercises/practice/transpose/.meta/tests.toml
+++ b/exercises/practice/transpose/.meta/tests.toml
@@ -34,3 +34,6 @@ description = "rectangle"
 
 [b80badc9-057e-4543-bd07-ce1296a1ea2c]
 description = "triangle"
+
+[76acfd50-5596-4d05-89f1-5116328a7dd9]
+description = "jagged triangle"

--- a/exercises/practice/transpose/transpose.spec.js
+++ b/exercises/practice/transpose/transpose.spec.js
@@ -88,6 +88,35 @@ describe('Transpose', () => {
     expect(transpose(input)).toEqual(expected);
   });
 
+  xtest('mixed line length', () => {
+    const input = [
+      'The longest line.',
+      'A long line.',
+      'A longer line.',
+      'A line.',
+    ];
+    const expected = [
+      'TAAA',
+      'h   ',
+      'elll',
+      ' ooi',
+      'lnnn',
+      'ogge',
+      'n e.',
+      'glr',
+      'ei ',
+      'snl',
+      'tei',
+      ' .n',
+      'l e',
+      'i .',
+      'n',
+      'e',
+      '.',
+    ];
+    expect(transpose(input)).toEqual(expected);
+  });
+
   xtest('square', () => {
     const input = ['HEART', 'EMBER', 'ABUSE', 'RESIN', 'TREND'];
     const expected = ['HEART', 'EMBER', 'ABUSE', 'RESIN', 'TREND'];
@@ -118,6 +147,19 @@ describe('Transpose', () => {
       '   SER',
       '    ER',
       '     R',
+    ];
+    expect(transpose(input)).toEqual(expected);
+  });
+
+  xtest('jagged triangle', () => {
+    const input = ['11', '2', '3333', '444', '555555', '66666'];
+    const expected = [
+      '123456',
+      '1 3456',
+      '  3456',
+      '  3 56',
+      '    56',
+      '    5',
     ];
     expect(transpose(input)).toEqual(expected);
   });


### PR DESCRIPTION
Follow-up from this topic: https://forum.exercism.org/t/transpose-ensure-all-lines-are-right-trimmed/5165

- `mixed line length` was already in the `exercises/practice/transpose/.meta/tests.toml` file
- `jagged triangle` was missing too so I went ahead and synced it too

@SleeplessByte