### PR TITLE
Fixing optional test issue

### DIFF
--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -27,6 +27,6 @@
     "version.tests.compatibility": "jest-27",
     "flag.tests.task-per-describe": false,
     "flag.tests.may-run-long": false,
-    "flag.tests.includes-optional": false
+    "flag.tests.includes-optional": true
   }
 }


### PR DESCRIPTION
continues #2648 

Changes the state of `flag.tests.includes-optional` to fix the optional tests issue found out by @devcyjung