### PR TITLE
Remove nested describes to unbreak task-based testing

### DIFF
--- a/exercises/concept/freelancer-rates/freelancer-rates.spec.js
+++ b/exercises/concept/freelancer-rates/freelancer-rates.spec.js
@@ -58,17 +58,17 @@ describe('days in budget', () => {
 });
 
 describe('cost with monthly discount', () => {
-    test('at 16/hour for 70 days', () => {
-      const actual = priceWithMonthlyDiscount(16, 70, 0);
-      const expected = 8960;
-      expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
-    });
+  test('at 16/hour for 70 days', () => {
+    const actual = priceWithMonthlyDiscount(16, 70, 0);
+    const expected = 8960;
+    expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
+  });
 
-    test('at 16/hour for 130 days with 15% discount', () => {
-      const actual = priceWithMonthlyDiscount(16, 130, 0.15);
-      const expected = 14528;
-      expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
-    });
+  test('at 16/hour for 130 days with 15% discount', () => {
+    const actual = priceWithMonthlyDiscount(16, 130, 0.15);
+    const expected = 14528;
+    expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
+  });
   test('at 29.654321/hour for 220 days with 11.2%', () => {
     const actual = priceWithMonthlyDiscount(29.654321, 220, 0.112);
     const expected = 46347;

--- a/exercises/concept/freelancer-rates/freelancer-rates.spec.js
+++ b/exercises/concept/freelancer-rates/freelancer-rates.spec.js
@@ -35,57 +35,49 @@ describe('day rate', () => {
 });
 
 describe('days in budget', () => {
-  describe('with a budget of 1280', () => {
-    test('at 16/hour', () => {
-      const actual = daysInBudget(1280, 16);
-      const expected = 10;
+  test('with a budget of 1280 at 16/hour', () => {
+    const actual = daysInBudget(1280, 16);
+    const expected = 10;
 
-      expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
-    });
+    expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
+  });
 
-    test('at 25/hour', () => {
-      const actual = daysInBudget(1280, 25);
-      const expected = 6;
+  test('with a budget of 1280 at 25/hour', () => {
+    const actual = daysInBudget(1280, 25);
+    const expected = 6;
 
-      expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
-    });
+    expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
+  });
 
-    describe('with a budget of 835', () => {
-      test('at 12/hour', () => {
-        const actual = daysInBudget(835, 12);
-        const expected = 8;
+  test('with a budget of 835 at 12/hour', () => {
+    const actual = daysInBudget(835, 12);
+    const expected = 8;
 
-        expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
-      });
-    });
+    expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
   });
 });
 
 describe('cost with monthly discount', () => {
-  describe('at 16/hour', () => {
-    test('for 70 days', () => {
+    test('at 16/hour for 70 days', () => {
       const actual = priceWithMonthlyDiscount(16, 70, 0);
       const expected = 8960;
       expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
     });
 
-    test('for 130 days with 15% discount', () => {
+    test('at 16/hour for 130 days with 15% discount', () => {
       const actual = priceWithMonthlyDiscount(16, 130, 0.15);
       const expected = 14528;
       expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
     });
+  test('at 29.654321/hour for 220 days with 11.2%', () => {
+    const actual = priceWithMonthlyDiscount(29.654321, 220, 0.112);
+    const expected = 46347;
+    expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
   });
-  describe('at 29.654321/hour', () => {
-    test('for 220 days with 11.2%', () => {
-      const actual = priceWithMonthlyDiscount(29.654321, 220, 0.112);
-      const expected = 46347;
-      expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
-    });
 
-    test('for 155 days with 25.47% discount', () => {
-      const actual = priceWithMonthlyDiscount(29.654321, 155, 0.2547);
-      const expected = 27467;
-      expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
-    });
+  test('at 29.654321/hour for 155 days with 25.47% discount', () => {
+    const actual = priceWithMonthlyDiscount(29.654321, 155, 0.2547);
+    const expected = 27467;
+    expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
   });
 });

--- a/exercises/concept/freelancer-rates/freelancer-rates.spec.js
+++ b/exercises/concept/freelancer-rates/freelancer-rates.spec.js
@@ -69,6 +69,7 @@ describe('cost with monthly discount', () => {
     const expected = 14528;
     expect(actual).toBeCloseTo(expected, DIFFERENCE_PRECISION_IN_DIGITS);
   });
+
   test('at 29.654321/hour for 220 days with 11.2%', () => {
     const actual = priceWithMonthlyDiscount(29.654321, 220, 0.112);
     const expected = 46347;


### PR DESCRIPTION
Fix issue where task based outputs do not work due to nested `describe()` calls. See [Discord discussion](https://discord.com/channels/854117591135027261/1385322924428230816).