### PR TITLE
add tests to regular-chatbot.spec.js

### DIFF
--- a/exercises/concept/regular-chatbot/regular-chatbot.spec.js
+++ b/exercises/concept/regular-chatbot/regular-chatbot.spec.js
@@ -56,6 +56,30 @@ describe('checkPhoneNumber', () => {
     expect(checkPhoneNumber('4355-67-274')).toBe(
       "Oops, it seems like I can't reach out to 4355-67-274",
     );
+    expect(checkPhoneNumber('(+34) 6433-876-459')).toBe(
+      "Oops, it seems like I can't reach out to (+34) 6433-876-459",
+    );
+    expect(checkPhoneNumber('(+) 643-876-459')).toBe(
+      "Oops, it seems like I can't reach out to (+) 643-876-459",
+    );
+    expect(checkPhoneNumber(' ')).toBe(
+      "Oops, it seems like I can't reach out to  ",
+    );
+    expect(checkPhoneNumber('(+49) --')).toBe(
+      "Oops, it seems like I can't reach out to (+49) --",
+    );
+    expect(checkPhoneNumber('(+49) 322-876666')).toBe(
+      "Oops, it seems like I can't reach out to (+49) 322-876666",
+    );
+    expect(checkPhoneNumber('(+49) 322787654')).toBe(
+      "Oops, it seems like I can't reach out to (+49) 322787654",
+    );
+    expect(checkPhoneNumber('(+4) 643-876-459')).toBe(
+      "Oops, it seems like I can't reach out to (+4) 643-876-459",
+    );
+    expect(checkPhoneNumber('(+) --')).toBe(
+      "Oops, it seems like I can't reach out to (+) --",
+    );
   });
 });
 


### PR DESCRIPTION
I noticed while completing this exercise that my function would pass the tests even when the  regular expression i was using `/\(\+[0-9]*\)\s[0-9]*\-[0-9]*\-[0-9]*/ ` did match way more patterns than the expected format `(+##) ###-###-###` given in the instructions . 
So i have added a few tests to ensure the regex is a more accurate match to what is being asked.

Thanks, let me know what you think 

