### PR TITLE
[FIX]: `Coordinate Transformation` JSDoc type error in offline mode

### DIFF
--- a/exercises/concept/coordinate-transformation/coordinate-transformation.js
+++ b/exercises/concept/coordinate-transformation/coordinate-transformation.js
@@ -60,6 +60,6 @@ export function composeTransform(f, g) {
  *  if the arguments are the same on subsequent calls, or compute a new result if they are different.
  */
 export function memoizeTransform(f) {
-  // if you have type error for callback function. Add `/** @type {[number, number]} */` to the return variable.
+  // To narrow the type of the return variable, add `/** @type {[number, number]} */` above it.
   throw new Error('Remove this line and implement the function');
 }

--- a/exercises/concept/coordinate-transformation/coordinate-transformation.js
+++ b/exercises/concept/coordinate-transformation/coordinate-transformation.js
@@ -5,13 +5,17 @@
 // implementing this exercise.
 
 /**
+ * @typedef {function (number, number): [number, number]} CallbackType
+ */
+
+/**
  * Create a function that returns a function making use of a closure to
  * perform a repeatable 2d translation of a coordinate pair.
  *
  * @param {number} dx the translate x component
  * @param {number} dy the translate y component
  *
- * @returns {function} a function which takes an x, y parameter, returns the
+ * @returns {CallbackType} a function which takes an x, y parameter, returns the
  *  translated coordinate pair in the form [x, y]
  */
 export function translate2d(dx, dy) {
@@ -25,7 +29,7 @@ export function translate2d(dx, dy) {
  * @param {number} sx the amount to scale the x component
  * @param {number} sy the amount to scale the y component
  *
- * @returns {function} a function which takes an x, y parameter, returns the
+ * @returns {CallbackType} a function which takes an x, y parameter, returns the
  *  scaled coordinate pair in the form [x, y]
  */
 export function scale2d(sx, sy) {
@@ -39,7 +43,7 @@ export function scale2d(sx, sy) {
  * @param {function} f the first function to apply
  * @param {function} g the second function to apply
  *
- * @returns {function} a function which takes an x, y parameter, returns the
+ * @returns {CallbackType} a function which takes an x, y parameter, returns the
  *  transformed coordinate pair in the form [x, y]
  */
 export function composeTransform(f, g) {
@@ -52,7 +56,7 @@ export function composeTransform(f, g) {
  *
  * @param {function} f the transformation function to memoize, assumes takes two arguments 'x' and 'y'
  *
- * @returns {function} a function which takes x and y arguments, and will either return the saved result
+ * @returns {CallbackType} a function which takes x and y arguments, and will either return the saved result
  *  if the arguments are the same on subsequent calls, or compute a new result if they are different.
  */
 export function memoizeTransform(f) {

--- a/exercises/concept/coordinate-transformation/coordinate-transformation.js
+++ b/exercises/concept/coordinate-transformation/coordinate-transformation.js
@@ -40,8 +40,8 @@ export function scale2d(sx, sy) {
  * Create a composition function that returns a function that combines two
  * functions to perform a repeatable transformation
  *
- * @param {function} f the first function to apply
- * @param {function} g the second function to apply
+ * @param {CallbackType} f the first function to apply
+ * @param {CallbackType} g the second function to apply
  *
  * @returns {CallbackType} a function which takes an x, y parameter, returns the
  *  transformed coordinate pair in the form [x, y]
@@ -54,11 +54,12 @@ export function composeTransform(f, g) {
  * Return a function that memoizes the last result.  If the arguments are the same as the last call,
  * then memoized result returned.
  *
- * @param {function} f the transformation function to memoize, assumes takes two arguments 'x' and 'y'
+ * @param {CallbackType} f the transformation function to memoize, assumes takes two arguments 'x' and 'y'
  *
  * @returns {CallbackType} a function which takes x and y arguments, and will either return the saved result
  *  if the arguments are the same on subsequent calls, or compute a new result if they are different.
  */
 export function memoizeTransform(f) {
+  // if you have type error for callback function. Add `/** @type {[number, number]} */` to the return variable.
   throw new Error('Remove this line and implement the function');
 }


### PR DESCRIPTION
This PR Solves JS Doc type error of [Coordinate Transformation](https://exercism.org/tracks/javascript/exercises/coordinate-transformation) exercise in offline mode. This issue was referenced in [Exercism Forum](https://forum.exercism.org/t/error-coordinate-transformation-jsdoc-type-error-in-offline-mode/47522)

The fix was made by adding type definition: `@typedef {function (number, number): [number, number]} CallbackType` and replaced all return types from `function` to `CallbackType`.

> NOTE: This issue got approval in the Forum thats why I made the effort to make the PR. Approval given by @SleeplessByte, I hope I did everything right.