### PR TITLE
Grains approach fix

### DIFF
--- a/exercises/practice/grains/.approaches/bit-shifting/content.md
+++ b/exercises/practice/grains/.approaches/bit-shifting/content.md
@@ -3,7 +3,7 @@
 ```javascript
 export function square(num) {
   if (num < 1 || num > 64) {
-    throw 'square must be between 1 and 64';
+    throw new Error('square must be between 1 and 64');
   }
   return 1n << (BigInt(num) - 1n);
 }

--- a/exercises/practice/grains/.approaches/bit-shifting/snippet.txt
+++ b/exercises/practice/grains/.approaches/bit-shifting/snippet.txt
@@ -1,6 +1,6 @@
 export function square(num) {
   if (num < 1 || num > 64) {
-    throw "square must be between 1 and 64";
+    throw new Error('square must be between 1 and 64');
   }
   return 1n << (BigInt(num) - 1n);
 }

--- a/exercises/practice/grains/.approaches/introduction.md
+++ b/exercises/practice/grains/.approaches/introduction.md
@@ -44,7 +44,7 @@ For more information, check the [exponentiation approach][approach-exponentiatio
 ```javascript
 export function square(num) {
   if (num < 1 || num > 64) {
-    throw 'square must be between 1 and 64';
+    throw new Error('square must be between 1 and 64');
   }
   return 1n << (BigInt(num) - 1n);
 }


### PR DESCRIPTION
fixed to `throw new Error` instead of just `throw`, which apparently does not throw an error.