### PR TITLE
Remove practices & format config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -2594,8 +2594,7 @@
         "name": "Ledger",
         "uuid": "8716b347-e18f-48a6-b373-426cc4ca98cb",
         "practices": [],
-        "prerequisites": [
-        ],
+        "prerequisites": [],
         "difficulty": 5
       },
       {

--- a/config.json
+++ b/config.json
@@ -2575,9 +2575,7 @@
         "slug": "markdown",
         "name": "Markdown",
         "uuid": "cd666b3a-7114-4ba9-9b2a-7622a2c8c12c",
-        "practices": [
-          "strings"
-        ],
+        "practices": [],
         "prerequisites": [],
         "difficulty": 5
       },
@@ -2644,10 +2642,7 @@
         "slug": "game-of-life",
         "name": "Conway's Game of Life",
         "uuid": "e51c01e9-b7b1-4877-939a-6254c4efe338",
-        "practices": [
-          "array-loops",
-          "array-transformations"
-        ],
+        "practices": [],
         "prerequisites": [],
         "difficulty": 2
       }


### PR DESCRIPTION
We currently don't "support" `practices` in the JavaScript track (as I don't think the UI is clear / helps). Will have to think this through before having it in "some" places.