### PR TITLE
Train Driver: Fix incorrect JSDoc type

### DIFF
--- a/exercises/concept/train-driver/train-driver.js
+++ b/exercises/concept/train-driver/train-driver.js
@@ -7,7 +7,7 @@
 /**
  * Return each wagon's id in form of an array.
  *
- * @param {...numbers} ids
+ * @param {...number} ids
  * @returns {number[]} wagon ids
  */
 export function getListOfWagons(a, b, c, d, e, f, g, h, i, j, k, l, m, n) {


### PR DESCRIPTION
Changed `@param {...numbers} ids` to `@param {...number} ids` as `numbers` is not a valid JSDoc type.

See https://forum.exercism.org/t/incorrect-function-stub-and-jsdoc-type-in-train-driver-exercise/19608.