### PR TITLE
[Mixed Juices] Fix hints' reference to MDN's fall-though section

### DIFF
--- a/exercises/concept/mixed-juices/.docs/hints.md
+++ b/exercises/concept/mixed-juices/.docs/hints.md
@@ -23,7 +23,7 @@
 - You can combine two conditions for the loop using [logical operators][concept-booleans].
 
 [mdn-switch]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch#
-[mdn-fallthrough]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch#what_happens_if_i_forgot_a_break
+[mdn-fallthrough]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch#taking_advantage_of_fall-through
 [mdn-while]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while
 [mdn-do-while]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/do...while
 [concept-booleans]: /tracks/javascript/concepts/booleans


### PR DESCRIPTION
MDN `switch` documentation has been updated some time ago, so section references has been changed.

This PR fixes the reference to fall-through section in tasks' hints.

### Screenshot

> <img width="600" alt="Screen Shot 2024-04-28 at 6 55 20 PM" src="https://github.com/exercism/javascript/assets/5333431/88bf8fd7-45ed-4bf9-ae6e-f810067555e3">

### Proposed change

| Currently | Suggested |
| --- | --- |
| [https://eveloper.mozilla.org/en-US/docs/.../](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch#what_happens_if_i_forgot_a_break) [switch#**what_happens_if_i_forgot_a_break**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch#what_happens_if_i_forgot_a_break) | [https://developer.mozilla.org/en-US/docs/.../](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch#breaking_and_fall-through) [switch#**breaking_and_fall-through**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch#breaking_and_fall-through) |
| <img width="350" alt="Screen Shot 2024-04-28 at 6 58 47 PM" src="https://github.com/exercism/javascript/assets/5333431/a357c7c7-d644-418d-ae76-c26a5aa6bdcb"> | <img width="350" alt="Screen Shot 2024-04-28 at 6 59 02 PM" src="https://github.com/exercism/javascript/assets/5333431/c0973b67-77ac-40d9-aa53-1c515631e8fa"> |
