### PR TITLE
Clarify URL format in Regular Chatbot exercise's instructions.md

### DIFF
--- a/exercises/concept/regular-chatbot/.docs/instructions.md
+++ b/exercises/concept/regular-chatbot/.docs/instructions.md
@@ -68,11 +68,11 @@ Example of Conversation:
 - **Chatbot**: Hey username, I would like to learn how to code in JavaScript, do you know any cool website where I could learn?
 - **User**: I learned a lot from [exercism.org](http://exercism.org)
 
-Implement the function `getURL()` which is able to return an array with just the link of each website.
+Implement the function `getURL()` which is able to return an array with just the link of each website. Writing a regex to recognize any URL would be very complicated, but the Chatbot only needs to read simple URLs. For this exercise, a URL is any `"."`-delimited sequence of words.
 
 ```javascript
-getURL('I learned a lot from exercism.org');
-// => ["exercism.org"];
+getURL('I learned a lot from exercism.org and developer.mozilla.org, but I found ts39.es very boring!');
+// => ["exercism.org", "developer.mozilla.org", "ts39.es"];
 ```
 
 ## Greet the user

--- a/exercises/concept/regular-chatbot/.docs/instructions.md
+++ b/exercises/concept/regular-chatbot/.docs/instructions.md
@@ -71,7 +71,9 @@ Example of Conversation:
 Implement the function `getURL()` which is able to return an array with just the link of each website. Writing a regex to recognize any URL would be very complicated, but the Chatbot only needs to read simple URLs. For this exercise, a URL is any `"."`-delimited sequence of words.
 
 ```javascript
-getURL('I learned a lot from exercism.org and developer.mozilla.org, but I found ts39.es very boring!');
+getURL(
+  'I learned a lot from exercism.org and developer.mozilla.org, but I found ts39.es very boring!',
+);
 // => ["exercism.org", "developer.mozilla.org", "ts39.es"];
 ```
 


### PR DESCRIPTION
Currently, the instructions say to get the URLs, but it doesn't specify what "URLs" are. (https://exercism.org/tracks/javascript/exercises/regular-chatbot is a valid URL, but this exercise does not test for such complicated URLs, and the reference solution in exemplar.js would not reject it.) It would be frustrating for a user to exert their effort trying to write a regex for URLs the exercise isn't testing for (especially if the tests were to reject a valid URL, though I haven't checked if they currently could).