### PR TITLE
Stop making copies of LICENSE and .gitignore files for each exercise.

### DIFF
--- a/scripts/sync
+++ b/scripts/sync
@@ -38,7 +38,7 @@ function copyConfigForAssignment(assignment) {
     .ShellString(JSON.stringify(mergedPackageJson, undefined, 2) + '\n')
     .to(assignmentPackageFilename);
 
-  ['.eslintrc', '.npmrc', 'babel.config.js', 'LICENSE', '.gitignore'].forEach(
+  ['.eslintrc', '.npmrc', 'babel.config.js'].forEach(
     (file) => {
       shell.cp(file, destination);
     }


### PR DESCRIPTION
The base repo LICENSE should suffice.

git will honor the root .gitignore if a child directory does not contain one.