### PR TITLE
Fix pseudorandom typo

### DIFF
--- a/concepts/randomness/about.md
+++ b/concepts/randomness/about.md
@@ -31,8 +31,8 @@ This concept is not about Web Crypto and will restrict itself to pseudo-random n
 
 ## Generating random numbers
 
-In Javascript, you can generate psuedorandom numbers using the [`Math.random()`][Math.random] function.
-It will return a psuedorandom floating-point number between 0 (inclusive), and 1 (exclusive).
+In Javascript, you can generate pseudorandom numbers using the [`Math.random()`][Math.random] function.
+It will return a pseudorandom floating-point number between 0 (inclusive), and 1 (exclusive).
 
 To get a random number between _min_ (inclusive) and _max_ (exclusive) you can use a function something like this:
 

--- a/concepts/randomness/introduction.md
+++ b/concepts/randomness/introduction.md
@@ -19,8 +19,8 @@ Finish the learning exercise(s) about this concept to learn more
 
 ## Generating random numbers
 
-In Javascript, you can generate psuedorandom numbers using the [`Math.random()`][Math.random] function.
-It will return a psuedorandom floating-point number between 0 (inclusive), and 1 (exclusive).
+In Javascript, you can generate pseudorandom numbers using the [`Math.random()`][Math.random] function.
+It will return a pseudorandom floating-point number between 0 (inclusive), and 1 (exclusive).
 
 To get a random number between _min_ (inclusive) and _max_ (exclusive) you can use a function something like this:
 

--- a/exercises/concept/captains-log/.docs/introduction.md
+++ b/exercises/concept/captains-log/.docs/introduction.md
@@ -19,8 +19,8 @@ Finish the learning exercise(s) about this concept to learn more
 
 ## Generating random numbers
 
-In Javascript, you can generate psuedorandom numbers using the [`Math.random()`][Math.random] function.
-It will return a psuedorandom floating-point number between 0 (inclusive), and 1 (exclusive).
+In Javascript, you can generate pseudorandom numbers using the [`Math.random()`][Math.random] function.
+It will return a pseudorandom floating-point number between 0 (inclusive), and 1 (exclusive).
 
 [why-randomness-is-hard]: https://www.malwarebytes.com/blog/news/2013/09/in-computers-are-random-numbers-really-random
 [Math.random]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random

--- a/exercises/concept/captains-log/.meta/design.md
+++ b/exercises/concept/captains-log/.meta/design.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-The goal of this exercise is to teach the student how to generate psuedorandom numbers in JavaScript.
+The goal of this exercise is to teach the student how to generate pseudorandom numbers in JavaScript.
 
 ## Learning objectives
 


### PR DESCRIPTION
Replaces all occurrences of "psuedorandom" with "pseudorandom".

Thanks, @BNAndras, for the additional spots.

Related forum thread: https://forum.exercism.org/t/typo-in-randomness-concept/19868