### PR TITLE
Updating `instructions.append.md` to address the skipped test

### DIFF
--- a/exercises/practice/pythagorean-triplet/.docs/instructions.append.md
+++ b/exercises/practice/pythagorean-triplet/.docs/instructions.append.md
@@ -4,7 +4,7 @@ By default, only `sum` is given to the `triplets` function, but it may optionall
 
 <!-- prettier-ignore-start -->
 ~~~exercism/advanced
-If you're solving this using the CLI, there's a test case involving large numbers that's currently skipped to avoid timeouts in our online test runner.
+If you're solving this using the CLI, there's a test case involving large numbers that's currently skipped to avoid timeouts in our test runner.
 You can enable it if you want by removing the `.skip`, just be aware that it may take a while to run.
 ~~~
 <!-- prettier-ignore-end -->

--- a/exercises/practice/pythagorean-triplet/.docs/instructions.append.md
+++ b/exercises/practice/pythagorean-triplet/.docs/instructions.append.md
@@ -1,3 +1,10 @@
 # Instructions append
 
 By default, only `sum` is given to the `triplets` function, but it may optionally also receive `minFactor` and/or `maxFactor`. When these are given, make sure _each_ factor of the triplet is at least `minFactor` and at most `maxFactor`.
+
+<!-- prettier-ignore-start -->
+~~~exercism/advanced
+If you're solving this using the CLI, there's a test case involving large numbers that's currently skipped to avoid timeouts in our online test runner.
+You can enable it if you want by removing the `.skip`, just be aware that it may take a while to run.
+~~~
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
This comes after the discussion in #2648 to update `instructions.append.md` to address the skipped test in the test runner!