### PR TITLE
Updating tests and proof solution for palindrome-products

### DIFF
--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -3,8 +3,10 @@
   "contributors": [
     "ankorGH",
     "cmccandless",
+    "Cool-Katt",
     "draalger",
     "ErikSchierboom",
+    "jagdish-15",
     "javaeeeee",
     "kytrinyx",
     "matthewmorgan",

--- a/exercises/practice/palindrome-products/.meta/proof.ci.js
+++ b/exercises/practice/palindrome-products/.meta/proof.ci.js
@@ -1,88 +1,38 @@
-const reverseString = (str) => str.split('').reverse().join('');
-
-class Palindrome {
-  constructor(factor1, factor2) {
-    this.value = factor1 * factor2;
-    this.factors = [[factor1, factor2]];
-  }
-
-  withFactors(factors) {
-    this.factors.push(factors);
-    return this;
-  }
-
-  valid() {
-    const s = `${this.value}`;
-    return s === reverseString(s);
-  }
-
-  merge(other) {
-    other.factors.forEach((f) => {
-      this.factors.push(f);
-    });
-    return this;
-  }
-}
-
 export class Palindromes {
-  constructor(maxFactor, minFactor = 1) {
-    this.maxFactor = maxFactor;
-    this.minFactor = minFactor;
-  }
-
-  get largest() {
-    let left = this.maxFactor,
-      right = this.maxFactor,
-      best = new Palindrome(this.minFactor, this.minFactor);
-
-    while (right >= this.minFactor) {
-      let p = new Palindrome(left, right);
-
-      if (best.value && p.value < best.value) {
-        right--;
-        left = right;
-        continue;
-      }
-
-      if (p.valid()) {
-        if (best.value < p.value) {
-          best = p;
-        } else if (best.value === p.value) {
-          best = p.merge(best);
+  static generate({ minFactor, maxFactor }) {
+    if (minFactor > maxFactor) throw new Error('min must be <= max');
+    let isPalindrome = (n) =>
+      [...n.toString()].reverse().join('') === n.toString();
+    let search = (n, pred, fn) => {
+      while (pred(n)) {
+        if (!isPalindrome(n)) {
+          n = fn(n);
+          continue;
         }
-      }
-
-      if (left <= this.minFactor) {
-        right--;
-        left = right;
-      } else {
-        left--;
-      }
-    }
-
-    if (best.valid()) {
-      return best;
-    }
-
-    return { value: null, factors: [] };
-  }
-
-  get smallest() {
-    for (let m = this.minFactor; m <= this.maxFactor; m += 1) {
-      for (let n = m; n <= this.maxFactor; n += 1) {
-        const p = new Palindrome(m, n);
-        if (p.valid()) {
-          return p;
+        let factors = [];
+        for (let p = minFactor; p <= n / p; p++) {
+          if (n % p === 0) {
+            let q = n / p;
+            if (q <= maxFactor) factors.push([p, q]);
+          }
         }
+        if (factors.length > 0) return { value: n, factors };
+        n = fn(n);
       }
-    }
-    return { value: null, factors: [] };
-  }
-
-  static generate(params) {
-    if ((params.minFactor || 1) > params.maxFactor) {
-      throw new Error('min must be <= max');
-    }
-    return new Palindromes(params.maxFactor, params.minFactor || 1);
+      return { value: null, factors: [] };
+    };
+    let [lower, upper] = [minFactor * minFactor, maxFactor * maxFactor];
+    return {
+      largest: search(
+        upper,
+        (n) => n >= lower,
+        (x) => x - 1,
+      ),
+      smallest: search(
+        lower,
+        (n) => n <= upper,
+        (x) => x + 1,
+      ),
+    };
   }
 }

--- a/exercises/practice/palindrome-products/.meta/tests.toml
+++ b/exercises/practice/palindrome-products/.meta/tests.toml
@@ -1,12 +1,19 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [5cff78fe-cf02-459d-85c2-ce584679f887]
-description = "finds the smallest palindrome from single digit factors"
+description = "find the smallest palindrome from single digit factors"
 
 [0853f82c-5fc4-44ae-be38-fadb2cced92d]
-description = "finds the largest palindrome from single digit factors"
+description = "find the largest palindrome from single digit factors"
 
 [66c3b496-bdec-4103-9129-3fcb5a9063e1]
 description = "find the smallest palindrome from double digit factors"
@@ -15,13 +22,13 @@ description = "find the smallest palindrome from double digit factors"
 description = "find the largest palindrome from double digit factors"
 
 [cecb5a35-46d1-4666-9719-fa2c3af7499d]
-description = "find smallest palindrome from triple digit factors"
+description = "find the smallest palindrome from triple digit factors"
 
 [edab43e1-c35f-4ea3-8c55-2f31dddd92e5]
 description = "find the largest palindrome from triple digit factors"
 
 [4f802b5a-9d74-4026-a70f-b53ff9234e4e]
-description = "find smallest palindrome from four digit factors"
+description = "find the smallest palindrome from four digit factors"
 
 [787525e0-a5f9-40f3-8cb2-23b52cf5d0be]
 description = "find the largest palindrome from four digit factors"
@@ -37,3 +44,6 @@ description = "error result for smallest if min is more than max"
 
 [eeeb5bff-3f47-4b1e-892f-05829277bd74]
 description = "error result for largest if min is more than max"
+
+[16481711-26c4-42e0-9180-e2e4e8b29c23]
+description = "smallest product does not use the smallest factor"

--- a/exercises/practice/palindrome-products/palindrome-products.spec.js
+++ b/exercises/practice/palindrome-products/palindrome-products.spec.js
@@ -135,6 +135,18 @@ describe('Palindromes', () => {
   });
 });
 
+xtest('smallest product does not use the smallest factor', () => {
+  const palindromes = Palindromes.generate({
+    maxFactor: 4000,
+    minFactor: 3215,
+  });
+  const smallest = palindromes.smallest;
+  const expected = { value: 10988901, factors: [[3297, 3333]] };
+
+  expect(smallest.value).toEqual(expected.value);
+  expect(sortFactors(smallest.factors)).toEqual(expected.factors);
+});
+
 function sortFactors(factors) {
   return factors.map((f) => f.sort()).sort();
 }


### PR DESCRIPTION
### Pull Request: Update Test Suite for Palindrome-Products Exercise  

This pull request updates the test suite for the **Palindrome-Products** exercise to align it with the latest problem specification.  

#### Key Changes  
- The test suite now incorporates the updated cases from the latest specification.  
- The old proof solution has been replaced with the one published by @Cool-Katt, as the previous solution assumed the smallest product was always derived from the smallest factor—a scenario specifically addressed by the new test cases.  
- @Cool-Katt has been added to the contributors' list in acknowledgement of their solution contribution.  

Please review the changes and let me know if further adjustments are needed.  
