### PR TITLE
Fix prerequisites for captains-log

### DIFF
--- a/config.json
+++ b/config.json
@@ -433,7 +433,9 @@
         "prerequisites": [
           "numbers",
           "arithmetic-operators",
-          "strings"
+          "strings",
+          "objects",
+          "functions"
         ]
       }
     ],

--- a/config.json
+++ b/config.json
@@ -432,7 +432,8 @@
         ],
         "prerequisites": [
           "numbers",
-          "arithmetic-operators"
+          "arithmetic-operators",
+          "strings"
         ]
       }
     ],


### PR DESCRIPTION
We have strings in this exercise, and it uses a function call on an object.

Moving it below functions works.