### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 The anagrams can be returned in any order.

--- a/exercises/practice/armstrong-numbers/.docs/instructions.append.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.append.md
@@ -1,3 +1,7 @@
+# Instructions append
+
+## Implementation
+
 <!-- prettier-ignore-start -->
 ~~~~exercism/note
 Some of the tests might pass a `BigInt` as input.

--- a/exercises/practice/book-store/.docs/instructions.append.md
+++ b/exercises/practice/book-store/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Implementation
+# Instructions append
+
+## Implementation
 
 Define a function - `cost` - that calculates the cost for a given list of books based on defined discounts.
 

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 Using the built-in [Date class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) and its methods is not allowed.

--- a/exercises/practice/collatz-conjecture/.docs/instructions.append.md
+++ b/exercises/practice/collatz-conjecture/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 If `n` is not a positive integer, stop the program from being executed further and return an error message.
 
 In JavaScript, this can be done using the `throw` statement.

--- a/exercises/practice/linked-list/.docs/instructions.append.md
+++ b/exercises/practice/linked-list/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 Your list must also implement the following interface:
 
 - `delete` (delete the first occurrence of a specified value)

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 Using core language features to build and deconstruct arrays via destructuring, and using the array literal `[]` are allowed, but no functions from the `Array.prototype` should be used.

--- a/exercises/practice/meetup/.docs/instructions.append.md
+++ b/exercises/practice/meetup/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 In JavaScript, the Date object month's index ranges from 0 to 11.
 
 ```javascript

--- a/exercises/practice/nucleotide-count/.docs/instructions.append.md
+++ b/exercises/practice/nucleotide-count/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 The result should be formatted as a string containing 4 numbers separated by spaces.
 Each number represents the count for A, C, G and T in this order.
 

--- a/exercises/practice/protein-translation/.docs/instructions.append.md
+++ b/exercises/practice/protein-translation/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 If an invalid character or codon is encountered _during_ translation, it should `throw` an error with the message `Invalid codon`.
 
 ```javascript

--- a/exercises/practice/proverb/.docs/instructions.append.md
+++ b/exercises/practice/proverb/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 If the final item in the list is an `object` instead of a `string`, it will hold a qualifier that modifies the final line in the proverb.
 
 ```javascript

--- a/exercises/practice/pythagorean-triplet/.docs/instructions.append.md
+++ b/exercises/practice/pythagorean-triplet/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 By default, only `sum` is given to the `triplets` function, but it may optionally also receive `minFactor` and/or `maxFactor`. When these are given, make sure _each_ factor of the triplet is at least `minFactor` and at most `maxFactor`.
 
 <!-- prettier-ignore-start -->

--- a/exercises/practice/queen-attack/.docs/instructions.append.md
+++ b/exercises/practice/queen-attack/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 A queen must be placed on a valid position on the board.
 Two queens cannot share the same position.
 

--- a/exercises/practice/resistor-color/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 Although the color names are capitalised in the description, the function colorCode will always be called with the lowercase equivalent, e.g brown instead of Brown

--- a/exercises/practice/reverse-string/.docs/instructions.append.md
+++ b/exercises/practice/reverse-string/.docs/instructions.append.md
@@ -1,3 +1,7 @@
+# Instructions append
+
+## Implementation
+
 <!-- prettier-ignore-start -->
 ~~~exercism/advanced
 If you solve this using the CLI, there are test cases that require you to deal with complex characters.

--- a/exercises/practice/square-root/.docs/instructions.append.md
+++ b/exercises/practice/square-root/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 The idea is not to use the built-in javascript functions such as `Math.sqrt(x)`, `x ** 0.5` or `x ** (1/2)`, it's to build your own.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.