### PR TITLE
Continue update tests reverse string

### DIFF
--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -4,6 +4,7 @@
   ],
   "contributors": [
     "brendanmckeown",
+    "jagdish-15",
     "slaymance",
     "SleeplessByte",
     "tejasbubane",

--- a/exercises/practice/forth/.meta/tests.toml
+++ b/exercises/practice/forth/.meta/tests.toml
@@ -1,144 +1,175 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [9962203f-f00a-4a85-b404-8a8ecbcec09d]
-description = "numbers just get pushed onto the stack"
+description = "parsing and numbers -> numbers just get pushed onto the stack"
+
+[fd7a8da2-6818-4203-a866-fed0714e7aa0]
+description = "parsing and numbers -> pushes negative numbers onto the stack"
 
 [9e69588e-a3d8-41a3-a371-ea02206c1e6e]
-description = "can add two numbers"
+description = "addition -> can add two numbers"
 
 [52336dd3-30da-4e5c-8523-bdf9a3427657]
-description = "errors if there is nothing on the stack"
+description = "addition -> errors if there is nothing on the stack"
 
 [06efb9a4-817a-435e-b509-06166993c1b8]
-description = "errors if there is only one value on the stack"
+description = "addition -> errors if there is only one value on the stack"
+
+[1e07a098-c5fa-4c66-97b2-3c81205dbc2f]
+description = "addition -> more than two values on the stack"
 
 [09687c99-7bbc-44af-8526-e402f997ccbf]
-description = "can subtract two numbers"
+description = "subtraction -> can subtract two numbers"
 
 [5d63eee2-1f7d-4538-b475-e27682ab8032]
-description = "errors if there is nothing on the stack"
+description = "subtraction -> errors if there is nothing on the stack"
 
 [b3cee1b2-9159-418a-b00d-a1bb3765c23b]
-description = "errors if there is only one value on the stack"
+description = "subtraction -> errors if there is only one value on the stack"
+
+[2c8cc5ed-da97-4cb1-8b98-fa7b526644f4]
+description = "subtraction -> more than two values on the stack"
 
 [5df0ceb5-922e-401f-974d-8287427dbf21]
-description = "can multiply two numbers"
+description = "multiplication -> can multiply two numbers"
 
 [9e004339-15ac-4063-8ec1-5720f4e75046]
-description = "errors if there is nothing on the stack"
+description = "multiplication -> errors if there is nothing on the stack"
 
 [8ba4b432-9f94-41e0-8fae-3b3712bd51b3]
-description = "errors if there is only one value on the stack"
+description = "multiplication -> errors if there is only one value on the stack"
+
+[5cd085b5-deb1-43cc-9c17-6b1c38bc9970]
+description = "multiplication -> more than two values on the stack"
 
 [e74c2204-b057-4cff-9aa9-31c7c97a93f5]
-description = "can divide two numbers"
+description = "division -> can divide two numbers"
 
 [54f6711c-4b14-4bb0-98ad-d974a22c4620]
-description = "performs integer division"
+description = "division -> performs integer division"
 
 [a5df3219-29b4-4d2f-b427-81f82f42a3f1]
-description = "errors if dividing by zero"
+description = "division -> errors if dividing by zero"
 
 [1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a]
-description = "errors if there is nothing on the stack"
+description = "division -> errors if there is nothing on the stack"
 
 [d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d]
-description = "errors if there is only one value on the stack"
+description = "division -> errors if there is only one value on the stack"
+
+[f224f3e0-b6b6-4864-81de-9769ecefa03f]
+description = "division -> more than two values on the stack"
 
 [ee28d729-6692-4a30-b9be-0d830c52a68c]
-description = "addition and subtraction"
+description = "combined arithmetic -> addition and subtraction"
 
 [40b197da-fa4b-4aca-a50b-f000d19422c1]
-description = "multiplication and division"
+description = "combined arithmetic -> multiplication and division"
+
+[f749b540-53aa-458e-87ec-a70797eddbcb]
+description = "combined arithmetic -> multiplication and addition"
+
+[c8e5a4c2-f9bf-4805-9a35-3c3314e4989a]
+description = "combined arithmetic -> addition and multiplication"
 
 [c5758235-6eef-4bf6-ab62-c878e50b9957]
-description = "copies a value on the stack"
+description = "dup -> copies a value on the stack"
 
 [f6889006-5a40-41e7-beb3-43b09e5a22f4]
-description = "copies the top value on the stack"
+description = "dup -> copies the top value on the stack"
 
 [40b7569c-8401-4bd4-a30d-9adf70d11bc4]
-description = "errors if there is nothing on the stack"
+description = "dup -> errors if there is nothing on the stack"
 
 [1971da68-1df2-4569-927a-72bf5bb7263c]
-description = "removes the top value on the stack if it is the only one"
+description = "drop -> removes the top value on the stack if it is the only one"
 
 [8929d9f2-4a78-4e0f-90ad-be1a0f313fd9]
-description = "removes the top value on the stack if it is not the only one"
+description = "drop -> removes the top value on the stack if it is not the only one"
 
 [6dd31873-6dd7-4cb8-9e90-7daa33ba045c]
-description = "errors if there is nothing on the stack"
+description = "drop -> errors if there is nothing on the stack"
 
 [3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3]
-description = "swaps the top two values on the stack if they are the only ones"
+description = "swap -> swaps the top two values on the stack if they are the only ones"
 
 [8ce869d5-a503-44e4-ab55-1da36816ff1c]
-description = "swaps the top two values on the stack if they are not the only ones"
+description = "swap -> swaps the top two values on the stack if they are not the only ones"
 
 [74ba5b2a-b028-4759-9176-c5c0e7b2b154]
-description = "errors if there is nothing on the stack"
+description = "swap -> errors if there is nothing on the stack"
 
 [dd52e154-5d0d-4a5c-9e5d-73eb36052bc8]
-description = "errors if there is only one value on the stack"
+description = "swap -> errors if there is only one value on the stack"
 
 [a2654074-ba68-4f93-b014-6b12693a8b50]
-description = "copies the second element if there are only two"
+description = "over -> copies the second element if there are only two"
 
 [c5b51097-741a-4da7-8736-5c93fa856339]
-description = "copies the second element if there are more than two"
+description = "over -> copies the second element if there are more than two"
 
 [6e1703a6-5963-4a03-abba-02e77e3181fd]
-description = "errors if there is nothing on the stack"
+description = "over -> errors if there is nothing on the stack"
 
 [ee574dc4-ef71-46f6-8c6a-b4af3a10c45f]
-description = "errors if there is only one value on the stack"
+description = "over -> errors if there is only one value on the stack"
 
 [ed45cbbf-4dbf-4901-825b-54b20dbee53b]
-description = "can consist of built-in words"
+description = "user-defined words -> can consist of built-in words"
 
 [2726ea44-73e4-436b-bc2b-5ff0c6aa014b]
-description = "execute in the right order"
+description = "user-defined words -> execute in the right order"
 
 [9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33]
-description = "can override other user-defined words"
+description = "user-defined words -> can override other user-defined words"
 
 [669db3f3-5bd6-4be0-83d1-618cd6e4984b]
-description = "can override built-in words"
+description = "user-defined words -> can override built-in words"
 
 [588de2f0-c56e-4c68-be0b-0bb1e603c500]
-description = "can override built-in operators"
+description = "user-defined words -> can override built-in operators"
 
 [ac12aaaf-26c6-4a10-8b3c-1c958fa2914c]
-description = "can use different words with the same name"
+description = "user-defined words -> can use different words with the same name"
 
 [53f82ef0-2750-4ccb-ac04-5d8c1aefabb1]
-description = "can define word that uses word with the same name"
+description = "user-defined words -> can define word that uses word with the same name"
 
 [35958cee-a976-4a0f-9378-f678518fa322]
-description = "cannot redefine numbers"
+description = "user-defined words -> cannot redefine non-negative numbers"
 
 [df5b2815-3843-4f55-b16c-c3ed507292a7]
-description = "cannot redefine negative numbers"
+description = "user-defined words -> cannot redefine negative numbers"
 
 [5180f261-89dd-491e-b230-62737e09806f]
-description = "errors if executing a non-existent word"
+description = "user-defined words -> errors if executing a non-existent word"
+
+[3c8bfef3-edbb-49c1-9993-21d4030043cb]
+description = "user-defined words -> only defines locally"
 
 [7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6]
-description = "DUP is case-insensitive"
+description = "case-insensitivity -> DUP is case-insensitive"
 
 [339ed30b-f5b4-47ff-ab1c-67591a9cd336]
-description = "DROP is case-insensitive"
+description = "case-insensitivity -> DROP is case-insensitive"
 
 [ee1af31e-1355-4b1b-bb95-f9d0b2961b87]
-description = "SWAP is case-insensitive"
+description = "case-insensitivity -> SWAP is case-insensitive"
 
 [acdc3a49-14c8-4cc2-945d-11edee6408fa]
-description = "OVER is case-insensitive"
+description = "case-insensitivity -> OVER is case-insensitive"
 
 [5934454f-a24f-4efc-9fdd-5794e5f0c23c]
-description = "user-defined words are case-insensitive"
+description = "case-insensitivity -> user-defined words are case-insensitive"
 
 [037d4299-195f-4be7-a46d-f07ca6280a06]
-description = "definitions are case-insensitive"
+description = "case-insensitivity -> definitions are case-insensitive"

--- a/exercises/practice/forth/forth.spec.js
+++ b/exercises/practice/forth/forth.spec.js
@@ -37,6 +37,11 @@ describe('Forth', () => {
         forth.evaluate('1 +');
       }).toThrow(new Error('Stack empty'));
     });
