### PR TITLE
[factory-sensors] Add test for temperature of 0 degrees

### DIFF
--- a/exercises/concept/factory-sensors/.meta/config.json
+++ b/exercises/concept/factory-sensors/.meta/config.json
@@ -4,7 +4,8 @@
   ],
   "contributors": [
     "SleeplessByte",
-    "junedev"
+    "junedev",
+    "themetar"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/factory-sensors/factory-sensors.spec.js
+++ b/exercises/concept/factory-sensors/factory-sensors.spec.js
@@ -25,6 +25,10 @@ describe('reportOverheating', () => {
     expect(() => reportOverheating(null)).toThrow(ArgumentError);
   });
 
+  test('should not throw if the temperature is 0°C', () => {
+    expect(() => reportOverheating(0)).not.toThrow();
+  });
+
   test('should throw an OverheatingError if the temperature is 501°C', () => {
     expect(() => reportOverheating(501)).toThrow(OverheatingError);
 


### PR DESCRIPTION
This exercise should reject solutions with `!temperature`.

1) In the story `null` is a special signal that the sensor is broken. That means in-universe the sensor will needlessly be replaced if it happens to encounter temperatures of 0 degrees.

2) In our world, the assignment requires that students make distinction between nulls and numbers. 0 is a valid number. There is no reason to have it _intentionally_ be handled differently than -1 or 1 and lumped with `null`.

This is supported by the existing exemplar solution; it uses `if (temperature === null)`