### PR TITLE
Captain's Log: Fix random override cleanup

### DIFF
--- a/exercises/concept/captains-log/.docs/instructions.md
+++ b/exercises/concept/captains-log/.docs/instructions.md
@@ -36,6 +36,12 @@ randomStardate();
 // => 41458.15721310934
 ```
 
+<!-- prettier-ignore -->
+~~~exercism/caution
+It is expected that the smallest random number (0) results in the smallest random stardate (41000.0) and
+the largest random number (just under 1) results in the largest random stardate (41999.999...).
+~~~
+
 ## 3. Generate a random planet
 
 The Starship Enterprise encounters many planets in its travels.

--- a/exercises/concept/captains-log/captains-log.spec.js
+++ b/exercises/concept/captains-log/captains-log.spec.js
@@ -12,7 +12,7 @@ describe('randomShipRegistryNumber', () => {
     }
   });
 
-  test('returns a random registry number', () => {
+  test('is a random registry number', () => {
     expect(randomShipRegistryNumber()).not.toEqual(randomShipRegistryNumber());
   });
 });


### PR DESCRIPTION
See: https://forum.exercism.org/t/tests-instructions-not-displayed/18559/6

~~(Do not merge quite yet, testing now locally if this actually solves it, will remove this message when done)~~

We also need a test-runner update for `beforeEach` per describe. Will fix that too.

## Do not merge yet

When we merge this without updating the browser-test-runner, you won't be able to complete this in the browser anymore. Right now in the browser you can complete it by starting the tests 3x once it fails.