+
+    xtest('more than two values on the stack', () => {
+      forth.evaluate('1 2 3 +');
+      expect(forth.stack).toEqual([1, 5]);
+    });
   });
 
   describe('subtraction', () => {
@@ -56,6 +61,11 @@ describe('Forth', () => {
         forth.evaluate('1 -');
       }).toThrow(new Error('Stack empty'));
     });
+
+    xtest('more than two values on the stack', () => {
+      forth.evaluate('1 12 3 -');
+      expect(forth.stack).toEqual([1, 9]);
+    });
   });
 
   describe('multiplication', () => {
@@ -74,6 +84,11 @@ describe('Forth', () => {
       expect(() => {
         forth.evaluate('1 *');
       }).toThrow(new Error('Stack empty'));
+    });
+
+    xtest('more than two values on the stack', () => {
+      forth.evaluate('1 2 3 *');
+      expect(forth.stack).toEqual([1, 6]);
     });
   });
 
@@ -105,6 +120,11 @@ describe('Forth', () => {
         forth.evaluate('1 /');
       }).toThrow(new Error('Stack empty'));
     });
+
+    xtest('more than two values on the stack', () => {
+      forth.evaluate('1 12 3 /');
+      expect(forth.stack).toEqual([1, 4]);
+    });
   });
 
   describe('combined arithmetic', () => {
@@ -116,6 +136,16 @@ describe('Forth', () => {
     xtest('multiplication and division', () => {
       forth.evaluate('2 4 * 3 /');
       expect(forth.stack).toEqual([2]);
+    });
+
+    xtest('multiplication and addition', () => {
+      forth.evaluate('1 3 4 * +');
+      expect(forth.stack).toEqual([13]);
+    });
+
+    xtest('addition and multiplication', () => {
+      forth.evaluate('1 3 4 + *');
+      expect(forth.stack).toEqual([7]);
     });
   });
 
@@ -250,11 +280,12 @@ describe('Forth', () => {
       expect(forth.stack).toEqual([11]);
     });
 
-    xtest('cannot redefine numbers', () => {
+    xtest('cannot redefine non-negative numbers', () => {
       expect(() => {
         forth.evaluate(': 1 2 ;');
       }).toThrow(new Error('Invalid definition'));
     });
+
     xtest('cannot redefine negative numbers', () => {
       expect(() => {
         forth.evaluate(': -1 2 ;');

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -27,6 +27,6 @@
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,
     "flag.tests.may-run-long": false,
-    "flag.tests.includes-optional": false
+    "flag.tests.includes-optional": true
   }
 }


### PR DESCRIPTION
continues #2648 

Changes the state of `flag.tests.includes-optional` to fix the optional test issue mentioned by @devcyjung  