### PR TITLE
Typo fix

### DIFF
--- a/exercises/concept/translation-service/api.js
+++ b/exercises/concept/translation-service/api.js
@@ -74,7 +74,7 @@ export class ExternalApi {
 
     if (typeof callback !== 'function') {
       throw new BadRequest(
-        `Expected callback function when calling fetch(text, callback), actual ${typeof callback}.`,
+        `Expected callback function when calling request(text, callback), actual ${typeof callback}.`,
       );
     }
 


### PR DESCRIPTION
'request' function had an error referencing to itself as 'fetch' function