### PR TITLE
Added curly brackets to JSDoc type declaration.

### DIFF
--- a/exercises/concept/elyses-destructured-enchantments/enchantments.js
+++ b/exercises/concept/elyses-destructured-enchantments/enchantments.js
@@ -46,7 +46,7 @@ export function discardTopCard(deck) {
   throw new Error('Implement the discardTopCard function');
 }
 
-/** @type Card[] **/
+/** @type {Card[]} **/
 const FACE_CARDS = ['jack', 'queen', 'king'];
 
 /**


### PR DESCRIPTION
JSDoc requires curly brackets for type declarations.  Solves issue where insertFaceCards function return was being highlighted as incorrect type when FACE_CARDS were spread into returned array.