### PR TITLE
Convert backtick (`) admonition fences to tildes (~)

### DIFF
--- a/concepts/array-transformations/about.md
+++ b/concepts/array-transformations/about.md
@@ -144,6 +144,7 @@ console.log(arr);
 // => ['a', 'b', 'c', 'z']
 ```
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/caution
 This default behavior leads to wrong results when you try to sort numbers.
 
@@ -154,6 +155,7 @@ arr.sort();
 // Because the string '10' comes before '2' in dictionary order.
 ```
 ~~~~
+<!-- prettier-ignore-end -->
 
 To customize the sorting behavior, you can pass a comparison function as an argument.
 The comparison function itself is called with two arguments which are two elements of the array.

--- a/concepts/array-transformations/about.md
+++ b/concepts/array-transformations/about.md
@@ -144,7 +144,7 @@ console.log(arr);
 // => ['a', 'b', 'c', 'z']
 ```
 
-~~~~exercism/caution
+````exercism/caution
 This default behavior leads to wrong results when you try to sort numbers.
 
 ```javascript
@@ -153,7 +153,7 @@ arr.sort();
 // => [1, 10, 2, 3]
 // Because the string '10' comes before '2' in dictionary order.
 ```
-~~~~
+````
 
 To customize the sorting behavior, you can pass a comparison function as an argument.
 The comparison function itself is called with two arguments which are two elements of the array.

--- a/concepts/array-transformations/about.md
+++ b/concepts/array-transformations/about.md
@@ -144,7 +144,7 @@ console.log(arr);
 // => ['a', 'b', 'c', 'z']
 ```
 
-````exercism/caution
+~~~~exercism/caution
 This default behavior leads to wrong results when you try to sort numbers.
 
 ```javascript
@@ -153,7 +153,7 @@ arr.sort();
 // => [1, 10, 2, 3]
 // Because the string '10' comes before '2' in dictionary order.
 ```
-````
+~~~~
 
 To customize the sorting behavior, you can pass a comparison function as an argument.
 The comparison function itself is called with two arguments which are two elements of the array.

--- a/concepts/classes/about.md
+++ b/concepts/classes/about.md
@@ -36,6 +36,7 @@ Before that, it was accessible via the key `__proto__` in many environments.
 
 Do not confuse the prototype of an object (`[[prototype]]`) with the `prototype` property of the constructor function.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 To summarize:
 
@@ -44,6 +45,7 @@ To summarize:
 - Functions are objects (callable objects) and therefore they can have properties.
 - The constructor's (function) `prototype` property will become the instance's _prototype_.
 ~~~~
+<!-- prettier-ignore-end -->
 
 ### Instance Fields
 
@@ -124,11 +126,13 @@ The `[[prototype]]` of `Object` is usually `null` so the prototype chain ends th
 In conclusion, you can call `myCar.toString()` and that method will exist because JavaScript searches for that method throughout the whole prototype chain.
 You can find a detailed example in the [MDN article "Inheritance and the prototype chain"][mdn-prototype-chain-example].
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/caution
 Note that the prototype chain is only travelled when retrieving a value.
 Setting a property directly or deleting a property of an instance object only targets that specific instance.
 This might not be what you would expect when you are used to a language with class-based inheritance.
 ~~~~
+<!-- prettier-ignore-end -->
 
 ### Dynamic Methods (Adding Methods to All Existing Instances)
 

--- a/concepts/classes/about.md
+++ b/concepts/classes/about.md
@@ -36,14 +36,14 @@ Before that, it was accessible via the key `__proto__` in many environments.
 
 Do not confuse the prototype of an object (`[[prototype]]`) with the `prototype` property of the constructor function.
 
-~~~~exercism/note
+```exercism/note
 To summarize:
 
 - Constructors in JavaScript are regular functions.
 - Constructing a new instance creates an object with a relation to its constructor called its _prototype_.
 - Functions are objects (callable objects) and therefore they can have properties.
 - The constructor's (function) `prototype` property will become the instance's _prototype_.
-~~~~
+```
 
 ### Instance Fields
 
@@ -124,11 +124,11 @@ The `[[prototype]]` of `Object` is usually `null` so the prototype chain ends th
 In conclusion, you can call `myCar.toString()` and that method will exist because JavaScript searches for that method throughout the whole prototype chain.
 You can find a detailed example in the [MDN article "Inheritance and the prototype chain"][mdn-prototype-chain-example].
 
-~~~~exercism/caution
+```exercism/caution
 Note that the prototype chain is only travelled when retrieving a value.
 Setting a property directly or deleting a property of an instance object only targets that specific instance.
 This might not be what you would expect when you are used to a language with class-based inheritance.
-~~~~
+```
 
 ### Dynamic Methods (Adding Methods to All Existing Instances)
 

--- a/concepts/classes/about.md
+++ b/concepts/classes/about.md
@@ -36,14 +36,14 @@ Before that, it was accessible via the key `__proto__` in many environments.
 
 Do not confuse the prototype of an object (`[[prototype]]`) with the `prototype` property of the constructor function.
 
-```exercism/note
+~~~~exercism/note
 To summarize:
 
 - Constructors in JavaScript are regular functions.
 - Constructing a new instance creates an object with a relation to its constructor called its _prototype_.
 - Functions are objects (callable objects) and therefore they can have properties.
 - The constructor's (function) `prototype` property will become the instance's _prototype_.
-```
+~~~~
 
 ### Instance Fields
 
@@ -124,11 +124,11 @@ The `[[prototype]]` of `Object` is usually `null` so the prototype chain ends th
 In conclusion, you can call `myCar.toString()` and that method will exist because JavaScript searches for that method throughout the whole prototype chain.
 You can find a detailed example in the [MDN article "Inheritance and the prototype chain"][mdn-prototype-chain-example].
 
-```exercism/caution
+~~~~exercism/caution
 Note that the prototype chain is only travelled when retrieving a value.
 Setting a property directly or deleting a property of an instance object only targets that specific instance.
 This might not be what you would expect when you are used to a language with class-based inheritance.
-```
+~~~~
 
 ### Dynamic Methods (Adding Methods to All Existing Instances)
 

--- a/concepts/classes/introduction.md
+++ b/concepts/classes/introduction.md
@@ -31,14 +31,14 @@ Every instance object includes a hidden, internal property referred to as `[[pro
 It holds a reference to the value of the `prototype` key of the constructor function.
 Yes, you read that correctly, a JavaScript function can have key/value pairs because it is also an object behind the scenes.
 
-~~~~exercism/note
+```exercism/note
 To summarize:
 
 - Constructors in JavaScript are regular functions.
 - Constructing a new instance creates an object with a relation to its constructor called its _prototype_.
 - Functions are objects (callable objects) and therefore they can have properties.
 - The constructor's (function) `prototype` property will become the instance's _prototype_.
-~~~~
+```
 
 ### Instance Fields
 
@@ -117,11 +117,11 @@ The `[[prototype]]` property of `Car.prototype` (`myCar.[[prototype]].[[prototyp
 It contains general methods that are available for all JavaScript objects, e.g. `toString()`.
 In conclusion, you can call `myCar.toString()` and that method will exist because JavaScript searches for that method throughout the whole prototype chain.
 
-~~~~exercism/caution
+```exercism/caution
 Note that the prototype chain is only travelled when retrieving a value.
 Setting a property directly or deleting a property of an instance object only targets that specific instance.
 This might not be what you would expect when you are used to a language with class-based inheritance.
-~~~~
+```
 
 ## Class Syntax
 

--- a/concepts/classes/introduction.md
+++ b/concepts/classes/introduction.md
@@ -31,6 +31,7 @@ Every instance object includes a hidden, internal property referred to as `[[pro
 It holds a reference to the value of the `prototype` key of the constructor function.
 Yes, you read that correctly, a JavaScript function can have key/value pairs because it is also an object behind the scenes.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 To summarize:
 
@@ -39,6 +40,7 @@ To summarize:
 - Functions are objects (callable objects) and therefore they can have properties.
 - The constructor's (function) `prototype` property will become the instance's _prototype_.
 ~~~~
+<!-- prettier-ignore-end -->
 
 ### Instance Fields
 
@@ -117,11 +119,13 @@ The `[[prototype]]` property of `Car.prototype` (`myCar.[[prototype]].[[prototyp
 It contains general methods that are available for all JavaScript objects, e.g. `toString()`.
 In conclusion, you can call `myCar.toString()` and that method will exist because JavaScript searches for that method throughout the whole prototype chain.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/caution
 Note that the prototype chain is only travelled when retrieving a value.
 Setting a property directly or deleting a property of an instance object only targets that specific instance.
 This might not be what you would expect when you are used to a language with class-based inheritance.
 ~~~~
+<!-- prettier-ignore-end -->
 
 ## Class Syntax
 

--- a/concepts/classes/introduction.md
+++ b/concepts/classes/introduction.md
@@ -31,14 +31,14 @@ Every instance object includes a hidden, internal property referred to as `[[pro
 It holds a reference to the value of the `prototype` key of the constructor function.
 Yes, you read that correctly, a JavaScript function can have key/value pairs because it is also an object behind the scenes.
 
-```exercism/note
+~~~~exercism/note
 To summarize:
 
 - Constructors in JavaScript are regular functions.
 - Constructing a new instance creates an object with a relation to its constructor called its _prototype_.
 - Functions are objects (callable objects) and therefore they can have properties.
 - The constructor's (function) `prototype` property will become the instance's _prototype_.
-```
+~~~~
 
 ### Instance Fields
 
@@ -117,11 +117,11 @@ The `[[prototype]]` property of `Car.prototype` (`myCar.[[prototype]].[[prototyp
 It contains general methods that are available for all JavaScript objects, e.g. `toString()`.
 In conclusion, you can call `myCar.toString()` and that method will exist because JavaScript searches for that method throughout the whole prototype chain.
 
-```exercism/caution
+~~~~exercism/caution
 Note that the prototype chain is only travelled when retrieving a value.
 Setting a property directly or deleting a property of an instance object only targets that specific instance.
 This might not be what you would expect when you are used to a language with class-based inheritance.
-```
+~~~~
 
 ## Class Syntax
 

--- a/concepts/dates/about.md
+++ b/concepts/dates/about.md
@@ -32,11 +32,11 @@ However, different types of arguments can also be used to create date object, as
 >
 > [^1]
 
-```exercism/note
+~~~~exercism/note
 > January 1st, 1970 at 00:00:00 UTC is referred to as the Unix epoch.
 > Unix is an operating system originally developed in the 1960s.
 > Early Unix engineers picked that date arbitrarily because they needed to set a uniform date for the start of time, and > New Year's Day, 1970, seemed most convenient. [^2]
-```
+~~~~
 
 ### Timestamp string
 
@@ -115,9 +115,9 @@ const d3 = Date.parse('2019-01-01T00:00:00.000');
 // it is set to your local time zone.
 ```
 
-```exercism/caution
+~~~~exercism/caution
 The use of `Date.parse()` (and the timestamp string method which works similarly) is strongly discouraged due to browser differences and inconsistencies. [^5]
-```
+~~~~
 
 ## Accessing `Date` components
 
@@ -141,12 +141,12 @@ const date1 = new Date(2020, 11, 13, 5); // Dec 13 2020 5:00:00
 let millsecs = date1.getTime(); // find out how many have milliseconds passed since Jan 1 1890!
 ```
 
-```exercism/caution
+~~~~exercism/caution
 Many JavaScript engines implement a non-standard method `getYear()`.
 **This method is deprecated.**
 It returns a 2-digit year sometimes.
 Hence, `getFullYear()` must always be used instead.
-```
+~~~~
 
 ## Modifying `Date` components
 

--- a/concepts/dates/about.md
+++ b/concepts/dates/about.md
@@ -32,11 +32,11 @@ However, different types of arguments can also be used to create date object, as
 >
 > [^1]
 
-~~~~exercism/note
+```exercism/note
 > January 1st, 1970 at 00:00:00 UTC is referred to as the Unix epoch.
 > Unix is an operating system originally developed in the 1960s.
 > Early Unix engineers picked that date arbitrarily because they needed to set a uniform date for the start of time, and > New Year's Day, 1970, seemed most convenient. [^2]
-~~~~
+```
 
 ### Timestamp string
 
@@ -115,9 +115,9 @@ const d3 = Date.parse('2019-01-01T00:00:00.000');
 // it is set to your local time zone.
 ```
 
-~~~~exercism/caution
+```exercism/caution
 The use of `Date.parse()` (and the timestamp string method which works similarly) is strongly discouraged due to browser differences and inconsistencies. [^5]
-~~~~
+```
 
 ## Accessing `Date` components
 
@@ -141,12 +141,12 @@ const date1 = new Date(2020, 11, 13, 5); // Dec 13 2020 5:00:00
 let millsecs = date1.getTime(); // find out how many have milliseconds passed since Jan 1 1890!
 ```
 
-~~~~exercism/caution
+```exercism/caution
 Many JavaScript engines implement a non-standard method `getYear()`.
 **This method is deprecated.**
 It returns a 2-digit year sometimes.
 Hence, `getFullYear()` must always be used instead.
-~~~~
+```
 
 ## Modifying `Date` components
 

--- a/concepts/dates/about.md
+++ b/concepts/dates/about.md
@@ -32,11 +32,13 @@ However, different types of arguments can also be used to create date object, as
 >
 > [^1]
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 > January 1st, 1970 at 00:00:00 UTC is referred to as the Unix epoch.
 > Unix is an operating system originally developed in the 1960s.
 > Early Unix engineers picked that date arbitrarily because they needed to set a uniform date for the start of time, and > New Year's Day, 1970, seemed most convenient. [^2]
 ~~~~
+<!-- prettier-ignore-end -->
 
 ### Timestamp string
 
@@ -115,9 +117,11 @@ const d3 = Date.parse('2019-01-01T00:00:00.000');
 // it is set to your local time zone.
 ```
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/caution
 The use of `Date.parse()` (and the timestamp string method which works similarly) is strongly discouraged due to browser differences and inconsistencies. [^5]
 ~~~~
+<!-- prettier-ignore-end -->
 
 ## Accessing `Date` components
 
@@ -141,12 +145,14 @@ const date1 = new Date(2020, 11, 13, 5); // Dec 13 2020 5:00:00
 let millsecs = date1.getTime(); // find out how many have milliseconds passed since Jan 1 1890!
 ```
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/caution
 Many JavaScript engines implement a non-standard method `getYear()`.
 **This method is deprecated.**
 It returns a 2-digit year sometimes.
 Hence, `getFullYear()` must always be used instead.
 ~~~~
+<!-- prettier-ignore-end -->
 
 ## Modifying `Date` components
 

--- a/concepts/dates/introduction.md
+++ b/concepts/dates/introduction.md
@@ -98,9 +98,9 @@ const date2 = new Date(2013, 12, 5, 13, 24, 0);
 Shorter variants are also possible, like `YYYY-MM-DD` or `YYYY-MM` or even `YYYY`. However, note that these variants **set the `Date` to UTC**, even though `Z` not mentioned.
 To understand what exactly happens check out [this section][mdn-diff-assumed-timezone] of a MDN page.
 
-~~~~exercism/caution
+```exercism/caution
 The use of `Date.parse()` (and the timestamp string method which works similarly) is strongly discouraged due to browser differences and inconsistencies. [^4]
-~~~~
+```
 
 ## Accessing `Date` components
 

--- a/concepts/dates/introduction.md
+++ b/concepts/dates/introduction.md
@@ -98,9 +98,9 @@ const date2 = new Date(2013, 12, 5, 13, 24, 0);
 Shorter variants are also possible, like `YYYY-MM-DD` or `YYYY-MM` or even `YYYY`. However, note that these variants **set the `Date` to UTC**, even though `Z` not mentioned.
 To understand what exactly happens check out [this section][mdn-diff-assumed-timezone] of a MDN page.
 
-```exercism/caution
+~~~~exercism/caution
 The use of `Date.parse()` (and the timestamp string method which works similarly) is strongly discouraged due to browser differences and inconsistencies. [^4]
-```
+~~~~
 
 ## Accessing `Date` components
 

--- a/concepts/dates/introduction.md
+++ b/concepts/dates/introduction.md
@@ -98,9 +98,11 @@ const date2 = new Date(2013, 12, 5, 13, 24, 0);
 Shorter variants are also possible, like `YYYY-MM-DD` or `YYYY-MM` or even `YYYY`. However, note that these variants **set the `Date` to UTC**, even though `Z` not mentioned.
 To understand what exactly happens check out [this section][mdn-diff-assumed-timezone] of a MDN page.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/caution
 The use of `Date.parse()` (and the timestamp string method which works similarly) is strongly discouraged due to browser differences and inconsistencies. [^4]
 ~~~~
+<!-- prettier-ignore-end -->
 
 ## Accessing `Date` components
 

--- a/exercises/concept/bird-watcher/.docs/instructions.md
+++ b/exercises/concept/bird-watcher/.docs/instructions.md
@@ -6,9 +6,9 @@ You already digitalized the bird counts per day for the past weeks that you kept
 
 Now you want to determine the total number of birds that you counted, calculate the bird count for a specific week and correct a counting mistake.
 
-~~~~exercism/note
+```exercism/note
 To practice, use a for loop to solve each of the tasks below.
-~~~~
+```
 
 ## 1. Determine the total number of birds that you counted so far
 

--- a/exercises/concept/bird-watcher/.docs/instructions.md
+++ b/exercises/concept/bird-watcher/.docs/instructions.md
@@ -6,9 +6,9 @@ You already digitalized the bird counts per day for the past weeks that you kept
 
 Now you want to determine the total number of birds that you counted, calculate the bird count for a specific week and correct a counting mistake.
 
-```exercism/note
+~~~~exercism/note
 To practice, use a for loop to solve each of the tasks below.
-```
+~~~~
 
 ## 1. Determine the total number of birds that you counted so far
 

--- a/exercises/concept/bird-watcher/.docs/instructions.md
+++ b/exercises/concept/bird-watcher/.docs/instructions.md
@@ -6,9 +6,11 @@ You already digitalized the bird counts per day for the past weeks that you kept
 
 Now you want to determine the total number of birds that you counted, calculate the bird count for a specific week and correct a counting mistake.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 To practice, use a for loop to solve each of the tasks below.
 ~~~~
+<!-- prettier-ignore-end -->
 
 ## 1. Determine the total number of birds that you counted so far
 

--- a/exercises/concept/elyses-enchantments/.docs/instructions.md
+++ b/exercises/concept/elyses-enchantments/.docs/instructions.md
@@ -9,9 +9,9 @@ of a certain card corresponds to the index in the array. That means
 position 0 refers to the first card, position 1 to the second card
 etc.
 
-```exercism/note
+~~~~exercism/note
 All functions should update the array of cards and then return the modified array - a common way of working known as the Builder pattern, which allows you to nicely daisy-chain functions together.
-```
+~~~~
 
 ## 1. Retrieve a card from a stack
 

--- a/exercises/concept/elyses-enchantments/.docs/instructions.md
+++ b/exercises/concept/elyses-enchantments/.docs/instructions.md
@@ -9,9 +9,9 @@ of a certain card corresponds to the index in the array. That means
 position 0 refers to the first card, position 1 to the second card
 etc.
 
-~~~~exercism/note
+```exercism/note
 All functions should update the array of cards and then return the modified array - a common way of working known as the Builder pattern, which allows you to nicely daisy-chain functions together.
-~~~~
+```
 
 ## 1. Retrieve a card from a stack
 

--- a/exercises/concept/elyses-enchantments/.docs/instructions.md
+++ b/exercises/concept/elyses-enchantments/.docs/instructions.md
@@ -9,9 +9,11 @@ of a certain card corresponds to the index in the array. That means
 position 0 refers to the first card, position 1 to the second card
 etc.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 All functions should update the array of cards and then return the modified array - a common way of working known as the Builder pattern, which allows you to nicely daisy-chain functions together.
 ~~~~
+<!-- prettier-ignore-end -->
 
 ## 1. Retrieve a card from a stack
 

--- a/exercises/concept/translation-service/.docs/instructions.md
+++ b/exercises/concept/translation-service/.docs/instructions.md
@@ -46,14 +46,14 @@ api.request('majQa’', callback);
 
 **⚠ Warning! ⚠**
 
-~~~~exercism/caution
+```exercism/caution
 The API works its magic by teleporting in the various translators when a `request` comes in.
 This is a very costly action, so it shouldn't be called when a translation *is* available.
 Unfortunately, not everyone reads the manual, so there is a system in place to kick-out bad actors.
 
 If an `api.request` is called for `text` is available, the API throws an `AbusiveClientError` for this call, **and every call after that**.
 Ensure that you *never* request a translation if something has already been translated.
-~~~~
+```
 
 ## 1. Fetch a translation, ignoring the quality
 
@@ -131,6 +131,6 @@ service.premium("'arlogh Qoylu'pu'?", 40);
 
 **N.B.**
 
-~~~~exercism/note
+```exercism/note
 The correct translation of `'arlogh Qoylu'pu'?` is **How many times has it been heard?**.
-~~~~
+```

--- a/exercises/concept/translation-service/.docs/instructions.md
+++ b/exercises/concept/translation-service/.docs/instructions.md
@@ -46,6 +46,7 @@ api.request('majQa’', callback);
 
 **⚠ Warning! ⚠**
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/caution
 The API works its magic by teleporting in the various translators when a `request` comes in.
 This is a very costly action, so it shouldn't be called when a translation *is* available.
@@ -54,6 +55,7 @@ Unfortunately, not everyone reads the manual, so there is a system in place to k
 If an `api.request` is called for `text` is available, the API throws an `AbusiveClientError` for this call, **and every call after that**.
 Ensure that you *never* request a translation if something has already been translated.
 ~~~~
+<!-- prettier-ignore-end -->
 
 ## 1. Fetch a translation, ignoring the quality
 
@@ -96,7 +98,7 @@ service.batch([]);
 ## 3. Request a translation, retrying at most 2 times
 
 Implement a premium user method `request(text)`, that _requests_ a translation be added to the _API storage_.
-The request should automatically retry if a failure occurs.  
+The request should automatically retry if a failure occurs.
 It should perform no more than **3 calls** for the same request (_don't upset the space translators!!!_).
 
 - If `api.request` does not return an error, resolve with `undefined`
@@ -131,6 +133,8 @@ service.premium("'arlogh Qoylu'pu'?", 40);
 
 **N.B.**
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 The correct translation of `'arlogh Qoylu'pu'?` is **How many times has it been heard?**.
 ~~~~
+<!-- prettier-ignore-end -->

--- a/exercises/concept/translation-service/.docs/instructions.md
+++ b/exercises/concept/translation-service/.docs/instructions.md
@@ -46,14 +46,14 @@ api.request('majQa’', callback);
 
 **⚠ Warning! ⚠**
 
-```exercism/caution
+~~~~exercism/caution
 The API works its magic by teleporting in the various translators when a `request` comes in.
 This is a very costly action, so it shouldn't be called when a translation *is* available.
 Unfortunately, not everyone reads the manual, so there is a system in place to kick-out bad actors.
 
 If an `api.request` is called for `text` is available, the API throws an `AbusiveClientError` for this call, **and every call after that**.
 Ensure that you *never* request a translation if something has already been translated.
-```
+~~~~
 
 ## 1. Fetch a translation, ignoring the quality
 
@@ -131,6 +131,6 @@ service.premium("'arlogh Qoylu'pu'?", 40);
 
 **N.B.**
 
-```exercism/note
+~~~~exercism/note
 The correct translation of `'arlogh Qoylu'pu'?` is **How many times has it been heard?**.
-```
+~~~~

--- a/exercises/concept/windowing-system/.docs/introduction.md
+++ b/exercises/concept/windowing-system/.docs/introduction.md
@@ -31,14 +31,14 @@ Every instance object includes a hidden, internal property referred to as `[[pro
 It holds a reference to the value of the `prototype` key of the constructor function.
 Yes, you read that correctly, a JavaScript function can have key/value pairs because it is also an object behind the scenes.
 
-~~~~exercism/note
+```exercism/note
 To summarize:
 
 - Constructors in JavaScript are regular functions.
 - Constructing a new instance creates an object with a relation to its constructor called its _prototype_.
 - Functions are objects (callable objects) and therefore they can have properties.
 - The constructor's (function) `prototype` property will become the instance's _prototype_.
-~~~~
+```
 
 ### Instance Fields
 
@@ -117,11 +117,11 @@ The `[[prototype]]` property of `Car.prototype` (`myCar.[[prototype]].[[prototyp
 It contains general methods that are available for all JavaScript objects, e.g. `toString()`.
 In conclusion, you can call `myCar.toString()` and that method will exist because JavaScript searches for that method throughout the whole prototype chain.
 
-~~~~exercism/caution
+```exercism/caution
 Note that the prototype chain is only travelled when retrieving a value.
 Setting a property directly or deleting a property of an instance object only targets that specific instance.
 This might not be what you would expect when you are used to a language with class-based inheritance.
-~~~~
+```
 
 ## Class Syntax
 

--- a/exercises/concept/windowing-system/.docs/introduction.md
+++ b/exercises/concept/windowing-system/.docs/introduction.md
@@ -31,6 +31,7 @@ Every instance object includes a hidden, internal property referred to as `[[pro
 It holds a reference to the value of the `prototype` key of the constructor function.
 Yes, you read that correctly, a JavaScript function can have key/value pairs because it is also an object behind the scenes.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 To summarize:
 
@@ -39,6 +40,7 @@ To summarize:
 - Functions are objects (callable objects) and therefore they can have properties.
 - The constructor's (function) `prototype` property will become the instance's _prototype_.
 ~~~~
+<!-- prettier-ignore-end -->
 
 ### Instance Fields
 
@@ -117,11 +119,13 @@ The `[[prototype]]` property of `Car.prototype` (`myCar.[[prototype]].[[prototyp
 It contains general methods that are available for all JavaScript objects, e.g. `toString()`.
 In conclusion, you can call `myCar.toString()` and that method will exist because JavaScript searches for that method throughout the whole prototype chain.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/caution
 Note that the prototype chain is only travelled when retrieving a value.
 Setting a property directly or deleting a property of an instance object only targets that specific instance.
 This might not be what you would expect when you are used to a language with class-based inheritance.
 ~~~~
+<!-- prettier-ignore-end -->
 
 ## Class Syntax
 

--- a/exercises/concept/windowing-system/.docs/introduction.md
+++ b/exercises/concept/windowing-system/.docs/introduction.md
@@ -31,14 +31,14 @@ Every instance object includes a hidden, internal property referred to as `[[pro
 It holds a reference to the value of the `prototype` key of the constructor function.
 Yes, you read that correctly, a JavaScript function can have key/value pairs because it is also an object behind the scenes.
 
-```exercism/note
+~~~~exercism/note
 To summarize:
 
 - Constructors in JavaScript are regular functions.
 - Constructing a new instance creates an object with a relation to its constructor called its _prototype_.
 - Functions are objects (callable objects) and therefore they can have properties.
 - The constructor's (function) `prototype` property will become the instance's _prototype_.
-```
+~~~~
 
 ### Instance Fields
 
@@ -117,11 +117,11 @@ The `[[prototype]]` property of `Car.prototype` (`myCar.[[prototype]].[[prototyp
 It contains general methods that are available for all JavaScript objects, e.g. `toString()`.
 In conclusion, you can call `myCar.toString()` and that method will exist because JavaScript searches for that method throughout the whole prototype chain.
 
-```exercism/caution
+~~~~exercism/caution
 Note that the prototype chain is only travelled when retrieving a value.
 Setting a property directly or deleting a property of an instance object only targets that specific instance.
 This might not be what you would expect when you are used to a language with class-based inheritance.
-```
+~~~~
 
 ## Class Syntax
 

--- a/exercises/practice/bob/.approaches/answer-array/content.md
+++ b/exercises/practice/bob/.approaches/answer-array/content.md
@@ -27,10 +27,10 @@ The correct answer is selected from the array by using the score as the array in
 The [`String`][string] [trimEnd][trimend] method is applied to the input to eliminate any whitespace at the end of the input.
 If the string has no characters left, it returns the response for saying nothing.
 
-~~~~exercism/caution
+```exercism/caution
 Note that a `null` or `undefined` `String` would be different from a `String` of all whitespace.
 A `null` or `undefined` `String` would raise a `TypeError` if `trimEnd` were applied to it.
-~~~~
+```
 
 The first half of the shout condition
 

--- a/exercises/practice/bob/.approaches/answer-array/content.md
+++ b/exercises/practice/bob/.approaches/answer-array/content.md
@@ -27,10 +27,10 @@ The correct answer is selected from the array by using the score as the array in
 The [`String`][string] [trimEnd][trimend] method is applied to the input to eliminate any whitespace at the end of the input.
 If the string has no characters left, it returns the response for saying nothing.
 
-```exercism/caution
+~~~~exercism/caution
 Note that a `null` or `undefined` `String` would be different from a `String` of all whitespace.
 A `null` or `undefined` `String` would raise a `TypeError` if `trimEnd` were applied to it.
-```
+~~~~
 
 The first half of the shout condition
 

--- a/exercises/practice/bob/.approaches/answer-array/content.md
+++ b/exercises/practice/bob/.approaches/answer-array/content.md
@@ -27,10 +27,12 @@ The correct answer is selected from the array by using the score as the array in
 The [`String`][string] [trimEnd][trimend] method is applied to the input to eliminate any whitespace at the end of the input.
 If the string has no characters left, it returns the response for saying nothing.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/caution
 Note that a `null` or `undefined` `String` would be different from a `String` of all whitespace.
 A `null` or `undefined` `String` would raise a `TypeError` if `trimEnd` were applied to it.
 ~~~~
+<!-- prettier-ignore-end -->
 
 The first half of the shout condition
 

--- a/exercises/practice/bob/.approaches/if-statements/content.md
+++ b/exercises/practice/bob/.approaches/if-statements/content.md
@@ -24,21 +24,25 @@ export function hey(message) {
 In this approach you have a series of `if` statements using the private methods to evaluate the conditions.
 As soon as the right condition is found, the correct response is returned.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 Note that there are no `else if` or `else` statements.
 If an `if` statement can return, then an `else if` or `else` is not needed.
 Execution will either return or will continue to the next statement anyway.
 ~~~~
+<!-- prettier-ignore-end -->
 
 The [`String`][string] [trimEnd][trimend] method is applied to the input to eliminate any whitespace at the end of the input.
 If the string has no characters left, it returns the response for saying nothing.
 
 The `String` method [endsWith][endswith] is used to determine if the input ends with a question mark.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/caution
 Note that a `null` or `undefined` `String` would be different from a `String` of all whitespace.
 A `null` or `undefined` `String` would raise a `TypeError` if `trimEnd` were applied to it.
 ~~~~
+<!-- prettier-ignore-end -->
 
 The first half of the shout condition
 

--- a/exercises/practice/bob/.approaches/if-statements/content.md
+++ b/exercises/practice/bob/.approaches/if-statements/content.md
@@ -24,21 +24,21 @@ export function hey(message) {
 In this approach you have a series of `if` statements using the private methods to evaluate the conditions.
 As soon as the right condition is found, the correct response is returned.
 
-~~~~exercism/note
+```exercism/note
 Note that there are no `else if` or `else` statements.
 If an `if` statement can return, then an `else if` or `else` is not needed.
 Execution will either return or will continue to the next statement anyway.
-~~~~
+```
 
 The [`String`][string] [trimEnd][trimend] method is applied to the input to eliminate any whitespace at the end of the input.
 If the string has no characters left, it returns the response for saying nothing.
 
 The `String` method [endsWith][endswith] is used to determine if the input ends with a question mark.
 
-~~~~exercism/caution
+```exercism/caution
 Note that a `null` or `undefined` `String` would be different from a `String` of all whitespace.
 A `null` or `undefined` `String` would raise a `TypeError` if `trimEnd` were applied to it.
-~~~~
+```
 
 The first half of the shout condition
 

--- a/exercises/practice/bob/.approaches/if-statements/content.md
+++ b/exercises/practice/bob/.approaches/if-statements/content.md
@@ -24,21 +24,21 @@ export function hey(message) {
 In this approach you have a series of `if` statements using the private methods to evaluate the conditions.
 As soon as the right condition is found, the correct response is returned.
 
-```exercism/note
+~~~~exercism/note
 Note that there are no `else if` or `else` statements.
 If an `if` statement can return, then an `else if` or `else` is not needed.
 Execution will either return or will continue to the next statement anyway.
-```
+~~~~
 
 The [`String`][string] [trimEnd][trimend] method is applied to the input to eliminate any whitespace at the end of the input.
 If the string has no characters left, it returns the response for saying nothing.
 
 The `String` method [endsWith][endswith] is used to determine if the input ends with a question mark.
 
-```exercism/caution
+~~~~exercism/caution
 Note that a `null` or `undefined` `String` would be different from a `String` of all whitespace.
 A `null` or `undefined` `String` would raise a `TypeError` if `trimEnd` were applied to it.
-```
+~~~~
 
 The first half of the shout condition
 

--- a/exercises/practice/bob/.approaches/switch-statement/content.md
+++ b/exercises/practice/bob/.approaches/switch-statement/content.md
@@ -29,10 +29,12 @@ The `switch` returns the right response for a question, shout, shouted question,
 The [`String`][string] [trimEnd][trimend] method is applied to the input to eliminate any whitespace at the end of the input.
 If the string has no characters left, it returns the response for saying nothing.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/caution
 Note that a `null` or `undefined` `String` would be different from a `String` of all whitespace.
 A `null` or `undefined` `String` would raise a `TypeError` if `trimEnd` were applied to it.
 ~~~~
+<!-- prettier-ignore-end -->
 
 The first half of the shout condition
 

--- a/exercises/practice/bob/.approaches/switch-statement/content.md
+++ b/exercises/practice/bob/.approaches/switch-statement/content.md
@@ -29,10 +29,10 @@ The `switch` returns the right response for a question, shout, shouted question,
 The [`String`][string] [trimEnd][trimend] method is applied to the input to eliminate any whitespace at the end of the input.
 If the string has no characters left, it returns the response for saying nothing.
 
-~~~~exercism/caution
+```exercism/caution
 Note that a `null` or `undefined` `String` would be different from a `String` of all whitespace.
 A `null` or `undefined` `String` would raise a `TypeError` if `trimEnd` were applied to it.
-~~~~
+```
 
 The first half of the shout condition
 

--- a/exercises/practice/bob/.approaches/switch-statement/content.md
+++ b/exercises/practice/bob/.approaches/switch-statement/content.md
@@ -29,10 +29,10 @@ The `switch` returns the right response for a question, shout, shouted question,
 The [`String`][string] [trimEnd][trimend] method is applied to the input to eliminate any whitespace at the end of the input.
 If the string has no characters left, it returns the response for saying nothing.
 
-```exercism/caution
+~~~~exercism/caution
 Note that a `null` or `undefined` `String` would be different from a `String` of all whitespace.
 A `null` or `undefined` `String` would raise a `TypeError` if `trimEnd` were applied to it.
-```
+~~~~
 
 The first half of the shout condition
 

--- a/exercises/practice/etl/.docs/instructions.md
+++ b/exercises/practice/etl/.docs/instructions.md
@@ -22,6 +22,6 @@ This needs to be changed to store each individual letter with its score in a one
 
 As part of this change, the team has also decided to change the letters to be lower-case rather than upper-case.
 
-~~~~exercism/note
+```exercism/note
 If you want to look at how the data was previously structured and how it needs to change, take a look at the examples in the test suite.
-~~~~
+```

--- a/exercises/practice/etl/.docs/instructions.md
+++ b/exercises/practice/etl/.docs/instructions.md
@@ -22,6 +22,6 @@ This needs to be changed to store each individual letter with its score in a one
 
 As part of this change, the team has also decided to change the letters to be lower-case rather than upper-case.
 
-```exercism/note
+~~~~exercism/note
 If you want to look at how the data was previously structured and how it needs to change, take a look at the examples in the test suite.
-```
+~~~~

--- a/exercises/practice/etl/.docs/instructions.md
+++ b/exercises/practice/etl/.docs/instructions.md
@@ -22,6 +22,8 @@ This needs to be changed to store each individual letter with its score in a one
 
 As part of this change, the team has also decided to change the letters to be lower-case rather than upper-case.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 If you want to look at how the data was previously structured and how it needs to change, take a look at the examples in the test suite.
 ~~~~
+<!-- prettier-ignore-end -->

--- a/exercises/practice/gigasecond/.docs/introduction.md
+++ b/exercises/practice/gigasecond/.docs/introduction.md
@@ -13,7 +13,7 @@ Then we can use metric system prefixes for writing large numbers of seconds in m
 - Perhaps you and your family would travel to somewhere exotic for two megaseconds (that's two million seconds).
 - And if you and your spouse were married for _a thousand million_ seconds, you would celebrate your one gigasecond anniversary.
 
-~~~~exercism/note
+```exercism/note
 If we ever colonize Mars or some other planet, measuring time is going to get even messier.
 If someone says "year" do they mean a year on Earth or a year on Mars?
 
@@ -21,4 +21,4 @@ The idea for this exercise came from the science fiction novel ["A Deepness in t
 In it the author uses the metric system as the basis for time measurements.
 
 [vinge-novel]: https://www.tor.com/2017/08/03/science-fiction-with-something-for-everyone-a-deepness-in-the-sky-by-vernor-vinge/
-~~~~
+```

--- a/exercises/practice/gigasecond/.docs/introduction.md
+++ b/exercises/practice/gigasecond/.docs/introduction.md
@@ -13,7 +13,7 @@ Then we can use metric system prefixes for writing large numbers of seconds in m
 - Perhaps you and your family would travel to somewhere exotic for two megaseconds (that's two million seconds).
 - And if you and your spouse were married for _a thousand million_ seconds, you would celebrate your one gigasecond anniversary.
 
-```exercism/note
+~~~~exercism/note
 If we ever colonize Mars or some other planet, measuring time is going to get even messier.
 If someone says "year" do they mean a year on Earth or a year on Mars?
 
@@ -21,4 +21,4 @@ The idea for this exercise came from the science fiction novel ["A Deepness in t
 In it the author uses the metric system as the basis for time measurements.
 
 [vinge-novel]: https://www.tor.com/2017/08/03/science-fiction-with-something-for-everyone-a-deepness-in-the-sky-by-vernor-vinge/
-```
+~~~~

--- a/exercises/practice/gigasecond/.docs/introduction.md
+++ b/exercises/practice/gigasecond/.docs/introduction.md
@@ -13,6 +13,7 @@ Then we can use metric system prefixes for writing large numbers of seconds in m
 - Perhaps you and your family would travel to somewhere exotic for two megaseconds (that's two million seconds).
 - And if you and your spouse were married for _a thousand million_ seconds, you would celebrate your one gigasecond anniversary.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 If we ever colonize Mars or some other planet, measuring time is going to get even messier.
 If someone says "year" do they mean a year on Earth or a year on Mars?
@@ -22,3 +23,4 @@ In it the author uses the metric system as the basis for time measurements.
 
 [vinge-novel]: https://www.tor.com/2017/08/03/science-fiction-with-something-for-everyone-a-deepness-in-the-sky-by-vernor-vinge/
 ~~~~
+<!-- prettier-ignore-end -->

--- a/exercises/practice/grains/.approaches/bit-shifting/content.md
+++ b/exercises/practice/grains/.approaches/bit-shifting/content.md
@@ -15,9 +15,9 @@ export function total() {
 
 Instead of using math to calculate the number of grains on a square, you can set a bit in the correct position of a [`BigInt`][bigint] value.
 
-```exercism/note
+~~~~exercism/note
 Note that a `BigInt` literal can be specified by appending `n` to the value.
-```
+~~~~
 
 To understand how this works, consider just two squares that are represented in binary bits as `00`.
 

--- a/exercises/practice/grains/.approaches/bit-shifting/content.md
+++ b/exercises/practice/grains/.approaches/bit-shifting/content.md
@@ -15,9 +15,11 @@ export function total() {
 
 Instead of using math to calculate the number of grains on a square, you can set a bit in the correct position of a [`BigInt`][bigint] value.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 Note that a `BigInt` literal can be specified by appending `n` to the value.
 ~~~~
+<!-- prettier-ignore-end -->
 
 To understand how this works, consider just two squares that are represented in binary bits as `00`.
 

--- a/exercises/practice/grains/.approaches/bit-shifting/content.md
+++ b/exercises/practice/grains/.approaches/bit-shifting/content.md
@@ -15,9 +15,9 @@ export function total() {
 
 Instead of using math to calculate the number of grains on a square, you can set a bit in the correct position of a [`BigInt`][bigint] value.
 
-~~~~exercism/note
+```exercism/note
 Note that a `BigInt` literal can be specified by appending `n` to the value.
-~~~~
+```
 
 To understand how this works, consider just two squares that are represented in binary bits as `00`.
 

--- a/exercises/practice/grains/.approaches/exponentiation/content.md
+++ b/exercises/practice/grains/.approaches/exponentiation/content.md
@@ -19,9 +19,9 @@ JavaScript uses the [exponential operator][exponentiation] to raise a number by 
 Exponentiation is nicely suited to the problem, since we start with one grain and keep doubling the number of grains on each successive square.
 `1` grain is `2n ** 0`, `2` grains is `2n ** 1`, `4` is `2n ** 2`, and so on.
 
-~~~~exercism/note
+```exercism/note
 Note that a [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) literal can be specified by appending `n` to the value.
-~~~~
+```
 
 So, to get the right exponent, we subtract `1` from the square number `num`.
 

--- a/exercises/practice/grains/.approaches/exponentiation/content.md
+++ b/exercises/practice/grains/.approaches/exponentiation/content.md
@@ -19,9 +19,9 @@ JavaScript uses the [exponential operator][exponentiation] to raise a number by 
 Exponentiation is nicely suited to the problem, since we start with one grain and keep doubling the number of grains on each successive square.
 `1` grain is `2n ** 0`, `2` grains is `2n ** 1`, `4` is `2n ** 2`, and so on.
 
-```exercism/note
+~~~~exercism/note
 Note that a [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) literal can be specified by appending `n` to the value.
-```
+~~~~
 
 So, to get the right exponent, we subtract `1` from the square number `num`.
 

--- a/exercises/practice/grains/.approaches/exponentiation/content.md
+++ b/exercises/practice/grains/.approaches/exponentiation/content.md
@@ -19,9 +19,11 @@ JavaScript uses the [exponential operator][exponentiation] to raise a number by 
 Exponentiation is nicely suited to the problem, since we start with one grain and keep doubling the number of grains on each successive square.
 `1` grain is `2n ** 0`, `2` grains is `2n ** 1`, `4` is `2n ** 2`, and so on.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 Note that a [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) literal can be specified by appending `n` to the value.
 ~~~~
+<!-- prettier-ignore-end -->
 
 So, to get the right exponent, we subtract `1` from the square number `num`.
 

--- a/exercises/practice/isogram/.approaches/bitfield/content.md
+++ b/exercises/practice/isogram/.approaches/bitfield/content.md
@@ -32,10 +32,10 @@ The ASCII value for `A` is `65`.
 - The `string` loops through its characters and looks for a character being `a` through `z` or `A` through `Z`.
 - If a letter is found, then its ASCII value is taken by the [`charCodeAt`][charcodeat] method.
 
-```exercism/note
+~~~~exercism/note
 `charCodeAt` actually returns the UTF-16 code unit for the character, which is an integer between `0` and `65535`.
 For the letters `a`-`z` and `A`-`Z`, the UTF-16 number is the same value as the ASCII value.
-```
+~~~~
 
 - If the lowercase letter is subtracted by `97`, then `a` will result in `0`, because `97` minus `97` equals `0`.
   `z` would result in `25`, because `122` minus `97` equals `25`.

--- a/exercises/practice/isogram/.approaches/bitfield/content.md
+++ b/exercises/practice/isogram/.approaches/bitfield/content.md
@@ -32,10 +32,10 @@ The ASCII value for `A` is `65`.
 - The `string` loops through its characters and looks for a character being `a` through `z` or `A` through `Z`.
 - If a letter is found, then its ASCII value is taken by the [`charCodeAt`][charcodeat] method.
 
-~~~~exercism/note
+```exercism/note
 `charCodeAt` actually returns the UTF-16 code unit for the character, which is an integer between `0` and `65535`.
 For the letters `a`-`z` and `A`-`Z`, the UTF-16 number is the same value as the ASCII value.
-~~~~
+```
 
 - If the lowercase letter is subtracted by `97`, then `a` will result in `0`, because `97` minus `97` equals `0`.
   `z` would result in `25`, because `122` minus `97` equals `25`.

--- a/exercises/practice/isogram/.approaches/bitfield/content.md
+++ b/exercises/practice/isogram/.approaches/bitfield/content.md
@@ -32,10 +32,12 @@ The ASCII value for `A` is `65`.
 - The `string` loops through its characters and looks for a character being `a` through `z` or `A` through `Z`.
 - If a letter is found, then its ASCII value is taken by the [`charCodeAt`][charcodeat] method.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 `charCodeAt` actually returns the UTF-16 code unit for the character, which is an integer between `0` and `65535`.
 For the letters `a`-`z` and `A`-`Z`, the UTF-16 number is the same value as the ASCII value.
 ~~~~
+<!-- prettier-ignore-end -->
 
 - If the lowercase letter is subtracted by `97`, then `a` will result in `0`, because `97` minus `97` equals `0`.
   `z` would result in `25`, because `122` minus `97` equals `25`.

--- a/exercises/practice/leap/.approaches/new-date-getmonth/content.md
+++ b/exercises/practice/leap/.approaches/new-date-getmonth/content.md
@@ -6,17 +6,17 @@ export function isLeap(year) {
 }
 ```
 
-~~~~exercism/caution
+```exercism/caution
 This approach may be considered a "cheat" for this exercise.
-~~~~
+```
 
 By creating a `new` [`Date`][date] from February 29th for the year, you can see if the month is still February.
 If it is, then the year is a leap year.
 This is checked by using the [getMonth][getmonth] method of the `Date` object.
 
-~~~~exercism/note
+```exercism/note
 Note that the value returned from the `getMonth` method is zero-based, meaning that February is `1`, not `2`.
-~~~~
+```
 
 ## Shortening
 

--- a/exercises/practice/leap/.approaches/new-date-getmonth/content.md
+++ b/exercises/practice/leap/.approaches/new-date-getmonth/content.md
@@ -6,17 +6,21 @@ export function isLeap(year) {
 }
 ```
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/caution
 This approach may be considered a "cheat" for this exercise.
 ~~~~
+<!-- prettier-ignore-end -->
 
 By creating a `new` [`Date`][date] from February 29th for the year, you can see if the month is still February.
 If it is, then the year is a leap year.
 This is checked by using the [getMonth][getmonth] method of the `Date` object.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 Note that the value returned from the `getMonth` method is zero-based, meaning that February is `1`, not `2`.
 ~~~~
+<!-- prettier-ignore-end -->
 
 ## Shortening
 

--- a/exercises/practice/leap/.approaches/new-date-getmonth/content.md
+++ b/exercises/practice/leap/.approaches/new-date-getmonth/content.md
@@ -6,17 +6,17 @@ export function isLeap(year) {
 }
 ```
 
-```exercism/caution
+~~~~exercism/caution
 This approach may be considered a "cheat" for this exercise.
-```
+~~~~
 
 By creating a `new` [`Date`][date] from February 29th for the year, you can see if the month is still February.
 If it is, then the year is a leap year.
 This is checked by using the [getMonth][getmonth] method of the `Date` object.
 
-```exercism/note
+~~~~exercism/note
 Note that the value returned from the `getMonth` method is zero-based, meaning that February is `1`, not `2`.
-```
+~~~~
 
 ## Shortening
 

--- a/exercises/practice/linked-list/.docs/instructions.md
+++ b/exercises/practice/linked-list/.docs/instructions.md
@@ -13,7 +13,7 @@ Sometimes a station gets closed down, and in that case the station needs to be r
 
 The size of a route is measured not by how far the train travels, but by how many stations it stops at.
 
-~~~~exercism/note
+```exercism/note
 The linked list is a fundamental data structure in computer science, often used in the implementation of other data structures.
 As the name suggests, it is a list of nodes that are linked together.
 It is a list of "nodes", where each node links to its neighbor or neighbors.
@@ -23,4 +23,4 @@ In a **doubly linked list** each node links to both the node that comes before, 
 If you want to dig deeper into linked lists, check out [this article][intro-linked-list] that explains it using nice drawings.
 
 [intro-linked-list]: https://medium.com/basecs/whats-a-linked-list-anyway-part-1-d8b7e6508b9d
-~~~~
+```

--- a/exercises/practice/linked-list/.docs/instructions.md
+++ b/exercises/practice/linked-list/.docs/instructions.md
@@ -13,7 +13,7 @@ Sometimes a station gets closed down, and in that case the station needs to be r
 
 The size of a route is measured not by how far the train travels, but by how many stations it stops at.
 
-```exercism/note
+~~~~exercism/note
 The linked list is a fundamental data structure in computer science, often used in the implementation of other data structures.
 As the name suggests, it is a list of nodes that are linked together.
 It is a list of "nodes", where each node links to its neighbor or neighbors.
@@ -23,4 +23,4 @@ In a **doubly linked list** each node links to both the node that comes before, 
 If you want to dig deeper into linked lists, check out [this article][intro-linked-list] that explains it using nice drawings.
 
 [intro-linked-list]: https://medium.com/basecs/whats-a-linked-list-anyway-part-1-d8b7e6508b9d
-```
+~~~~

--- a/exercises/practice/linked-list/.docs/instructions.md
+++ b/exercises/practice/linked-list/.docs/instructions.md
@@ -13,6 +13,7 @@ Sometimes a station gets closed down, and in that case the station needs to be r
 
 The size of a route is measured not by how far the train travels, but by how many stations it stops at.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 The linked list is a fundamental data structure in computer science, often used in the implementation of other data structures.
 As the name suggests, it is a list of nodes that are linked together.
@@ -24,3 +25,4 @@ If you want to dig deeper into linked lists, check out [this article][intro-link
 
 [intro-linked-list]: https://medium.com/basecs/whats-a-linked-list-anyway-part-1-d8b7e6508b9d
 ~~~~
+<!-- prettier-ignore-end -->

--- a/exercises/practice/pangram/.approaches/bitfield/content.md
+++ b/exercises/practice/pangram/.approaches/bitfield/content.md
@@ -28,10 +28,10 @@ The value for all of the rightmost 26 bits being set is `67108863`.
 - The `Array` method [`forEach`][foreach] loops through the characters and looks for a character being `a` through `z` or `A` through `Z`.
 - If a letter is found, then its ASCII value is taken by the [`charCodeAt`][charcodeat] method.
 
-~~~~exercism/note
+```exercism/note
 `charCodeAt` actually returns the UTF-16 code unit for the character, which is an integer between `0` and `65535`.
 For the letters `a`-`z` and `A`-`Z`, the UTF-16 number is the same value as the ASCII value.
-~~~~
+```
 
 - If the lowercase letter is subtracted by `97`, then `a` will result in `0`, because `97` minus `97` equals `0`.
   `z` would result in `25`, because `122` minus `97` equals `25`.

--- a/exercises/practice/pangram/.approaches/bitfield/content.md
+++ b/exercises/practice/pangram/.approaches/bitfield/content.md
@@ -28,10 +28,10 @@ The value for all of the rightmost 26 bits being set is `67108863`.
 - The `Array` method [`forEach`][foreach] loops through the characters and looks for a character being `a` through `z` or `A` through `Z`.
 - If a letter is found, then its ASCII value is taken by the [`charCodeAt`][charcodeat] method.
 
-```exercism/note
+~~~~exercism/note
 `charCodeAt` actually returns the UTF-16 code unit for the character, which is an integer between `0` and `65535`.
 For the letters `a`-`z` and `A`-`Z`, the UTF-16 number is the same value as the ASCII value.
-```
+~~~~
 
 - If the lowercase letter is subtracted by `97`, then `a` will result in `0`, because `97` minus `97` equals `0`.
   `z` would result in `25`, because `122` minus `97` equals `25`.

--- a/exercises/practice/pangram/.approaches/bitfield/content.md
+++ b/exercises/practice/pangram/.approaches/bitfield/content.md
@@ -28,10 +28,12 @@ The value for all of the rightmost 26 bits being set is `67108863`.
 - The `Array` method [`forEach`][foreach] loops through the characters and looks for a character being `a` through `z` or `A` through `Z`.
 - If a letter is found, then its ASCII value is taken by the [`charCodeAt`][charcodeat] method.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 `charCodeAt` actually returns the UTF-16 code unit for the character, which is an integer between `0` and `65535`.
 For the letters `a`-`z` and `A`-`Z`, the UTF-16 number is the same value as the ASCII value.
 ~~~~
+<!-- prettier-ignore-end -->
 
 - If the lowercase letter is subtracted by `97`, then `a` will result in `0`, because `97` minus `97` equals `0`.
   `z` would result in `25`, because `122` minus `97` equals `25`.

--- a/exercises/practice/pangram/.docs/introduction.md
+++ b/exercises/practice/pangram/.docs/introduction.md
@@ -7,10 +7,10 @@ To give a comprehensive sense of the font, the random sentences should use **all
 They're running a competition to get suggestions for sentences that they can use.
 You're in charge of checking the submissions to see if they are valid.
 
-```exercism/note
+~~~~exercism/note
 Pangram comes from Greek, παν γράμμα, pan gramma, which means "every letter".
 
 The best known English pangram is:
 
 > The quick brown fox jumps over the lazy dog.
-```
+~~~~

--- a/exercises/practice/pangram/.docs/introduction.md
+++ b/exercises/practice/pangram/.docs/introduction.md
@@ -7,10 +7,10 @@ To give a comprehensive sense of the font, the random sentences should use **all
 They're running a competition to get suggestions for sentences that they can use.
 You're in charge of checking the submissions to see if they are valid.
 
-~~~~exercism/note
+```exercism/note
 Pangram comes from Greek, παν γράμμα, pan gramma, which means "every letter".
 
 The best known English pangram is:
 
 > The quick brown fox jumps over the lazy dog.
-~~~~
+```

--- a/exercises/practice/pangram/.docs/introduction.md
+++ b/exercises/practice/pangram/.docs/introduction.md
@@ -7,6 +7,7 @@ To give a comprehensive sense of the font, the random sentences should use **all
 They're running a competition to get suggestions for sentences that they can use.
 You're in charge of checking the submissions to see if they are valid.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 Pangram comes from Greek, παν γράμμα, pan gramma, which means "every letter".
 
@@ -14,3 +15,4 @@ The best known English pangram is:
 
 > The quick brown fox jumps over the lazy dog.
 ~~~~
+<!-- prettier-ignore-end -->

--- a/exercises/practice/simple-linked-list/.docs/instructions.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.md
@@ -7,7 +7,7 @@ Given a range of numbers (the song IDs), create a singly linked list.
 
 Given a singly linked list, you should be able to reverse the list to play the songs in the opposite order.
 
-~~~~exercism/note
+```exercism/note
 The linked list is a fundamental data structure in computer science, often used in the implementation of other data structures.
 
 The simplest kind of linked list is a **singly** linked list.
@@ -16,4 +16,4 @@ That means that each element (or "node") contains data, along with something tha
 If you want to dig deeper into linked lists, check out [this article][intro-linked-list] that explains it using nice drawings.
 
 [intro-linked-list]: https://medium.com/basecs/whats-a-linked-list-anyway-part-1-d8b7e6508b9d
-~~~~
+```

--- a/exercises/practice/simple-linked-list/.docs/instructions.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.md
@@ -7,7 +7,7 @@ Given a range of numbers (the song IDs), create a singly linked list.
 
 Given a singly linked list, you should be able to reverse the list to play the songs in the opposite order.
 
-```exercism/note
+~~~~exercism/note
 The linked list is a fundamental data structure in computer science, often used in the implementation of other data structures.
 
 The simplest kind of linked list is a **singly** linked list.
@@ -16,4 +16,4 @@ That means that each element (or "node") contains data, along with something tha
 If you want to dig deeper into linked lists, check out [this article][intro-linked-list] that explains it using nice drawings.
 
 [intro-linked-list]: https://medium.com/basecs/whats-a-linked-list-anyway-part-1-d8b7e6508b9d
-```
+~~~~

--- a/exercises/practice/simple-linked-list/.docs/instructions.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.md
@@ -7,6 +7,7 @@ Given a range of numbers (the song IDs), create a singly linked list.
 
 Given a singly linked list, you should be able to reverse the list to play the songs in the opposite order.
 
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 The linked list is a fundamental data structure in computer science, often used in the implementation of other data structures.
 
@@ -17,3 +18,4 @@ If you want to dig deeper into linked lists, check out [this article][intro-link
 
 [intro-linked-list]: https://medium.com/basecs/whats-a-linked-list-anyway-part-1-d8b7e6508b9d
 ~~~~
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
In line with Exercism's spec, we're ensuring that all admonition fences are demarcated with four tildes (`~~~~`) across all repositories. We will be following up with an org-wide script that can be used to keep this consistent. [Problem Specifications](https://github.com/exercism/problem-specifications) has already been updated.

We'll automatically merge this a week from now, but feel free to merge beforehand!

- Spec: https://exercism.org/docs/building/markdown/markdown#h-special-blocks-sometimes-called-admonitions
- Meta issue: https://github.com/exercism/exercism/issues/6705