### PR TITLE
Updating tests for armstrong-numbers

### DIFF
--- a/exercises/practice/armstrong-numbers/.docs/instructions.append.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.append.md
@@ -1,2 +1,4 @@
-Note: Some of the tests might pass a `BigInt` as input.
+~~~~exercism/note
+Some of the tests might pass a `BigInt` as input.
 Ensure that your implementation can handle such cases.
+~~~~

--- a/exercises/practice/armstrong-numbers/.docs/instructions.append.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.append.md
@@ -1,4 +1,6 @@
+<!-- prettier-ignore-start -->
 ~~~~exercism/note
 Some of the tests might pass a `BigInt` as input.
 Ensure that your implementation can handle such cases.
 ~~~~
+<!-- prettier-ignore-end -->

--- a/exercises/practice/armstrong-numbers/.docs/instructions.append.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.append.md
@@ -1,0 +1,2 @@
+Note: Some of the tests might pass a `BigInt` as input.
+Ensure that your implementation can handle such cases.

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -6,6 +6,7 @@
     "ankorGH",
     "gargrave",
     "hayashi-ay",
+    "jagdish-15",
     "ovidiu141",
     "SleeplessByte",
     "xarxziux"

--- a/exercises/practice/armstrong-numbers/.meta/proof.ci.js
+++ b/exercises/practice/armstrong-numbers/.meta/proof.ci.js
@@ -1,8 +1,12 @@
 export const isArmstrongNumber = (input) => {
-  const digits = [...String(input)];
+  const bigInput = BigInt(input);
+
+  const digits = [...String(bigInput)];
+
   const sum = digits.reduce(
-    (total, current) => total + current ** digits.length,
-    0,
+    (total, current) => total + BigInt(current) ** BigInt(digits.length),
+    BigInt(0),
   );
-  return sum === input;
+
+  return sum === bigInput;
 };

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -1,30 +1,43 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [c1ed103c-258d-45b2-be73-d8c6d9580c7b]
 description = "Zero is an Armstrong number"
 
 [579e8f03-9659-4b85-a1a2-d64350f6b17a]
