### PR TITLE
test: constrict lower bounds and upper bounds of test case

### DIFF
--- a/exercises/concept/factory-sensors/factory-sensors.spec.js
+++ b/exercises/concept/factory-sensors/factory-sensors.spec.js
@@ -8,8 +8,16 @@ import {
 } from './factory-sensors';
 
 describe('checkHumidityLevel', () => {
+  test('should throw if the humidity percentage is 71', () => {
+    expect(() => checkHumidityLevel(71)).toThrow();
+  });
+  
   test('should throw if the humidity percentage is 100', () => {
     expect(() => checkHumidityLevel(100)).toThrow();
+  });
+
+  test('should not throw if the humidity level is 70', () => {
+    expect(() => checkHumidityLevel(70)).not.toThrow();
   });
 
   test('should not throw if the humidity level is 53', () => {

--- a/exercises/concept/factory-sensors/factory-sensors.spec.js
+++ b/exercises/concept/factory-sensors/factory-sensors.spec.js
@@ -11,7 +11,7 @@ describe('checkHumidityLevel', () => {
   test('should throw if the humidity percentage is 71', () => {
     expect(() => checkHumidityLevel(71)).toThrow();
   });
-  
+
   test('should throw if the humidity percentage is 100', () => {
     expect(() => checkHumidityLevel(100)).toThrow();
   });


### PR DESCRIPTION
I recently mentored a solution where the mentee used `>=100` and it passed. I'm making this PR to fix that.

Link to solution: https://exercism.org/mentoring/requests/dad84dead4344defb12e2788a142713b