### PR TITLE
Ignore org-wide files from prettier check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,10 @@ exercises/**/README.md
 # Originates from https://github.com/exercism/org-wide-files
 CODE_OF_CONDUCT.md
 LICENSE
+.github/workflows/configlet.yml
+.github/workflows/sync-labels.yml
+.github/workflows/no-important-files-changed.yml
+.github/workflows/pause-community-contributions.yml
 
 # These are formatted via configlet and will not match prettier
 exercises/**/.meta/config.json


### PR DESCRIPTION
Fixes current CI failure on main branch: https://github.com/exercism/javascript/actions/runs/8275983609/job/22643776556