-description = "Single digit numbers are Armstrong numbers"
+description = "Single-digit numbers are Armstrong numbers"
 
 [2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
-description = "There are no 2 digit Armstrong numbers"
+description = "There are no two-digit Armstrong numbers"
 
 [509c087f-e327-4113-a7d2-26a4e9d18283]
-description = "Three digit number that is an Armstrong number"
+description = "Three-digit number that is an Armstrong number"
 
 [7154547d-c2ce-468d-b214-4cb953b870cf]
-description = "Three digit number that is not an Armstrong number"
+description = "Three-digit number that is not an Armstrong number"
 
 [6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
-description = "Four digit number that is an Armstrong number"
+description = "Four-digit number that is an Armstrong number"
 
 [eed4b331-af80-45b5-a80b-19c9ea444b2e]
-description = "Four digit number that is not an Armstrong number"
+description = "Four-digit number that is not an Armstrong number"
 
 [f971ced7-8d68-4758-aea1-d4194900b864]
-description = "Seven digit number that is an Armstrong number"
+description = "Seven-digit number that is an Armstrong number"
 
 [7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
-description = "Seven digit number that is not an Armstrong number"
+description = "Seven-digit number that is not an Armstrong number"
+
+[5ee2fdf8-334e-4a46-bb8d-e5c19c02c148]
+description = "Armstrong number containing seven zeroes"
+
+[12ffbf10-307a-434e-b4ad-c925680e1dd4]
+description = "The largest and last Armstrong number"

--- a/exercises/practice/armstrong-numbers/armstrong-numbers.spec.js
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.spec.js
@@ -37,4 +37,12 @@ describe('Armstrong Numbers', () => {
   xtest('Seven digit number that is not an Armstrong number', () => {
     expect(isArmstrongNumber(9926314)).toEqual(false);
   });
+
+  xtest('Armstrong number containing seven zeroes', () => {
+    expect(isArmstrongNumber(186709961001538790100634132976990)).toEqual(true);
+  });
+
+  xtest('The largest and last Armstrong number', () => {
+    expect(isArmstrongNumber(115132219018763992565095597973971522401)).toEqual(true);
+  });
 });

--- a/exercises/practice/armstrong-numbers/armstrong-numbers.spec.js
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.spec.js
@@ -6,46 +6,45 @@ describe('Armstrong Numbers', () => {
     expect(isArmstrongNumber(0)).toEqual(true);
   });
 
-  xtest('Single digit numbers are Armstrong numbers', () => {
+  xtest('Single-digit numbers are Armstrong numbers', () => {
     expect(isArmstrongNumber(5)).toEqual(true);
   });
 
-  xtest('There are no 2 digit Armstrong numbers', () => {
+  xtest('There are no two-digit Armstrong numbers', () => {
     expect(isArmstrongNumber(10)).toEqual(false);
   });
 
-  xtest('Three digit number that is an Armstrong number', () => {
+  xtest('Three-digit number that is an Armstrong number', () => {
     expect(isArmstrongNumber(153)).toEqual(true);
   });
 
-  xtest('Three digit number that is not an Armstrong number', () => {
+  xtest('Three-digit number that is not an Armstrong number', () => {
     expect(isArmstrongNumber(100)).toEqual(false);
   });
 
-  xtest('Four digit number that is an Armstrong number', () => {
+  xtest('Four-digit number that is an Armstrong number', () => {
     expect(isArmstrongNumber(9474)).toEqual(true);
   });
 
-  xtest('Four digit number that is not an Armstrong number', () => {
+  xtest('Four-digit number that is not an Armstrong number', () => {
     expect(isArmstrongNumber(9475)).toEqual(false);
   });
 
-  xtest('Seven digit number that is an Armstrong number', () => {
+  xtest('Seven-digit number that is an Armstrong number', () => {
     expect(isArmstrongNumber(9926315)).toEqual(true);
   });
 
-  xtest('Seven digit number that is not an Armstrong number', () => {
+  xtest('Seven-digit number that is not an Armstrong number', () => {
     expect(isArmstrongNumber(9926314)).toEqual(false);
   });
 
   xtest('Armstrong number containing seven zeroes', () => {
-    const largeNumber = BigInt(`186709961001538790100634132976990`);
-    expect(isArmstrongNumber(largeNumber)).toEqual(true);
+    const bigInput = 186709961001538790100634132976990n;
+    expect(isArmstrongNumber(bigInput)).toEqual(true);
   });
 
   xtest('The largest and last Armstrong number', () => {
-    expect(
-      isArmstrongNumber(`115132219018763992565095597973971522401`),
-    ).toEqual(true);
+    const bigInput = 115132219018763992565095597973971522401n;
+    expect(isArmstrongNumber(bigInput)).toEqual(true);
   });
 });

--- a/exercises/practice/armstrong-numbers/armstrong-numbers.spec.js
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.spec.js
@@ -39,10 +39,13 @@ describe('Armstrong Numbers', () => {
   });
 
   xtest('Armstrong number containing seven zeroes', () => {
-    expect(isArmstrongNumber(186709961001538790100634132976990)).toEqual(true);
+    const largeNumber = BigInt(`186709961001538790100634132976990`);
+    expect(isArmstrongNumber(largeNumber)).toEqual(true);
   });
 
   xtest('The largest and last Armstrong number', () => {
-    expect(isArmstrongNumber(115132219018763992565095597973971522401)).toEqual(true);
+    expect(
+      isArmstrongNumber(`115132219018763992565095597973971522401`),
+    ).toEqual(true);
   });
 });


### PR DESCRIPTION
# Pull Request

This PR adds two new test cases to the Armstrong-Numbers exercise to align it with the `problem-specifications` repository. However, both numbers in these new tests are extremely large and will cause the `test-runner` to fail. Please let me know how you'd like me to proceed with this!