### PR TITLE
Fix 'name cannot be modified' test

### DIFF
--- a/exercises/practice/robot-name/robot-name.spec.js
+++ b/exercises/practice/robot-name/robot-name.spec.js
@@ -73,7 +73,7 @@ describe('Robot', () => {
     const modifyInternal = () => {
       robot.name += 'a modification';
     };
-    expect(modifyInternal).toThrow();
+    expect(() => modifyInternal()).toThrow();
   });
 
   xtest('new names should not be sequential', () => {


### PR DESCRIPTION
Without the IIFE, `expect()` fails to detect the failure; see https://forum.exercism.org/t/8300