### PR TITLE
Aesthetic changes

### DIFF
--- a/exercises/practice/resistor-color/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color/.docs/instructions.append.md
@@ -1,3 +1,3 @@
 # Instructions append
 
-Although the color names are capitalised in the description, the function colorCode will always be called with the lowercase equivalent, e.g brown instead of Brown
+Although the color names are capitalized in the description, the function `colorCode` will always be called with the lowercase equivalent, e.g "brown" instead of "Brown".


### PR DESCRIPTION
The change of "capitalized" is due to the US English rule. Revert if unnecessary.