### PR TITLE
Corrected price spelling and numbered tasks in instructions.

### DIFF
--- a/exercises/concept/pizza-order/.docs/instructions.md
+++ b/exercises/concept/pizza-order/.docs/instructions.md
@@ -10,7 +10,7 @@ If customers want, they can add an unlimited number of extra options: either "Ex
 
 Your task is to write code that assists the customer in figuring out the cost to them.
 
-## Calculate the price of a pizza
+## 1. Calculate the price of a pizza
 
 Provided the pizza's name as the first argument, and an unlimited number of added options, calculate the price of the pizza in dollars.
 
@@ -31,7 +31,7 @@ pizzaPrice(
 // => 17
 ```
 
-## Calculate the total price of an order
+## 2. Calculate the total price of an order
 
 Your function is called with a list of `PizzaOrder`s and should return the total price of the order in dollars.
 Each `PizzaOrder` has a `pizza` property - the pizza's name, and an `extras` property - the list of extra options.

--- a/exercises/concept/pizza-order/.meta/exemplar.js
+++ b/exercises/concept/pizza-order/.meta/exemplar.js
@@ -11,7 +11,7 @@ const PIZZA_PRICES = {
 };
 
 /**
- * Determine the prize of the pizza given the pizza and optional extras
+ * Determine the price of the pizza given the pizza and optional extras
  *
  * @param {Pizza} pizza name of the pizza to be made
  * @param {Extra[]} extras list of extras
@@ -33,7 +33,7 @@ export function pizzaPrice(pizza, ...[extra, ...otherExtras]) {
 }
 
 /**
- * Calculate the prize of the total order, given individual orders
+ * Calculate the price of the total order, given individual orders
  *
  * @param {PizzaOrder[]} pizzaOrders a list of pizza orders
  * @returns {number} the price of the total order

--- a/exercises/concept/pizza-order/pizza-order.js
+++ b/exercises/concept/pizza-order/pizza-order.js
@@ -3,7 +3,7 @@
 // @ts-check
 
 /**
- * Determine the prize of the pizza given the pizza and optional extras
+ * Determine the price of the pizza given the pizza and optional extras
  *
  * @param {Pizza} pizza name of the pizza to be made
  * @param {Extra[]} extras list of extras


### PR DESCRIPTION
Noticed that price was misspelled as 'prize' in a few places and that the hints weren't showing on the website, so I've also updated the instructions to add numbers to the task which should fix that.